### PR TITLE
Add golangci-lint config to suppress ST1001 in test utilities

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      - path: test/
+        linters:
+          - staticcheck
+        text: "ST1001"


### PR DESCRIPTION
## Summary
- Add `.golangci.yml` with v2 config format
- Exclude ST1001 (dot imports) staticcheck rule for `test/` paths, since dot-importing gomega is idiomatic in Ginkgo test helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)