### PR TITLE
Add listener for ManifestWork

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -110,6 +110,13 @@ func RegisterController(mgr manager.Manager) error {
 				return obj.GetLabels()[MeshNameLabel] != "" && obj.GetLabels()[MeshNamespaceLabel] != ""
 			})),
 		).
+		Watches(
+			&workv1.ManifestWork{},
+			handler.EnqueueRequestsFromMapFunc(reconciler.findMeshesForManifestWork),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				return obj.GetLabels()[ManagedByLabel] == ManagedByValue
+			})),
+		).
 		Complete(reconciler)
 }
 
@@ -242,6 +249,19 @@ func (r *Reconciler) findMeshesForClusterSet(ctx context.Context, obj client.Obj
 	}
 
 	return requests
+}
+
+// findMeshesForManifestWork returns a list of all meshes to reconcile following a ManifestWork change
+func (r *Reconciler) findMeshesForManifestWork(ctx context.Context, obj client.Object) []reconcile.Request {
+	cluster := &clusterv1.ManagedCluster{}
+	if err := r.Get(ctx, types.NamespacedName{Name: obj.GetNamespace()}, cluster); err != nil {
+		if !errors.IsNotFound(err) {
+			klog.Errorf("Failed to get ManagedCluster %s for ManifestWork %s: %v", obj.GetNamespace(), obj.GetName(), err)
+		}
+		return nil
+	}
+
+	return r.findMeshesForCluster(ctx, cluster)
 }
 
 // handleDeletion handles cleanup when the MultiClusterMesh is being deleted

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -250,8 +250,12 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should recreate ManifestWork when it is externally deleted", func() {
-				util.DeleteResource(ctx, k8sClient, &workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, clusterName)
-				expectOperatorManifestWork(clusterName)
+				work := expectOperatorManifestWork(clusterName)
+				originalUID := work.UID
+				Expect(k8sClient.Delete(ctx, work)).To(Succeed())
+				Eventually(func() types.UID {
+					return expectOperatorManifestWork(clusterName).UID
+				}).ShouldNot(Equal(originalUID))
 			})
 
 			When("moving the cluster between sets", func() {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -249,6 +249,11 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectAllManifestWorksDeleted()
 			})
 
+			It("should recreate ManifestWork when it is externally deleted", func() {
+				util.DeleteResource(ctx, k8sClient, &workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, clusterName)
+				expectOperatorManifestWork(clusterName)
+			})
+
 			When("moving the cluster between sets", func() {
 				var otherClusterSet string
 


### PR DESCRIPTION
The listener will reconcile in case an owned ManifestWork is created/updated/delete.
In case of creation/update the controller is idempotently handling the reconciliation.