### PR TITLE
Fix KIND controller crash due to missing auth-reader RoleBinding

### DIFF
--- a/config/deploy/07-rolebinding-auth-reader.yaml
+++ b/config/deploy/07-rolebinding-auth-reader.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: multicluster-mesh-controller-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: multicluster-mesh-controller
+    namespace: multicluster-mesh-system


### PR DESCRIPTION
When the controller was deployed on a KIND cluster it was crashlooping with the following error log.

```
  error initializing delegating authentication: unable to load configmap
  based request-header-client-ca-file: configmaps
  "extension-apiserver-authentication" is forbidden
```

The delegating authenticator in k8s.io/apiserver reads the extension-apiserver-authentication ConfigMap from kube-system at startup to bootstrap request-header CA validation. On OpenShift this works out of the box because authenticated users get read access to that ConfigMap by default, but vanilla Kubernetes doesn't grant it.

This PR adds the standard RoleBinding to extension-apiserver-authentication-reader in kube-system so the controller starts cleanly on any cluster.