### PR TITLE
Add status reporting

### DIFF
--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -129,6 +129,29 @@ type DiscoveryConfig struct {
 	TokenValidity string `json:"tokenValidity,omitempty"`
 }
 
+const (
+	// ConditionReady indicates whether the mesh is fully operational
+	ConditionReady = "Ready"
+
+	// ConditionOperatorInstalled indicates whether the operator is installed on a cluster
+	ConditionOperatorInstalled = "OperatorInstalled"
+
+	// ReasonAllClustersReady indicates all clusters have confirmed operator installation
+	ReasonAllClustersReady = "AllClustersReady"
+
+	// ReasonClustersNotReady indicates that not all clusters have confirmed operator installation
+	ReasonClustersNotReady = "ClustersNotReady"
+
+	// ReasonManifestWorkCreated indicates the operator ManifestWork has been created
+	ReasonManifestWorkCreated = "ManifestWorkCreated"
+
+	// ReasonMissingProductClaim indicates the cluster is missing its product claim
+	ReasonMissingProductClaim = "MissingProductClaim"
+
+	// ReasonReconcileError indicates an error occurred during reconciliation
+	ReasonReconcileError = "ReconcileError"
+)
+
 // MultiClusterMeshStatus defines the observed state of MultiClusterMesh
 type MultiClusterMeshStatus struct {
 	// Conditions represent the latest available observations of the mesh state
@@ -145,16 +168,7 @@ type ClusterMeshStatus struct {
 	// ClusterName is the name of the managed cluster
 	ClusterName string `json:"clusterName"`
 
-	// OperatorReady indicates if the Sail Operator is installed and ready
-	OperatorReady bool `json:"operatorReady"`
-
-	// TrustEstablished indicates if certificates have been distributed
-	TrustEstablished bool `json:"trustEstablished"`
-
-	// DiscoveryConfigured indicates if discovery secrets are in place
-	DiscoveryConfigured bool `json:"discoveryConfigured"`
-
-	// Conditions specific to this cluster
+	// Conditions represent the latest available observations of this cluster's state
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -2,6 +2,7 @@ package mesh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -13,7 +14,8 @@ import (
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -123,7 +125,7 @@ func RegisterController(mgr manager.Manager) error {
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 // Reconcile implements the reconcile loop for MultiClusterMesh resources
-func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (result reconcile.Result, reconcileErr error) {
 	klog.Infof("Reconciling MultiClusterMesh: %s/%s", req.Namespace, req.Name)
 
 	// Fetch the MultiClusterMesh resource
@@ -144,20 +146,43 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if err := r.Update(ctx, mesh); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
-		return reconcile.Result{}, nil
+		return
 	}
 
-	klog.Infof("MultiClusterMesh reconciling: %s/%s, ClusterSet: %s",
-		req.Namespace, req.Name, mesh.Spec.ClusterSet)
+	// Copy the status so we can avoid updating it in case nothing changed.
+	oldStatus := mesh.Status.DeepCopy()
+
 	clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
 	if err != nil {
-		klog.Errorf("Failed to get clusters from set %s: %v", mesh.Spec.ClusterSet, err)
-		return reconcile.Result{}, err
+		reconcileErr = fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
+	} else {
+		result, reconcileErr = r.doReconcile(ctx, mesh, clusters)
 	}
 
-	klog.Infof("Found %d clusters in set %s", len(clusters), mesh.Spec.ClusterSet)
+	// Determine status in case all's OK, and catch any possible error so that we can report it
+	if reconcileErr == nil {
+		klog.Infof("Successfully reconciled MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
+		reconcileErr = r.determineStatus(ctx, mesh, clusters)
+	}
 
+	if reconcileErr != nil {
+		klog.Errorf("Encountered an error while reconciling MultiClusterMesh %s/%s: %v", mesh.Namespace, mesh.Name, reconcileErr)
+		r.setErrorStatus(mesh, reconcileErr)
+	}
+
+	// Update status only if something changed, to avoid unnecessary reconciliations
+	var statusErr error
+	if !reflect.DeepEqual(oldStatus, &mesh.Status) {
+		statusErr = r.Status().Update(ctx, mesh)
+	}
+
+	return result, errors.Join(reconcileErr, statusErr)
+}
+
+func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) (reconcile.Result, error) {
 	for _, cluster := range clusters {
+		klog.V(4).Infof("Reconciling cluster %s", cluster.Name)
+
 		if getProductClaim(&cluster) == "" {
 			klog.V(4).Infof("Cluster %s missing product claim (needed for platform detection), skipping", cluster.Name)
 			continue
@@ -165,10 +190,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 		result, err := r.ensureOperatorInstalled(ctx, mesh, &cluster)
 		if err != nil {
-			klog.Errorf("Failed to ensure mesh operator on cluster %s: %v", cluster.Name, err)
-			return reconcile.Result{}, err
-		}
-		if result.RequeueAfter > 0 {
+			return reconcile.Result{}, fmt.Errorf("failed to ensure mesh operator on cluster %s: %w", cluster.Name, err)
+		} else if result.RequeueAfter > 0 {
 			return result, nil
 		}
 	}
@@ -187,11 +210,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	if err := r.cleanupOperatorManifestWorks(ctx); err != nil {
-		klog.Errorf("Failed to cleanup operator ManifestWorks: %v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("failed to cleanup operator ManifestWorks: %w", err)
 	}
 
-	klog.Infof("Successfully reconciled MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
 	return reconcile.Result{}, nil
 }
 
@@ -285,7 +306,7 @@ func (r *Reconciler) ensureOperatorInstalled(ctx context.Context, mesh *meshv1al
 		return reconcile.Result{}, nil
 	}
 
-	if !errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return reconcile.Result{}, fmt.Errorf("failed to get ManifestWork: %w", err)
 	}
 
@@ -316,12 +337,81 @@ func (r *Reconciler) cleanupOperatorManifestWorks(ctx context.Context) error {
 		}
 
 		klog.Infof("Deleting operator ManifestWork %s/%s (no mesh targets this cluster)", work.Namespace, work.Name)
-		if err := r.Delete(ctx, &work); err != nil && !errors.IsNotFound(err) {
+		if err := r.Delete(ctx, &work); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete operator ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
 		}
 	}
 
 	return nil
+}
+
+func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
+	var clusterStatuses []meshv1alpha1.ClusterMeshStatus
+	allReady := len(clusters) > 0
+
+	for _, cluster := range clusters {
+		status := meshv1alpha1.ClusterMeshStatus{
+			ClusterName: cluster.Name,
+		}
+
+		if getProductClaim(&cluster) == "" {
+			allReady = false
+			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+				Type:    meshv1alpha1.ConditionOperatorInstalled,
+				Status:  metav1.ConditionFalse,
+				Reason:  meshv1alpha1.ReasonMissingProductClaim,
+				Message: "Cluster is missing product claim, cannot determine platform",
+			})
+			clusterStatuses = append(clusterStatuses, status)
+			continue
+		}
+
+		work := &workv1.ManifestWork{}
+		err := r.Get(ctx, types.NamespacedName{
+			Name:      OperatorManifestWorkName,
+			Namespace: cluster.Name,
+		}, work)
+
+		if err == nil {
+			// TODO: Set to actual status when operator installation is confirmed via ManifestWork status feedback
+			allReady = false
+			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+				Type:    meshv1alpha1.ConditionOperatorInstalled,
+				Status:  metav1.ConditionFalse,
+				Reason:  meshv1alpha1.ReasonManifestWorkCreated,
+				Message: "Operator ManifestWork has been created, awaiting installation confirmation",
+			})
+		} else {
+			return fmt.Errorf("failed to get operator ManifestWork for cluster %s: %w", cluster.Name, err)
+		}
+
+		clusterStatuses = append(clusterStatuses, status)
+	}
+
+	mesh.Status.ClusterStatus = clusterStatuses
+
+	readyCondition := metav1.Condition{Type: meshv1alpha1.ConditionReady}
+	if allReady {
+		readyCondition.Status = metav1.ConditionTrue
+		readyCondition.Reason = meshv1alpha1.ReasonAllClustersReady
+		readyCondition.Message = "All clusters are ready"
+	} else {
+		readyCondition.Status = metav1.ConditionFalse
+		readyCondition.Reason = meshv1alpha1.ReasonClustersNotReady
+		readyCondition.Message = "Not all clusters are ready, check individual cluster statuses for details"
+	}
+	meta.SetStatusCondition(&mesh.Status.Conditions, readyCondition)
+
+	return nil
+}
+
+func (r *Reconciler) setErrorStatus(mesh *meshv1alpha1.MultiClusterMesh, reconcileErr error) {
+	meta.SetStatusCondition(&mesh.Status.Conditions, metav1.Condition{
+		Type:    meshv1alpha1.ConditionReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  meshv1alpha1.ReasonReconcileError,
+		Message: reconcileErr.Error(),
+	})
 }
 
 // getClustersNeededByAnyMesh returns a set of cluster names that are targeted by at least one active mesh.
@@ -366,7 +456,7 @@ func getProductClaim(cluster *clusterv1.ManagedCluster) string {
 func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName string) ([]clusterv1.ManagedCluster, error) {
 	clusterSet := &clusterv1beta2.ManagedClusterSet{}
 	if err := r.Get(ctx, types.NamespacedName{Name: clusterSetName}, clusterSet); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			klog.V(4).Infof("ManagedClusterSet %s not found", clusterSetName)
 			return []clusterv1.ManagedCluster{}, nil
 		}
@@ -567,7 +657,7 @@ func (r *Reconciler) ensureCertificateForCluster(ctx context.Context, mesh *mesh
 		return nil
 	}
 
-	if !errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get Certificate: %w", err)
 	}
 
@@ -629,7 +719,7 @@ func (r *Reconciler) ensureCacertsManifestWork(ctx context.Context, mesh *meshv1
 	}, secret)
 
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			klog.V(4).Infof("Secret %s/%s not found yet, waiting for cert-manager to create it", mesh.Namespace, secretName)
 			return nil
 		}
@@ -647,7 +737,7 @@ func (r *Reconciler) ensureCacertsManifestWork(ctx context.Context, mesh *meshv1
 		return r.updateCacertsManifestWorkIfNeeded(ctx, mesh, existingWork, secret)
 	}
 
-	if !errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get ManifestWork: %w", err)
 	}
 

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -276,7 +276,7 @@ func (r *Reconciler) findMeshesForClusterSet(ctx context.Context, obj client.Obj
 func (r *Reconciler) findMeshesForManifestWork(ctx context.Context, obj client.Object) []reconcile.Request {
 	cluster := &clusterv1.ManagedCluster{}
 	if err := r.Get(ctx, types.NamespacedName{Name: obj.GetNamespace()}, cluster); err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			klog.Errorf("Failed to get ManagedCluster %s for ManifestWork %s: %v", obj.GetNamespace(), obj.GetName(), err)
 		}
 		return nil

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -98,6 +98,10 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			Expect(work1.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
 			Expect(work2.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
+
+			expectMeshNotReady(meshName, testNs)
+			expectClusterOperatorConditionReason(meshName, testNs, cluster1, meshv1alpha1.ReasonManifestWorkCreated)
+			expectClusterOperatorConditionReason(meshName, testNs, cluster2, meshv1alpha1.ReasonManifestWorkCreated)
 		})
 
 		It("should use custom operator configuration on K8s when specified", func() {
@@ -175,12 +179,15 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should not create ManifestWorks", func() {
 				expectNoManifestWorks()
+				expectMeshNotReady(meshName, testNs)
 			})
 
 			It("should reconcile when the ClusterSet is created", func() {
 				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, otherClusterSet)
 				util.CreateManagedClusterSet(ctx, k8sClient, otherClusterSet)
 				expectOperatorManifestWork(clusterName)
+				expectMeshNotReady(meshName, testNs)
+				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonManifestWorkCreated)
 			})
 		})
 
@@ -192,16 +199,20 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should not process it", func() {
 				expectNoManifestWorks()
+				expectMeshNotReady(meshName, testNs)
 			})
 
 			It("shouldn't process a cluster without clusterset label", func() {
 				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, "")
 				expectNoManifestWorks()
+				expectMeshNotReady(meshName, testNs)
 			})
 
 			It("should process a cluster when it's added", func() {
 				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				expectOperatorManifestWork(clusterName)
+				expectMeshNotReady(meshName, testNs)
+				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonManifestWorkCreated)
 			})
 		})
 
@@ -212,13 +223,16 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				awaitReconcileFinished()
 			})
 
-			It("should skip it", func() {
+			It("should skip it and report missing product claim", func() {
 				expectNoManifestWorks()
+				expectMeshNotReady(meshName, testNs)
+				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonMissingProductClaim)
 			})
 
 			It("should process it when a claim is set", func() {
 				util.SetProductClaim(ctx, k8sClient, clusterName, "Other")
 				expectOperatorManifestWork(clusterName)
+				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonManifestWorkCreated)
 			})
 		})
 
@@ -237,16 +251,19 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			It("should cleanup ManifestWork when the cluster is removed from ClusterSet", func() {
 				updateClusterSetLabel(clusterName, "")
 				expectAllManifestWorksDeleted()
+				expectNoClusterStatus(meshName, testNs, clusterName)
 			})
 
 			It("should cleanup ManifestWork when the cluster is deleted", func() {
 				util.DeleteResource(ctx, k8sClient, &clusterv1.ManagedCluster{}, clusterName, "")
 				expectAllManifestWorksDeleted()
+				expectNoClusterStatus(meshName, testNs, clusterName)
 			})
 
 			It("should cleanup ManifestWork when the ClusterSet is deleted", func() {
 				util.DeleteResource(ctx, k8sClient, &clusterv1beta2.ManagedClusterSet{}, testClusterSet, "")
 				expectAllManifestWorksDeleted()
+				expectNoClusterStatus(meshName, testNs, clusterName)
 			})
 
 			When("moving the cluster between sets", func() {
@@ -261,6 +278,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				It("should cleanup ManifestWork when no mesh targets the new set", func() {
 					updateClusterSetLabel(clusterName, otherClusterSet)
 					expectAllManifestWorksDeleted()
+					expectNoClusterStatus(meshName, testNs, clusterName)
 				})
 
 				It("should keep ManifestWork when another mesh targets the new set", func() {
@@ -272,6 +290,8 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 					awaitReconcileFinished()
 
 					expectOperatorManifestWork(clusterName)
+					expectNoClusterStatus(meshName, testNs, clusterName)
+					expectClusterOperatorConditionReason(otherMesh, testNs, clusterName, meshv1alpha1.ReasonManifestWorkCreated)
 				})
 			})
 
@@ -617,4 +637,53 @@ func expectSubscription(work *workv1.ManifestWork, index int, isOCP bool, expect
 	Expect(sub.Spec.CatalogSourceNamespace).To(Equal(expectedCatalogSourceNamespace))
 	Expect(sub.Spec.Channel).To(Equal(expectedChannel))
 	Expect(sub.Spec.InstallPlanApproval).To(Equal(expectedInstallPlanApproval))
+}
+
+func expectMeshNotReady(meshName, namespace string) {
+	Eventually(func() metav1.ConditionStatus {
+		mesh := &meshv1alpha1.MultiClusterMesh{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
+			return ""
+		}
+		for _, c := range mesh.Status.Conditions {
+			if c.Type == meshv1alpha1.ConditionReady {
+				return c.Status
+			}
+		}
+		return ""
+	}).Should(Equal(metav1.ConditionFalse))
+}
+
+func expectClusterOperatorConditionReason(meshName, namespace, clusterName, reason string) {
+	Eventually(func() string {
+		mesh := &meshv1alpha1.MultiClusterMesh{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
+			return ""
+		}
+		for _, cs := range mesh.Status.ClusterStatus {
+			if cs.ClusterName == clusterName {
+				for _, c := range cs.Conditions {
+					if c.Type == meshv1alpha1.ConditionOperatorInstalled {
+						return c.Reason
+					}
+				}
+			}
+		}
+		return ""
+	}).Should(Equal(reason))
+}
+
+func expectNoClusterStatus(meshName, namespace, clusterName string) {
+	Eventually(func() bool {
+		mesh := &meshv1alpha1.MultiClusterMesh{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
+			return false
+		}
+		for _, cs := range mesh.Status.ClusterStatus {
+			if cs.ClusterName == clusterName {
+				return false
+			}
+		}
+		return true
+	}).Should(BeTrue())
 }


### PR DESCRIPTION
Add basic status reporting to report status per cluster and overall. Right now this is a very basic implementation, and will be expanded upon in upcoming future work.