### PR TITLE
Add Finalizer support to deletion

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -18,6 +18,7 @@ import (
 	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -40,6 +41,8 @@ const (
 
 	ManifestWorkNameOSSM = "multicluster-mesh-operator-ossm"
 	ManifestWorkNameSail = "multicluster-mesh-operator-sail"
+
+	FinalizerName = "mesh.open-cluster-management.io/finalizer"
 
 	clusterClaimProduct = "product.open-cluster-management.io"
 
@@ -96,6 +99,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return r.handleDeletion(ctx, mesh)
 	}
 
+	if !controllerutil.ContainsFinalizer(mesh, FinalizerName) {
+		klog.Infof("Adding finalizer to MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
+		controllerutil.AddFinalizer(mesh, FinalizerName)
+		if err := r.Update(ctx, mesh); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+		return reconcile.Result{}, nil
+	}
+
 	klog.Infof("MultiClusterMesh reconciling: %s/%s, ClusterSet: %s",
 		req.Namespace, req.Name, mesh.Spec.ClusterSet)
 	clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
@@ -132,10 +144,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 // handleDeletion handles cleanup when the MultiClusterMesh is being deleted
 func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) (reconcile.Result, error) {
+	if !controllerutil.ContainsFinalizer(mesh, FinalizerName) {
+		klog.V(4).Infof("MultiClusterMesh %s/%s has no finalizer, nothing to clean up", mesh.Namespace, mesh.Name)
+		return reconcile.Result{}, nil
+	}
+
 	klog.Infof("Handling deletion for MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
 	clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get clusters for cleanup: %w", err)
+	if err != nil && !errors.IsNotFound(err) {
+		return reconcile.Result{}, fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
 	}
 
 	for _, cluster := range clusters {
@@ -164,8 +181,12 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 		}
 	}
 
-	// TODO: We don't remove finalizer here since we haven't added one yet
-	// This will be added when we implement more complex lifecycle management
+	klog.Infof("Removing finalizer from MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
+	controllerutil.RemoveFinalizer(mesh, FinalizerName)
+	if err := r.Update(ctx, mesh); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -44,6 +44,9 @@ const (
 
 	FinalizerName = "mesh.open-cluster-management.io/finalizer"
 
+	LabelMeshName      = "mesh.open-cluster-management.io/mesh-name"
+	LabelMeshNamespace = "mesh.open-cluster-management.io/mesh-namespace"
+
 	clusterClaimProduct = "product.open-cluster-management.io"
 
 	// Product claim values from github.com/stolostron/multicloud-operators-foundation/pkg/klusterlet/clusterclaim
@@ -150,34 +153,26 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 	}
 
 	klog.Infof("Handling deletion for MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
-	clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
-	if err != nil && !errors.IsNotFound(err) {
-		return reconcile.Result{}, fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
+	workList := &workv1.ManifestWorkList{}
+	labelSelector := client.MatchingLabels{
+		LabelMeshName:      mesh.Name,
+		LabelMeshNamespace: mesh.Namespace,
 	}
 
-	for _, cluster := range clusters {
-		workName := getOperatorManifestWorkName(isOpenShift(&cluster))
-		work := &workv1.ManifestWork{}
-		err := r.Get(ctx, types.NamespacedName{
-			Name:      workName,
-			Namespace: cluster.Name,
-		}, work)
+	if err := r.List(ctx, workList, labelSelector); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list ManifestWorks for cleanup: %w", err)
+	}
 
-		if err != nil {
-			if errors.IsNotFound(err) {
-				klog.V(4).Infof("ManifestWork %s/%s already deleted", cluster.Name, workName)
-				continue
-			}
-			return reconcile.Result{}, fmt.Errorf("failed to get ManifestWork %s/%s: %w", cluster.Name, workName, err)
-		}
-
+	klog.V(4).Infof("Found %d ManifestWorks to clean up for MultiClusterMesh %s/%s", len(workList.Items), mesh.Namespace, mesh.Name)
+	for i := range workList.Items {
+		work := &workList.Items[i]
 		if err := r.Delete(ctx, work); err != nil {
 			if !errors.IsNotFound(err) {
-				return reconcile.Result{}, fmt.Errorf("failed to delete ManifestWork %s/%s: %w", cluster.Name, workName, err)
+				return reconcile.Result{}, fmt.Errorf("failed to delete ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
 			}
-			klog.V(4).Infof("ManifestWork %s/%s already deleted", cluster.Name, workName)
+			klog.V(4).Infof("ManifestWork %s/%s already deleted", work.Namespace, work.Name)
 		} else {
-			klog.Infof("Deleted ManifestWork %s/%s", cluster.Name, workName)
+			klog.Infof("Deleted ManifestWork %s/%s", work.Namespace, work.Name)
 		}
 	}
 
@@ -213,7 +208,7 @@ func (r *Reconciler) ensureOperatorInstalled(ctx context.Context, mesh *meshv1al
 	}
 
 	klog.Infof("Creating ManifestWork to install operator on cluster %s", cluster.Name)
-	work := r.buildOperatorManifestWork(mesh.Spec.Operator, cluster)
+	work := r.buildOperatorManifestWork(mesh, cluster)
 
 	if err := r.Create(ctx, work); err != nil {
 		return fmt.Errorf("failed to create ManifestWork: %w", err)
@@ -273,10 +268,10 @@ func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName stri
 	return clusterList.Items, nil
 }
 
-func (r *Reconciler) buildOperatorManifestWork(config meshv1alpha1.OperatorConfig, cluster *clusterv1.ManagedCluster) *workv1.ManifestWork {
+func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) *workv1.ManifestWork {
 	manifests := []workv1.Manifest{}
 	isOCP := isOpenShift(cluster)
-	config = r.applyOperatorDefaults(config, isOCP)
+	config := r.applyOperatorDefaults(mesh.Spec.Operator, isOCP)
 
 	// openshift-operators exists by default on OCP and already has a global OperatorGroup
 	if config.Namespace != DefaultOCPOperatorNs {
@@ -339,6 +334,10 @@ func (r *Reconciler) buildOperatorManifestWork(config meshv1alpha1.OperatorConfi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getOperatorManifestWorkName(isOCP),
 			Namespace: cluster.Name,
+			Labels: map[string]string{
+				LabelMeshName:      mesh.Name,
+				LabelMeshNamespace: mesh.Namespace,
+			},
 		},
 		Spec: workv1.ManifestWorkSpec{
 			Workload: workv1.ManifestsTemplate{

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -224,6 +224,25 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
 		})
+
+		It("should delete ManifestWork even when the ClusterSet is deleted first", func() {
+			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+			expectFinalizer(meshName, testNs)
+			expectSailManifestWork(clusterName)
+
+			clusterSet := &clusterv1beta2.ManagedClusterSet{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testClusterSet}, clusterSet)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, clusterSet)).To(Succeed())
+			expectResourceDeleted(&clusterv1beta2.ManagedClusterSet{}, testClusterSet, "")
+
+			mesh := &meshv1alpha1.MultiClusterMesh{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, mesh)).To(Succeed())
+
+			expectResourceDeleted(&workv1.ManifestWork{}, meshcontroller.ManifestWorkNameSail, clusterName)
+			expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
+		})
 	})
 
 	Context("Platform detection", func() {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -12,11 +12,13 @@ import (
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
@@ -186,6 +188,42 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			util.SetProductClaim(ctx, k8sClient, clusterName, "Other")
 			expectSailManifestWork(clusterName)
 		})
+
+		It("should add finalizer on MultiClusterMesh creation", func() {
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+			expectFinalizer(meshName, testNs)
+		})
+	})
+
+	Context("Deleting MultiClusterMesh", func() {
+		It("should delete related ManifestWorks", func() {
+			cluster2 := util.UniqueName("cluster2")
+			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateOCPManagedCluster(ctx, k8sClient, cluster2, testClusterSet, meshcontroller.ProductOCP)
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+			expectFinalizer(meshName, testNs)
+			expectSailManifestWork(clusterName)
+			expectOSSMManifestWork(cluster2)
+
+			mesh := &meshv1alpha1.MultiClusterMesh{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, mesh)).To(Succeed())
+
+			expectResourceDeleted(&workv1.ManifestWork{}, meshcontroller.ManifestWorkNameSail, clusterName)
+			expectResourceDeleted(&workv1.ManifestWork{}, meshcontroller.ManifestWorkNameOSSM, cluster2)
+			expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
+		})
+
+		It("should work when ClusterSet doesn't exist", func() {
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, util.UniqueName("nonexistent-set"), meshv1alpha1.OperatorConfig{})
+			expectFinalizer(meshName, testNs)
+
+			mesh := &meshv1alpha1.MultiClusterMesh{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, mesh)).To(Succeed())
+
+			expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
+		})
 	})
 
 	Context("Platform detection", func() {
@@ -223,6 +261,23 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 		})
 	})
 })
+
+func expectFinalizer(name, namespace string) {
+	Eventually(func() []string {
+		mesh := &meshv1alpha1.MultiClusterMesh{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, mesh); err != nil {
+			return nil
+		}
+		return mesh.Finalizers
+	}).Should(ContainElement(meshcontroller.FinalizerName))
+}
+
+func expectResourceDeleted(obj client.Object, name, namespace string) {
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)
+		return errors.IsNotFound(err)
+	}).Should(BeTrue())
+}
 
 func expectManifestWork(name, namespace string) *workv1.ManifestWork {
 	work := &workv1.ManifestWork{}


### PR DESCRIPTION
This ensures the controller cleans up the created resources before the MultiClusterMesh CR is deleted.