### PR TITLE
Add sample YAML files and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,35 +104,35 @@ kubectl create namespace multicluster-mesh-system
 
 ### Usage
 
-Create a namespace to host your multi cluster mesh resources.
-Inside the namespace, create an `Issuer` resource that will act as the Root CA.
+#### Quick Start
 
-Create a `MultiClusterMesh` resource on the hub cluster:
-
-```yaml
-apiVersion: mesh.open-cluster-management.io/v1alpha1
-kind: MultiClusterMesh
-metadata:
-  name: prod-mesh
-  namespace: mesh-ns
-spec:
-  clusterSet: finance-prod
-  controlPlane:
-    namespace: istio-system
-  operator:
-    channel: "stable"
-    source: redhat-operators
-  security:
-    trust:
-      certManager:
-        issuerRef:
-          name: mesh-root-issuer
-    discovery:
-      tokenValidity: "1w"
+1. Create a namespace for your mesh resources:
+```bash
+kubectl create namespace mesh-system
 ```
 
+2. Create a cert-manager Issuer to act as the Root CA:
+```bash
+kubectl apply -f samples/cert-manager-issuer.yaml
+```
+
+3. Deploy a basic MultiClusterMesh:
+```bash
+kubectl apply -f samples/basic.yaml
+```
+
+For more configuration options, see the [samples](./samples/) directory:
+
+- **[basic.yaml](./samples/basic.yaml)** - Minimal configuration using defaults
+- **[complete.yaml](./samples/complete.yaml)** - All available fields with documentation
+- **[openshift.yaml](./samples/openshift.yaml)** - OpenShift-specific configuration
+- **[pinned-version.yaml](./samples/pinned-version.yaml)** - Version pinning with manual approval
+- **[cert-manager-issuer.yaml](./samples/cert-manager-issuer.yaml)** - Example cert-manager Issuer setup
+
+#### What the Addon Does
+
 The addon will:
-1. Install the Sail Operator on all clusters in the `finance-prod` ManagedClusterSet
+1. Install the Sail Operator on all clusters in the referenced ManagedClusterSet
 2. Generate and distribute intermediate CA certificates to establish trust
 3. Exchange discovery tokens between clusters for endpoint resolution
 4. Manage automatic rotation of certificates and tokens

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ kubectl apply -f samples/cert-manager-issuer.yaml
 kubectl apply -f samples/basic.yaml
 ```
 
+> **Note:** All samples use `clusterSet: default` as the ManagedClusterSet reference. Update this field to match your actual ManagedClusterSet name as needed.
+
 For more configuration options, see the [samples](./samples/) directory:
 
 - **[basic.yaml](./samples/basic.yaml)** - Minimal configuration using defaults

--- a/samples/basic.yaml
+++ b/samples/basic.yaml
@@ -1,0 +1,15 @@
+apiVersion: mesh.open-cluster-management.io/v1alpha1
+kind: MultiClusterMesh
+metadata:
+  name: basic-mesh
+  namespace: mesh-system
+spec:
+  # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
+  clusterSet: default
+
+  # Minimal security configuration using cert-manager for trust
+  security:
+    trust:
+      certManager:
+        issuerRef:
+          name: mesh-root-ca

--- a/samples/basic.yaml
+++ b/samples/basic.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: mesh-system
 spec:
   # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
+  # NOTE: Update this to match your ManagedClusterSet name
   clusterSet: default
 
   # Minimal security configuration using cert-manager for trust

--- a/samples/cert-manager-issuer.yaml
+++ b/samples/cert-manager-issuer.yaml
@@ -8,13 +8,3 @@ metadata:
   namespace: mesh-system
 spec:
   selfSigned: {}
----
-# Alternative: ClusterIssuer for cluster-wide root CA
-# Note: MultiClusterMesh currently references Issuers, not ClusterIssuers
-
-# apiVersion: cert-manager.io/v1
-# kind: ClusterIssuer
-# metadata:
-#   name: mesh-root-ca
-# spec:
-#   selfSigned: {}

--- a/samples/cert-manager-issuer.yaml
+++ b/samples/cert-manager-issuer.yaml
@@ -1,0 +1,20 @@
+# Example cert-manager Issuer to use with MultiClusterMesh
+# This must be created in the same namespace as the MultiClusterMesh resource
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: mesh-root-ca
+  namespace: mesh-system
+spec:
+  selfSigned: {}
+---
+# Alternative: ClusterIssuer for cluster-wide root CA
+# Note: MultiClusterMesh currently references Issuers, not ClusterIssuers
+
+# apiVersion: cert-manager.io/v1
+# kind: ClusterIssuer
+# metadata:
+#   name: mesh-root-ca
+# spec:
+#   selfSigned: {}

--- a/samples/complete.yaml
+++ b/samples/complete.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: mesh-system
 spec:
   # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
+  # NOTE: Update this to match your ManagedClusterSet name
   clusterSet: default
 
   # Control plane configuration
@@ -19,7 +20,7 @@ spec:
     namespace: sail-operator
 
     # OLM subscription channel
-    channel: "stable"
+    channel: stable
 
     # CatalogSource name
     # Defaults to "redhat-operators" on OpenShift, "operatorhubio-catalog" on vanilla Kubernetes
@@ -30,7 +31,7 @@ spec:
     sourceNamespace: olm
 
     # Specific operator version (optional - pins to a specific CSV)
-    # startingCSV: "sail-operator.v1.23.0"
+    # startingCSV: sail-operator.v1.23.0
 
     # Install plan approval strategy
     installPlanApproval: Automatic
@@ -49,4 +50,4 @@ spec:
     discovery:
       # How long discovery tokens remain valid
       # Supports: hours (h), days (d), weeks (w), months (m)
-      tokenValidity: "1m"
+      tokenValidity: 1m

--- a/samples/complete.yaml
+++ b/samples/complete.yaml
@@ -1,0 +1,52 @@
+apiVersion: mesh.open-cluster-management.io/v1alpha1
+kind: MultiClusterMesh
+metadata:
+  name: complete-mesh
+  namespace: mesh-system
+spec:
+  # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
+  clusterSet: default
+
+  # Control plane configuration
+  controlPlane:
+    # Namespace where Istio will be installed on each cluster
+    namespace: istio-system
+
+  # Sail Operator installation configuration
+  operator:
+    # Namespace where the Sail Operator will be installed
+    # Defaults to "openshift-operators" on OpenShift, "sail-operator" on vanilla Kubernetes
+    namespace: sail-operator
+
+    # OLM subscription channel
+    channel: "stable"
+
+    # CatalogSource name
+    # Defaults to "redhat-operators" on OpenShift, "operatorhubio-catalog" on vanilla Kubernetes
+    source: operatorhubio-catalog
+
+    # CatalogSource namespace
+    # Defaults to "openshift-marketplace" on OpenShift, "olm" on vanilla Kubernetes
+    sourceNamespace: olm
+
+    # Specific operator version (optional - pins to a specific CSV)
+    # startingCSV: "sail-operator.v1.23.0"
+
+    # Install plan approval strategy
+    installPlanApproval: Automatic
+
+  # Security configuration for trust and discovery
+  security:
+    # mTLS trust configuration using cert-manager
+    trust:
+      certManager:
+        issuerRef:
+          # Name of the cert-manager Issuer to use as Root CA
+          # This Issuer must exist in the same namespace as the MultiClusterMesh
+          name: mesh-root-ca
+
+    # Endpoint discovery token configuration
+    discovery:
+      # How long discovery tokens remain valid
+      # Supports: hours (h), days (d), weeks (w), months (m)
+      tokenValidity: "1m"

--- a/samples/openshift.yaml
+++ b/samples/openshift.yaml
@@ -1,0 +1,35 @@
+apiVersion: mesh.open-cluster-management.io/v1alpha1
+kind: MultiClusterMesh
+metadata:
+  name: openshift-mesh
+  namespace: mesh-system
+spec:
+  # Reference to the ManagedClusterSet
+  clusterSet: default
+
+  # Control plane configuration
+  controlPlane:
+    namespace: istio-system
+
+  # OpenShift-specific operator configuration
+  operator:
+    # On OpenShift, the operator is typically installed in openshift-operators
+    namespace: openshift-operators
+
+    # Use Red Hat's operator catalog
+    channel: "stable"
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace
+
+    # Automatic approval for production environments
+    installPlanApproval: Automatic
+
+  # Security configuration
+  security:
+    trust:
+      certManager:
+        issuerRef:
+          name: openshift-mesh-root-ca
+    discovery:
+      # Weekly token rotation for enhanced security
+      tokenValidity: "1w"

--- a/samples/openshift.yaml
+++ b/samples/openshift.yaml
@@ -4,7 +4,8 @@ metadata:
   name: openshift-mesh
   namespace: mesh-system
 spec:
-  # Reference to the ManagedClusterSet
+  # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
+  # NOTE: Update this to match your ManagedClusterSet name
   clusterSet: default
 
   # Control plane configuration
@@ -17,7 +18,7 @@ spec:
     namespace: openshift-operators
 
     # Use Red Hat's operator catalog
-    channel: "stable"
+    channel: stable
     source: redhat-operators
     sourceNamespace: openshift-marketplace
 
@@ -29,7 +30,7 @@ spec:
     trust:
       certManager:
         issuerRef:
-          name: openshift-mesh-root-ca
+          name: mesh-root-ca
     discovery:
       # Weekly token rotation for enhanced security
-      tokenValidity: "1w"
+      tokenValidity: 1w

--- a/samples/pinned-version.yaml
+++ b/samples/pinned-version.yaml
@@ -1,0 +1,33 @@
+apiVersion: mesh.open-cluster-management.io/v1alpha1
+kind: MultiClusterMesh
+metadata:
+  name: pinned-version-mesh
+  namespace: mesh-system
+spec:
+  # Reference to the ManagedClusterSet
+  clusterSet: default
+
+  controlPlane:
+    namespace: istio-system
+
+  # Operator configuration with version pinning and manual approval
+  operator:
+    namespace: sail-operator
+    channel: "stable"
+    source: operatorhubio-catalog
+    sourceNamespace: olm
+
+    # Pin to a specific operator version for controlled rollouts
+    startingCSV: "sail-operator.v1.23.0"
+
+    # Manual approval for staged deployments
+    installPlanApproval: Manual
+
+  security:
+    trust:
+      certManager:
+        issuerRef:
+          name: staging-mesh-root-ca
+    discovery:
+      # Daily token rotation for staging environments
+      tokenValidity: "1d"

--- a/samples/pinned-version.yaml
+++ b/samples/pinned-version.yaml
@@ -4,7 +4,8 @@ metadata:
   name: pinned-version-mesh
   namespace: mesh-system
 spec:
-  # Reference to the ManagedClusterSet
+  # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
+  # NOTE: Update this to match your ManagedClusterSet name
   clusterSet: default
 
   controlPlane:
@@ -13,12 +14,12 @@ spec:
   # Operator configuration with version pinning and manual approval
   operator:
     namespace: sail-operator
-    channel: "stable"
+    channel: stable
     source: operatorhubio-catalog
     sourceNamespace: olm
 
     # Pin to a specific operator version for controlled rollouts
-    startingCSV: "sail-operator.v1.23.0"
+    startingCSV: sail-operator.v1.23.0
 
     # Manual approval for staged deployments
     installPlanApproval: Manual
@@ -27,7 +28,7 @@ spec:
     trust:
       certManager:
         issuerRef:
-          name: staging-mesh-root-ca
+          name: mesh-root-ca
     discovery:
       # Daily token rotation for staging environments
-      tokenValidity: "1d"
+      tokenValidity: 1d


### PR DESCRIPTION
Create samples directory with five MultiClusterMesh examples demonstrating different use cases: basic minimal config, complete with all fields, OpenShift-specific, version pinning with manual approval, and cert-manager Issuer setup. Update README to reference samples instead of showing full YAML inline.