### PR TITLE
Commit cert-manager clusterrole changes

### DIFF
--- a/config/deploy/base/clusterrole.yaml
+++ b/config/deploy/base/clusterrole.yaml
@@ -7,6 +7,26 @@ metadata:
   name: multicluster-mesh-controller
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - cluster.open-cluster-management.io
   resources:
   - managedclusters


### PR DESCRIPTION
In one of the recent PRs, the controller code was updated with Kubebuilder annotations for the cert-manager.io group. Running `make gen` now shows differences in the clusterrole.yaml file because it was not updated accordingly. This PR fixes that.