### PR TITLE
Add listener for ManagedCluster changes with Singleton approach

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -44,8 +44,8 @@ const (
 
 	FinalizerName = "mesh.open-cluster-management.io/finalizer"
 
-	LabelMeshName      = "mesh.open-cluster-management.io/mesh-name"
-	LabelMeshNamespace = "mesh.open-cluster-management.io/mesh-namespace"
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+	ManagedByValue = "multicluster-mesh-addon"
 
 	ClusterSetLabel     = "cluster.open-cluster-management.io/clusterset"
 	clusterClaimProduct = "product.open-cluster-management.io"
@@ -140,8 +140,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 	}
 
-	if err := r.cleanupOrphanedManifestWorks(ctx, mesh, clusters); err != nil {
-		klog.Errorf("Failed to cleanup orphaned ManifestWorks: %v", err)
+	if err := r.cleanupOperatorManifestWorks(ctx); err != nil {
+		klog.Errorf("Failed to cleanup operator ManifestWorks: %v", err)
 		return reconcile.Result{}, err
 	}
 
@@ -184,22 +184,8 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 	}
 
 	klog.Infof("Handling deletion for MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
-	workList := &workv1.ManifestWorkList{}
-	if err := r.List(ctx, workList, meshLabelSelector(mesh)); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to list ManifestWorks for cleanup: %w", err)
-	}
-
-	klog.V(4).Infof("Found %d ManifestWorks to clean up for MultiClusterMesh %s/%s", len(workList.Items), mesh.Namespace, mesh.Name)
-	for i := range workList.Items {
-		work := &workList.Items[i]
-		if err := r.Delete(ctx, work); err != nil {
-			if !errors.IsNotFound(err) {
-				return reconcile.Result{}, fmt.Errorf("failed to delete ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
-			}
-			klog.V(4).Infof("ManifestWork %s/%s already deleted", work.Namespace, work.Name)
-		} else {
-			klog.Infof("Deleted ManifestWork %s/%s", work.Namespace, work.Name)
-		}
+	if err := r.cleanupOperatorManifestWorks(ctx); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to cleanup operator ManifestWorks: %w", err)
 	}
 
 	klog.Infof("Removing finalizer from MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
@@ -248,39 +234,59 @@ func (r *Reconciler) ensureOperatorInstalled(ctx context.Context, mesh *meshv1al
 	return nil
 }
 
-func (r *Reconciler) cleanupOrphanedManifestWorks(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
-	expectedClusters := make(map[string]bool)
-	for _, cluster := range clusters {
-		expectedClusters[cluster.Name] = true
+// cleanupOperatorManifestWorks deletes operator ManifestWorks on clusters that no mesh needs anymore.
+func (r *Reconciler) cleanupOperatorManifestWorks(ctx context.Context) error {
+	neededClusters, err := r.getClustersNeededByAnyMesh(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to determine needed clusters: %w", err)
 	}
 
-	// List ALL ManifestWorks that were created for this mesh, some of which might be orphaned
 	workList := &workv1.ManifestWorkList{}
-	if err := r.List(ctx, workList, meshLabelSelector(mesh)); err != nil {
-		return fmt.Errorf("failed to list ManifestWorks: %w", err)
+	if err := r.List(ctx, workList, client.MatchingLabels{ManagedByLabel: ManagedByValue}); err != nil {
+		return fmt.Errorf("failed to list operator ManifestWorks: %w", err)
 	}
 
 	for _, work := range workList.Items {
-		// Skip any clusters that are still in the set the mesh is referencing
-		if expectedClusters[work.Namespace] {
+		if neededClusters[work.Namespace] {
 			continue
 		}
 
-		klog.Infof("Deleting orphaned ManifestWork %s/%s (cluster no longer in ClusterSet %s)",
-			work.Namespace, work.Name, mesh.Spec.ClusterSet)
+		klog.Infof("Deleting operator ManifestWork %s/%s (no mesh targets this cluster)", work.Namespace, work.Name)
 		if err := r.Delete(ctx, &work); err != nil && !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete orphaned ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
+			return fmt.Errorf("failed to delete operator ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
 		}
 	}
 
 	return nil
 }
 
-func meshLabelSelector(mesh *meshv1alpha1.MultiClusterMesh) client.MatchingLabels {
-	return client.MatchingLabels{
-		LabelMeshName:      mesh.Name,
-		LabelMeshNamespace: mesh.Namespace,
+// getClustersNeededByAnyMesh returns a set of cluster names that are targeted by at least one active mesh.
+func (r *Reconciler) getClustersNeededByAnyMesh(ctx context.Context) (map[string]bool, error) {
+	needed := make(map[string]bool)
+	checkedSets := make(map[string]bool)
+
+	meshList := &meshv1alpha1.MultiClusterMeshList{}
+	if err := r.List(ctx, meshList); err != nil {
+		return nil, fmt.Errorf("failed to list meshes: %w", err)
 	}
+
+	for _, mesh := range meshList.Items {
+		if !mesh.DeletionTimestamp.IsZero() || checkedSets[mesh.Spec.ClusterSet] {
+			continue
+		}
+
+		checkedSets[mesh.Spec.ClusterSet] = true
+		clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
+		}
+
+		for _, cluster := range clusters {
+			needed[cluster.Name] = true
+		}
+	}
+
+	return needed, nil
 }
 
 func isOpenShift(cluster *clusterv1.ManagedCluster) bool {
@@ -404,8 +410,7 @@ func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMe
 			Name:      getOperatorManifestWorkName(isOCP),
 			Namespace: cluster.Name,
 			Labels: map[string]string{
-				LabelMeshName:      mesh.Name,
-				LabelMeshNamespace: mesh.Namespace,
+				ManagedByLabel: ManagedByValue,
 			},
 		},
 		Spec: workv1.ManifestWorkSpec{

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -39,8 +39,7 @@ const (
 
 	DefaultChannel = "stable"
 
-	ManifestWorkNameOSSM = "multicluster-mesh-operator-ossm"
-	ManifestWorkNameSail = "multicluster-mesh-operator-sail"
+	OperatorManifestWorkName = "multicluster-mesh-operator"
 
 	FinalizerName = "mesh.open-cluster-management.io/finalizer"
 
@@ -199,13 +198,10 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 
 func (r *Reconciler) ensureOperatorInstalled(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) error {
 	klog.V(4).Infof("Ensuring mesh operator on cluster %s for mesh %s", cluster.Name, mesh.Name)
-	isOCP := isOpenShift(cluster)
-	workName := getOperatorManifestWorkName(isOCP)
 
-	// Check if ManifestWork already exists
 	existingWork := &workv1.ManifestWork{}
 	err := r.Get(ctx, types.NamespacedName{
-		Name:      workName,
+		Name:      OperatorManifestWorkName,
 		Namespace: cluster.Name,
 	}, existingWork)
 
@@ -214,7 +210,7 @@ func (r *Reconciler) ensureOperatorInstalled(ctx context.Context, mesh *meshv1al
 			return fmt.Errorf("ManifestWork is terminating, requeueing")
 		}
 
-		klog.V(4).Infof("ManifestWork %s/%s already exists", cluster.Name, workName)
+		klog.V(4).Infof("ManifestWork %s/%s already exists", cluster.Name, OperatorManifestWorkName)
 		// TODO: Add logic to check if the work needs updating (e.g., channel change)
 		return nil
 	}
@@ -224,13 +220,11 @@ func (r *Reconciler) ensureOperatorInstalled(ctx context.Context, mesh *meshv1al
 	}
 
 	klog.Infof("Creating ManifestWork to install operator on cluster %s", cluster.Name)
-	work := r.buildOperatorManifestWork(mesh, cluster)
-
-	if err := r.Create(ctx, work); err != nil {
+	if err := r.Create(ctx, r.buildOperatorManifestWork(mesh, cluster)); err != nil {
 		return fmt.Errorf("failed to create ManifestWork: %w", err)
 	}
 
-	klog.Infof("Successfully created ManifestWork %s/%s for operator installation", cluster.Name, work.Name)
+	klog.Infof("Successfully created ManifestWork %s/%s for operator installation", cluster.Name, OperatorManifestWorkName)
 	return nil
 }
 
@@ -289,14 +283,6 @@ func (r *Reconciler) getClustersNeededByAnyMesh(ctx context.Context) (map[string
 	return needed, nil
 }
 
-func isOpenShift(cluster *clusterv1.ManagedCluster) bool {
-	switch getProductClaim(cluster) {
-	case ProductOCP, ProductROSA, ProductARO, ProductROKS, ProductOSD:
-		return true
-	}
-	return false
-}
-
 // getProductClaim returns the value for the cluster, or empty string if not found
 func getProductClaim(cluster *clusterv1.ManagedCluster) string {
 	for _, claim := range cluster.Status.ClusterClaims {
@@ -305,13 +291,6 @@ func getProductClaim(cluster *clusterv1.ManagedCluster) string {
 		}
 	}
 	return ""
-}
-
-func getOperatorManifestWorkName(isOCP bool) string {
-	if isOCP {
-		return ManifestWorkNameOSSM
-	}
-	return ManifestWorkNameSail
 }
 
 func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName string) ([]clusterv1.ManagedCluster, error) {
@@ -345,7 +324,12 @@ func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName stri
 
 func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) *workv1.ManifestWork {
 	manifests := []workv1.Manifest{}
-	isOCP := isOpenShift(cluster)
+	isOCP := false
+	switch getProductClaim(cluster) {
+	case ProductOCP, ProductROSA, ProductARO, ProductROKS, ProductOSD:
+		isOCP = true
+	}
+
 	config := r.applyOperatorDefaults(mesh.Spec.Operator, isOCP)
 
 	// openshift-operators exists by default on OCP and already has a global OperatorGroup
@@ -407,7 +391,7 @@ func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMe
 
 	return &workv1.ManifestWork{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getOperatorManifestWorkName(isOCP),
+			Name:      OperatorManifestWorkName,
 			Namespace: cluster.Name,
 			Labels: map[string]string{
 				ManagedByLabel: ManagedByValue,

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -3,7 +3,6 @@ package mesh
 import (
 	"context"
 	"fmt"
-	"time"
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -19,6 +18,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -47,6 +47,7 @@ const (
 	LabelMeshName      = "mesh.open-cluster-management.io/mesh-name"
 	LabelMeshNamespace = "mesh.open-cluster-management.io/mesh-namespace"
 
+	ClusterSetLabel     = "cluster.open-cluster-management.io/clusterset"
 	clusterClaimProduct = "product.open-cluster-management.io"
 
 	// Product claim values from github.com/stolostron/multicloud-operators-foundation/pkg/klusterlet/clusterclaim
@@ -55,10 +56,6 @@ const (
 	ProductARO  = "ARO"
 	ProductROKS = "ROKS"
 	ProductOSD  = "OpenShiftDedicated"
-)
-
-var (
-	MissingClaimRequeueDelay = 30 * time.Second
 )
 
 // Reconciler reconciles MultiClusterMesh resources
@@ -76,6 +73,10 @@ func RegisterController(mgr manager.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&meshv1alpha1.MultiClusterMesh{}).
+		Watches(
+			&clusterv1.ManagedCluster{},
+			handler.EnqueueRequestsFromMapFunc(reconciler.findMeshesForCluster),
+		).
 		Complete(reconciler)
 }
 
@@ -121,12 +122,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	klog.Infof("Found %d clusters in set %s", len(clusters), mesh.Spec.ClusterSet)
 
-	// Install the operator on each cluster
-	missingClaims := false
 	for _, cluster := range clusters {
 		if getProductClaim(&cluster) == "" {
-			klog.V(4).Infof("Cluster %s missing product claim (needed for platform detection), skipping (will requeue)", cluster.Name)
-			missingClaims = true
+			klog.V(4).Infof("Cluster %s missing product claim (needed for platform detection), skipping", cluster.Name)
 			continue
 		}
 
@@ -136,13 +134,44 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 	}
 
-	if missingClaims {
-		klog.Infof("Some clusters are missing product claims, requeueing the reconcile request")
-		return reconcile.Result{RequeueAfter: MissingClaimRequeueDelay}, nil
+	if err := r.cleanupOrphanedManifestWorks(ctx, mesh, clusters); err != nil {
+		klog.Errorf("Failed to cleanup orphaned ManifestWorks: %v", err)
+		return reconcile.Result{}, err
 	}
 
 	klog.Infof("Successfully reconciled MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
 	return reconcile.Result{}, nil
+}
+
+// findMeshesForCluster returns a list of all meshes to reconcile following a cluster change
+func (r *Reconciler) findMeshesForCluster(ctx context.Context, obj client.Object) (requests []reconcile.Request) {
+	cluster := obj.(*clusterv1.ManagedCluster)
+	clusterSetName := cluster.Labels[ClusterSetLabel]
+	if clusterSetName == "" {
+		klog.V(4).Infof("Cluster %s has no clusterset label, skipping", cluster.Name)
+		return
+	}
+
+	meshList := &meshv1alpha1.MultiClusterMeshList{}
+	if err := r.List(ctx, meshList); err != nil {
+		klog.Errorf("Failed to list MultiClusterMeshes when handling cluster %s: %v", cluster.Name, err)
+		return
+	}
+
+	for _, mesh := range meshList.Items {
+		if mesh.Spec.ClusterSet == clusterSetName {
+			klog.V(4).Infof("Cluster %s change triggers reconciliation of MultiClusterMesh %s/%s",
+				cluster.Name, mesh.Namespace, mesh.Name)
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      mesh.Name,
+					Namespace: mesh.Namespace,
+				},
+			})
+		}
+	}
+
+	return requests
 }
 
 // handleDeletion handles cleanup when the MultiClusterMesh is being deleted
@@ -154,12 +183,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 
 	klog.Infof("Handling deletion for MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
 	workList := &workv1.ManifestWorkList{}
-	labelSelector := client.MatchingLabels{
-		LabelMeshName:      mesh.Name,
-		LabelMeshNamespace: mesh.Namespace,
-	}
-
-	if err := r.List(ctx, workList, labelSelector); err != nil {
+	if err := r.List(ctx, workList, meshLabelSelector(mesh)); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to list ManifestWorks for cleanup: %w", err)
 	}
 
@@ -198,6 +222,10 @@ func (r *Reconciler) ensureOperatorInstalled(ctx context.Context, mesh *meshv1al
 	}, existingWork)
 
 	if err == nil {
+		if !existingWork.DeletionTimestamp.IsZero() {
+			return fmt.Errorf("ManifestWork is terminating, requeueing")
+		}
+
 		klog.V(4).Infof("ManifestWork %s/%s already exists", cluster.Name, workName)
 		// TODO: Add logic to check if the work needs updating (e.g., channel change)
 		return nil
@@ -216,6 +244,44 @@ func (r *Reconciler) ensureOperatorInstalled(ctx context.Context, mesh *meshv1al
 
 	klog.Infof("Successfully created ManifestWork %s/%s for operator installation", cluster.Name, work.Name)
 	return nil
+}
+
+func (r *Reconciler) cleanupOrphanedManifestWorks(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
+	expectedClusters := make(map[string]bool)
+	for _, cluster := range clusters {
+		expectedClusters[cluster.Name] = true
+	}
+
+	// List ALL ManifestWorks that were created for this mesh, some of which might be orphaned
+	workList := &workv1.ManifestWorkList{}
+	if err := r.List(ctx, workList, meshLabelSelector(mesh)); err != nil {
+		return fmt.Errorf("failed to list ManifestWorks: %w", err)
+	}
+
+	for i := range workList.Items {
+		work := &workList.Items[i]
+		clusterName := work.Namespace
+
+		// Skip any clusters that are still in the set the mesh is referencing
+		if expectedClusters[clusterName] {
+			continue
+		}
+
+		klog.Infof("Deleting orphaned ManifestWork %s/%s (cluster no longer in ClusterSet %s)",
+			work.Namespace, work.Name, mesh.Spec.ClusterSet)
+		if err := r.Delete(ctx, work); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete orphaned ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func meshLabelSelector(mesh *meshv1alpha1.MultiClusterMesh) client.MatchingLabels {
+	return client.MatchingLabels{
+		LabelMeshName:      mesh.Name,
+		LabelMeshNamespace: mesh.Namespace,
+	}
 }
 
 func isOpenShift(cluster *clusterv1.ManagedCluster) bool {
@@ -246,6 +312,10 @@ func getOperatorManifestWorkName(isOCP bool) string {
 func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName string) ([]clusterv1.ManagedCluster, error) {
 	clusterSet := &clusterv1beta2.ManagedClusterSet{}
 	if err := r.Get(ctx, types.NamespacedName{Name: clusterSetName}, clusterSet); err != nil {
+		if errors.IsNotFound(err) {
+			klog.V(4).Infof("ManagedClusterSet %s not found, will reconcile when it is created", clusterSetName)
+			return []clusterv1.ManagedCluster{}, nil
+		}
 		return nil, fmt.Errorf("failed to get ManagedClusterSet %s: %w", clusterSetName, err)
 	}
 
@@ -258,7 +328,7 @@ func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName stri
 
 	clusterList := &clusterv1.ManagedClusterList{}
 	labelSelector := client.MatchingLabels{
-		"cluster.open-cluster-management.io/clusterset": clusterSetName,
+		ClusterSetLabel: clusterSetName,
 	}
 
 	if err := r.List(ctx, clusterList, labelSelector); err != nil {

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -66,6 +66,12 @@ type Reconciler struct {
 
 // RegisterController registers the MultiClusterMesh controller with the manager
 func RegisterController(mgr manager.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &meshv1alpha1.MultiClusterMesh{}, "spec.clusterSet", func(obj client.Object) []string {
+		return []string{obj.(*meshv1alpha1.MultiClusterMesh).Spec.ClusterSet}
+	}); err != nil {
+		return fmt.Errorf("failed to create field index: %w", err)
+	}
+
 	reconciler := &Reconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
@@ -153,22 +159,18 @@ func (r *Reconciler) findMeshesForCluster(ctx context.Context, obj client.Object
 	}
 
 	meshList := &meshv1alpha1.MultiClusterMeshList{}
-	if err := r.List(ctx, meshList); err != nil {
+	if err := r.List(ctx, meshList, client.MatchingFields{"spec.clusterSet": clusterSetName}); err != nil {
 		klog.Errorf("Failed to list MultiClusterMeshes when handling cluster %s: %v", cluster.Name, err)
 		return
 	}
 
 	for _, mesh := range meshList.Items {
-		if mesh.Spec.ClusterSet == clusterSetName {
-			klog.V(4).Infof("Cluster %s change triggers reconciliation of MultiClusterMesh %s/%s",
-				cluster.Name, mesh.Namespace, mesh.Name)
-			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      mesh.Name,
-					Namespace: mesh.Namespace,
-				},
-			})
-		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      mesh.Name,
+				Namespace: mesh.Namespace,
+			},
+		})
 	}
 
 	return requests
@@ -258,18 +260,15 @@ func (r *Reconciler) cleanupOrphanedManifestWorks(ctx context.Context, mesh *mes
 		return fmt.Errorf("failed to list ManifestWorks: %w", err)
 	}
 
-	for i := range workList.Items {
-		work := &workList.Items[i]
-		clusterName := work.Namespace
-
+	for _, work := range workList.Items {
 		// Skip any clusters that are still in the set the mesh is referencing
-		if expectedClusters[clusterName] {
+		if expectedClusters[work.Namespace] {
 			continue
 		}
 
 		klog.Infof("Deleting orphaned ManifestWork %s/%s (cluster no longer in ClusterSet %s)",
 			work.Namespace, work.Name, mesh.Spec.ClusterSet)
-		if err := r.Delete(ctx, work); err != nil && !errors.IsNotFound(err) {
+		if err := r.Delete(ctx, &work); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete orphaned ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
 		}
 	}
@@ -313,7 +312,7 @@ func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName stri
 	clusterSet := &clusterv1beta2.ManagedClusterSet{}
 	if err := r.Get(ctx, types.NamespacedName{Name: clusterSetName}, clusterSet); err != nil {
 		if errors.IsNotFound(err) {
-			klog.V(4).Infof("ManagedClusterSet %s not found, will reconcile when it is created", clusterSetName)
+			klog.V(4).Infof("ManagedClusterSet %s not found", clusterSetName)
 			return []clusterv1.ManagedCluster{}, nil
 		}
 		return nil, fmt.Errorf("failed to get ManagedClusterSet %s: %w", clusterSetName, err)

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -163,8 +163,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 		It("should not create ManifestWorks when ClusterSet doesn't exist", func() {
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, util.UniqueName("set"), meshv1alpha1.OperatorConfig{})
-
-			awaitReconcileFinished()
 			expectNoManifestWorks()
 		})
 
@@ -180,7 +178,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("shouldn't process a cluster without clusterset label", func() {
 				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, "")
-				awaitReconcileFinished()
 				expectNoManifestWorks()
 			})
 
@@ -221,34 +218,25 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should cleanup ManifestWork when the cluster is removed from ClusterSet", func() {
 				updateClusterSetLabel(clusterName, "")
-				awaitReconcileFinished()
-				expectNoManifestWorks()
+				expectAllManifestWorksDeleted()
 			})
 
 			It("should cleanup ManifestWork when the cluster is deleted", func() {
 				cluster := &clusterv1.ManagedCluster{}
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster)).To(Succeed())
 				Expect(k8sClient.Delete(ctx, cluster)).To(Succeed())
-				expectResourceDeleted(&clusterv1.ManagedCluster{}, testClusterSet, "")
+				expectResourceDeleted(&clusterv1.ManagedCluster{}, clusterName, "")
 
-				awaitReconcileFinished()
-				expectNoManifestWorks()
+				expectAllManifestWorksDeleted()
 			})
 
-			When("moving the cluster between sets", func() {
-				var otherClusterSet string
+			It("should cleanup ManifestWork when moving the cluster to another set", func() {
+				otherClusterSet := util.UniqueName("other-set")
+				util.CreateManagedClusterSet(ctx, k8sClient, otherClusterSet)
+				awaitReconcileFinished()
 
-				BeforeEach(func() {
-					otherClusterSet = util.UniqueName("other-set")
-					util.CreateManagedClusterSet(ctx, k8sClient, otherClusterSet)
-					awaitReconcileFinished()
-				})
-
-				It("should cleanup ManifestWork", func() {
-					updateClusterSetLabel(clusterName, otherClusterSet)
-					awaitReconcileFinished()
-					expectNoManifestWorks()
-				})
+				updateClusterSetLabel(clusterName, otherClusterSet)
+				expectAllManifestWorksDeleted()
 			})
 		})
 	})
@@ -367,10 +355,22 @@ func updateClusterSetLabel(clusterName, newClusterSet string) {
 	Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
 }
 
+// expectNoManifestWorks makes sure that no ManifestWorks are created, checking consistently
 func expectNoManifestWorks() {
-	workList := &workv1.ManifestWorkList{}
-	Expect(k8sClient.List(ctx, workList)).To(Succeed())
-	Expect(workList.Items).To(BeEmpty())
+	Consistently(func() []workv1.ManifestWork {
+		workList := &workv1.ManifestWorkList{}
+		Expect(k8sClient.List(ctx, workList)).To(Succeed())
+		return workList.Items
+	}).Should(BeEmpty())
+}
+
+// expectAllManifestWorksDeleted makes sure ManifestWorks are deleted and none remain
+func expectAllManifestWorksDeleted() {
+	Eventually(func() []workv1.ManifestWork {
+		workList := &workv1.ManifestWorkList{}
+		Expect(k8sClient.List(ctx, workList)).To(Succeed())
+		return workList.Items
+	}).Should(BeEmpty())
 }
 
 func expectManifestWork(name, namespace string) *workv1.ManifestWork {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -82,7 +82,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			cluster2 := util.UniqueName("cluster")
 
 			util.CreateK8sManagedCluster(ctx, k8sClient, cluster1, testClusterSet)
-			util.CreateK8sManagedCluster(ctx, k8sClient, cluster2, testClusterSet)
+			util.CreateOCPManagedCluster(ctx, k8sClient, cluster2, testClusterSet, meshcontroller.ProductOCP)
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
 
 			Eventually(func() int {
@@ -93,8 +93,11 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				return len(workList.Items)
 			}).Should(Equal(2))
 
-			expectSailManifestWork(cluster1)
-			expectSailManifestWork(cluster2)
+			work1 := expectSailManifestWork(cluster1)
+			work2 := expectOSSMManifestWork(cluster2)
+
+			Expect(work1.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
+			Expect(work2.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
 		})
 
 		It("should use custom operator configuration on K8s when specified", func() {
@@ -230,15 +233,62 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectAllManifestWorksDeleted()
 			})
 
-			It("should cleanup ManifestWork when moving the cluster to another set", func() {
-				otherClusterSet := util.UniqueName("other-set")
-				util.CreateManagedClusterSet(ctx, k8sClient, otherClusterSet)
-				awaitReconcileFinished()
+			When("moving the cluster between sets", func() {
+				var otherClusterSet string
 
-				updateClusterSetLabel(clusterName, otherClusterSet)
-				expectAllManifestWorksDeleted()
+				BeforeEach(func() {
+					otherClusterSet = util.UniqueName("other-set")
+					util.CreateManagedClusterSet(ctx, k8sClient, otherClusterSet)
+					awaitReconcileFinished()
+				})
+
+				It("should cleanup ManifestWork when no mesh targets the new set", func() {
+					updateClusterSetLabel(clusterName, otherClusterSet)
+					expectAllManifestWorksDeleted()
+				})
+
+				It("should keep ManifestWork when another mesh targets the new set", func() {
+					otherMesh := util.UniqueName("other-mesh")
+					util.CreateMultiClusterMesh(ctx, k8sClient, otherMesh, testNs, otherClusterSet, meshv1alpha1.OperatorConfig{})
+					awaitReconcileFinished()
+
+					updateClusterSetLabel(clusterName, otherClusterSet)
+					awaitReconcileFinished()
+
+					expectSailManifestWork(clusterName)
+				})
+			})
+
+			When("two meshes target the same cluster", func() {
+				var otherNs, otherMesh string
+
+				BeforeEach(func() {
+					otherNs = util.UniqueName("other-ns")
+					otherMesh = util.UniqueName("other-mesh")
+					util.CreateNamespace(ctx, k8sClient, otherNs)
+					util.CreateMultiClusterMesh(ctx, k8sClient, otherMesh, otherNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+					awaitReconcileFinished()
+				})
+
+				It("should keep the ManifestWork when one mesh is deleted", func() {
+					util.DeleteMultiClusterMesh(ctx, k8sClient, otherMesh, otherNs)
+					expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, otherMesh, otherNs)
+
+					expectSailManifestWork(clusterName)
+				})
+
+				It("should delete the ManifestWork when both meshes are deleted", func() {
+					util.DeleteMultiClusterMesh(ctx, k8sClient, meshName, testNs)
+					expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
+
+					util.DeleteMultiClusterMesh(ctx, k8sClient, otherMesh, otherNs)
+					expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, otherMesh, otherNs)
+
+					expectAllManifestWorksDeleted()
+				})
 			})
 		})
+
 	})
 
 	Context("Deleting MultiClusterMesh", func() {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -93,8 +93,8 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				return len(workList.Items)
 			}).Should(Equal(2))
 
-			work1 := expectSailManifestWork(cluster1)
-			work2 := expectOSSMManifestWork(cluster2)
+			work1 := expectOperatorManifestWork(cluster1)
+			work2 := expectOperatorManifestWork(cluster2)
 
 			Expect(work1.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
 			Expect(work2.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
@@ -113,7 +113,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, customConfig)
 
-			work := expectSailManifestWork(clusterName)
+			work := expectOperatorManifestWork(clusterName)
 
 			Expect(work.Spec.Workload.Manifests).To(HaveLen(3))
 			expectNamespace(work, 0, customConfig.Namespace)
@@ -145,7 +145,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			util.CreateOCPManagedCluster(ctx, k8sClient, clusterName, testClusterSet, meshcontroller.ProductOCP)
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, customConfig)
 
-			work := expectOSSMManifestWork(clusterName)
+			work := expectOperatorManifestWork(clusterName)
 
 			Expect(work.Spec.Workload.Manifests).To(HaveLen(3))
 			expectNamespace(work, 0, customConfig.Namespace)
@@ -186,7 +186,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should process a cluster when it's added", func() {
 				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-				expectSailManifestWork(clusterName)
+				expectOperatorManifestWork(clusterName)
 			})
 		})
 
@@ -203,7 +203,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should process it when a claim is set", func() {
 				util.SetProductClaim(ctx, k8sClient, clusterName, "Other")
-				expectSailManifestWork(clusterName)
+				expectOperatorManifestWork(clusterName)
 			})
 		})
 
@@ -216,7 +216,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			BeforeEach(func() {
 				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
-				expectSailManifestWork(clusterName)
+				expectOperatorManifestWork(clusterName)
 			})
 
 			It("should cleanup ManifestWork when the cluster is removed from ClusterSet", func() {
@@ -255,7 +255,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 					updateClusterSetLabel(clusterName, otherClusterSet)
 					awaitReconcileFinished()
 
-					expectSailManifestWork(clusterName)
+					expectOperatorManifestWork(clusterName)
 				})
 			})
 
@@ -274,7 +274,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 					util.DeleteMultiClusterMesh(ctx, k8sClient, otherMesh, otherNs)
 					expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, otherMesh, otherNs)
 
-					expectSailManifestWork(clusterName)
+					expectOperatorManifestWork(clusterName)
 				})
 
 				It("should delete the ManifestWork when both meshes are deleted", func() {
@@ -298,15 +298,15 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			util.CreateOCPManagedCluster(ctx, k8sClient, cluster2, testClusterSet, meshcontroller.ProductOCP)
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
 			expectFinalizer(meshName, testNs)
-			expectSailManifestWork(clusterName)
-			expectOSSMManifestWork(cluster2)
+			expectOperatorManifestWork(clusterName)
+			expectOperatorManifestWork(cluster2)
 
 			mesh := &meshv1alpha1.MultiClusterMesh{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, mesh)).To(Succeed())
 
-			expectResourceDeleted(&workv1.ManifestWork{}, meshcontroller.ManifestWorkNameSail, clusterName)
-			expectResourceDeleted(&workv1.ManifestWork{}, meshcontroller.ManifestWorkNameOSSM, cluster2)
+			expectResourceDeleted(&workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, clusterName)
+			expectResourceDeleted(&workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, cluster2)
 			expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
 		})
 
@@ -325,7 +325,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
 			expectFinalizer(meshName, testNs)
-			expectSailManifestWork(clusterName)
+			expectOperatorManifestWork(clusterName)
 
 			clusterSet := &clusterv1beta2.ManagedClusterSet{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testClusterSet}, clusterSet)).To(Succeed())
@@ -336,7 +336,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, mesh)).To(Succeed())
 
-			expectResourceDeleted(&workv1.ManifestWork{}, meshcontroller.ManifestWorkNameSail, clusterName)
+			expectResourceDeleted(&workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, clusterName)
 			expectResourceDeleted(&meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
 		})
 	})
@@ -347,7 +347,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				util.CreateOCPManagedCluster(ctx, k8sClient, clusterName, testClusterSet, productClaim)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
 
-				work := expectOSSMManifestWork(clusterName)
+				work := expectOperatorManifestWork(clusterName)
 
 				// OpenShift: expect only Subscription (openshift-operators namespace/OperatorGroup exist by default)
 				Expect(work.Spec.Workload.Manifests).To(HaveLen(1))
@@ -365,7 +365,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
 
-			work := expectSailManifestWork(clusterName)
+			work := expectOperatorManifestWork(clusterName)
 
 			// Kubernetes: Namespace + OperatorGroup + Subscription (unlike OpenShift)
 			Expect(work.Spec.Workload.Manifests).To(HaveLen(3))
@@ -434,12 +434,8 @@ func expectManifestWork(name, namespace string) *workv1.ManifestWork {
 	return work
 }
 
-func expectSailManifestWork(clusterNamespace string) *workv1.ManifestWork {
-	return expectManifestWork(meshcontroller.ManifestWorkNameSail, clusterNamespace)
-}
-
-func expectOSSMManifestWork(clusterNamespace string) *workv1.ManifestWork {
-	return expectManifestWork(meshcontroller.ManifestWorkNameOSSM, clusterNamespace)
+func expectOperatorManifestWork(clusterNamespace string) *workv1.ManifestWork {
+	return expectManifestWork(meshcontroller.OperatorManifestWorkName, clusterNamespace)
 }
 
 // unmarshalManifest extracts a manifest from ManifestWork's RawExtension.

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -164,34 +164,92 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 		It("should not create ManifestWorks when ClusterSet doesn't exist", func() {
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, util.UniqueName("set"), meshv1alpha1.OperatorConfig{})
 
-			// Give controller time to process reconciliation
-			time.Sleep(2 * time.Second)
-
-			workList := &workv1.ManifestWorkList{}
-			Expect(k8sClient.List(ctx, workList)).To(Succeed())
-			Expect(workList.Items).To(BeEmpty())
+			awaitReconcileFinished()
+			expectNoManifestWorks()
 		})
 
-		It("should skip clusters without product claims and requeue", func() {
-			util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+		When("referencing an empty ClusterSet", func() {
+			BeforeEach(func() {
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+				awaitReconcileFinished()
+			})
 
-			// Give controller time to process reconciliation
-			time.Sleep(2 * time.Second)
+			It("should not process it", func() {
+				expectNoManifestWorks()
+			})
 
-			// No ManifestWork should be created because the cluster lacks product claim
-			workList := &workv1.ManifestWorkList{}
-			Expect(k8sClient.List(ctx, workList)).To(Succeed())
-			Expect(workList.Items).To(BeEmpty())
+			It("shouldn't process a cluster without clusterset label", func() {
+				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, "")
+				awaitReconcileFinished()
+				expectNoManifestWorks()
+			})
 
-			// Now add the product claim and expect the corresponding ManifestWork to be created
-			util.SetProductClaim(ctx, k8sClient, clusterName, "Other")
-			expectSailManifestWork(clusterName)
+			It("should process a cluster when it's added", func() {
+				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				expectSailManifestWork(clusterName)
+			})
+		})
+
+		When("referencing a cluster with no product claim", func() {
+			BeforeEach(func() {
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+				awaitReconcileFinished()
+			})
+
+			It("should skip it", func() {
+				expectNoManifestWorks()
+			})
+
+			It("should process it when a claim is set", func() {
+				util.SetProductClaim(ctx, k8sClient, clusterName, "Other")
+				expectSailManifestWork(clusterName)
+			})
 		})
 
 		It("should add finalizer on MultiClusterMesh creation", func() {
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
 			expectFinalizer(meshName, testNs)
+		})
+
+		When("referencing a set with a cluster", func() {
+			BeforeEach(func() {
+				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+				expectSailManifestWork(clusterName)
+			})
+
+			It("should cleanup ManifestWork when the cluster is removed from ClusterSet", func() {
+				updateClusterSetLabel(clusterName, "")
+				awaitReconcileFinished()
+				expectNoManifestWorks()
+			})
+
+			It("should cleanup ManifestWork when the cluster is deleted", func() {
+				cluster := &clusterv1.ManagedCluster{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, cluster)).To(Succeed())
+				expectResourceDeleted(&clusterv1.ManagedCluster{}, testClusterSet, "")
+
+				awaitReconcileFinished()
+				expectNoManifestWorks()
+			})
+
+			When("moving the cluster between sets", func() {
+				var otherClusterSet string
+
+				BeforeEach(func() {
+					otherClusterSet = util.UniqueName("other-set")
+					util.CreateManagedClusterSet(ctx, k8sClient, otherClusterSet)
+					awaitReconcileFinished()
+				})
+
+				It("should cleanup ManifestWork", func() {
+					updateClusterSetLabel(clusterName, otherClusterSet)
+					awaitReconcileFinished()
+					expectNoManifestWorks()
+				})
+			})
 		})
 	})
 
@@ -296,6 +354,23 @@ func expectResourceDeleted(obj client.Object, name, namespace string) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)
 		return errors.IsNotFound(err)
 	}).Should(BeTrue())
+}
+
+func awaitReconcileFinished() {
+	time.Sleep(1 * time.Second)
+}
+
+func updateClusterSetLabel(clusterName, newClusterSet string) {
+	cluster := &clusterv1.ManagedCluster{}
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster)).To(Succeed())
+	cluster.Labels[meshcontroller.ClusterSetLabel] = newClusterSet
+	Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+}
+
+func expectNoManifestWorks() {
+	workList := &workv1.ManifestWorkList{}
+	Expect(k8sClient.List(ctx, workList)).To(Succeed())
+	Expect(workList.Items).To(BeEmpty())
 }
 
 func expectManifestWork(name, namespace string) *workv1.ManifestWork {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -51,7 +51,6 @@ var _ = BeforeSuite(func() {
 	SetDefaultEventuallyPollingInterval(250 * time.Millisecond)
 	SetDefaultConsistentlyDuration(2 * time.Second)
 	SetDefaultConsistentlyPollingInterval(250 * time.Millisecond)
-	meshcontroller.MissingClaimRequeueDelay = 1 * time.Second
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{

--- a/test/util/mesh.go
+++ b/test/util/mesh.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // CreateMultiClusterMesh creates a MultiClusterMesh resource with optional operator configuration.
@@ -23,4 +24,11 @@ func CreateMultiClusterMesh(ctx context.Context, k8sClient client.Client, name, 
 		},
 	}
 	Expect(k8sClient.Create(ctx, mesh)).To(Succeed())
+}
+
+// DeleteMultiClusterMesh deletes a MultiClusterMesh resource.
+func DeleteMultiClusterMesh(ctx context.Context, k8sClient client.Client, name, namespace string) {
+	mesh := &meshv1alpha1.MultiClusterMesh{}
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, mesh)).To(Succeed())
+	Expect(k8sClient.Delete(ctx, mesh)).To(Succeed())
 }


### PR DESCRIPTION
This is an improvement over PR #56 which uses a singleton approach for the operator installation

Since there can be only one Sail/OSSM operatr installed, we shouldn't associate the ManifestWork with a specific mesh but rather with the addon.
The new code makes sure that when necessary, the ManifestWork gets removed and doesn't get removes if it's cluster is still being referenced by a mesh.
