### PR TITLE
Removing yannuil from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
 reviewers:
 - mkolesnik
-- yannuil
 - yxun
 
 approvers:
 - mkolesnik
-- yannuil
 - yxun


### PR DESCRIPTION
Removing yannuil (Yann Liu) from OWNERS file as he is no longer able to contribute to this project in the capacity of a Reviewer or Approver.