### PR TITLE
Add predicate to ManagedClusterSet watcher

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -16,10 +16,12 @@ import (
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
@@ -85,6 +87,7 @@ func RegisterController(mgr manager.Manager) error {
 		Watches(
 			&clusterv1beta2.ManagedClusterSet{},
 			handler.EnqueueRequestsFromMapFunc(reconciler.findMeshesForClusterSet),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Complete(reconciler)
 }


### PR DESCRIPTION
The ManagedClusterSet watcher triggers reconciliation on every
event, including status-only and metadata-only updates. The
reconciler only reads Spec.ClusterSelector.SelectorType from
ManagedClusterSet, so these extra reconciliations are unnecessary.
