### PR TITLE
Add validation for operator config conflict

### DIFF
--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -150,6 +150,9 @@ const (
 
 	// ReasonReconcileError indicates an error occurred during reconciliation
 	ReasonReconcileError = "ReconcileError"
+
+	// ReasonOperatorConfigConflict indicates a conflict with an older mesh's operator config
+	ReasonOperatorConfigConflict = "OperatorConfigConflict"
 )
 
 // MultiClusterMeshStatus defines the observed state of MultiClusterMesh

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -159,22 +159,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	// Copy the status so we can avoid updating it in case nothing changed.
 	oldStatus := mesh.Status.DeepCopy()
 
-	clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
-	if err != nil {
-		reconcileErr = fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
-	} else {
-		result, reconcileErr = r.doReconcile(ctx, mesh, clusters)
-	}
-
-	// Determine status in case all's OK, and catch any possible error so that we can report it
-	if reconcileErr == nil {
-		klog.Infof("Successfully reconciled MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
-		reconcileErr = r.determineStatus(ctx, mesh, clusters)
-	}
-
-	if reconcileErr != nil {
-		klog.Errorf("Encountered an error while reconciling MultiClusterMesh %s/%s: %v", mesh.Namespace, mesh.Name, reconcileErr)
+	var invalidCondition *metav1.Condition
+	if invalidCondition, reconcileErr = r.validate(ctx, mesh); reconcileErr != nil {
 		r.setErrorStatus(mesh, reconcileErr)
+	} else if invalidCondition != nil {
+		meta.SetStatusCondition(&mesh.Status.Conditions, *invalidCondition)
+	} else {
+		clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
+		if err != nil {
+			reconcileErr = fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
+		} else {
+			result, reconcileErr = r.doReconcile(ctx, mesh, clusters)
+		}
+
+		if reconcileErr == nil {
+			klog.Infof("Successfully reconciled MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
+			reconcileErr = r.determineStatus(ctx, mesh, clusters)
+		}
+
+		if reconcileErr != nil {
+			klog.Errorf("Encountered an error while reconciling MultiClusterMesh %s/%s: %v", mesh.Namespace, mesh.Name, reconcileErr)
+			r.setErrorStatus(mesh, reconcileErr)
+		}
 	}
 
 	// Update status only if something changed, to avoid unnecessary reconciliations
@@ -184,6 +190,49 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	}
 
 	return result, errors.Join(reconcileErr, statusErr)
+}
+
+// validate checks for conflicts that prevent reconciliation.
+// Returns a condition to set on the mesh if validation fails, or nil if ok.
+func (r *Reconciler) validate(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) (*metav1.Condition, error) {
+	meshList := &meshv1alpha1.MultiClusterMeshList{}
+	if err := r.List(ctx, meshList, client.MatchingFields{"spec.clusterSet": mesh.Spec.ClusterSet}); err != nil {
+		return nil, fmt.Errorf("failed to validate: %w", err)
+	}
+
+	for _, other := range meshList.Items {
+		if other.UID == mesh.UID {
+			continue
+		}
+		if !other.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if isOlderMesh(&other, mesh) && r.operatorConfigConflicts(mesh.Spec.Operator, other.Spec.Operator) {
+			return &metav1.Condition{
+				Type:   meshv1alpha1.ConditionReady,
+				Status: metav1.ConditionFalse,
+				Reason: meshv1alpha1.ReasonOperatorConfigConflict,
+				Message: fmt.Sprintf("operator config conflicts with older mesh %s/%s targeting the same ClusterSet %s",
+					other.Namespace, other.Name, mesh.Spec.ClusterSet),
+			}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// isOlderMesh returns true if a is older than b, using namespace/name as tiebreaker for equal timestamps.
+func isOlderMesh(a, b *meshv1alpha1.MultiClusterMesh) bool {
+	return a.CreationTimestamp.Before(&b.CreationTimestamp) ||
+		(a.CreationTimestamp.Equal(&b.CreationTimestamp) &&
+			client.ObjectKeyFromObject(a).String() < client.ObjectKeyFromObject(b).String())
+}
+
+// operatorConfigConflicts compares two operator configs after applying defaults to detect real conflicts.
+// This avoids false positives when one mesh explicitly sets a value that matches the other's default.
+func (r *Reconciler) operatorConfigConflicts(a, b meshv1alpha1.OperatorConfig) bool {
+	return r.applyOperatorDefaults(a, false) != r.applyOperatorDefaults(b, false) ||
+		r.applyOperatorDefaults(a, true) != r.applyOperatorDefaults(b, true)
 }
 
 func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) (reconcile.Result, error) {
@@ -297,6 +346,10 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 		return reconcile.Result{}, fmt.Errorf("failed to cleanup operator ManifestWorks: %w", err)
 	}
 
+	// Trigger reconciliation for other meshes targeting the same cluster set.
+	// If this fails, we don't want to block the mesh deletion. The other meshes will eventually reconcile.
+	r.triggerReconcileForBlockedMeshes(ctx, mesh)
+
 	klog.Infof("Removing finalizer from MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
 	controllerutil.RemoveFinalizer(mesh, FinalizerName)
 	if err := r.Update(ctx, mesh); err != nil {
@@ -363,6 +416,32 @@ func (r *Reconciler) cleanupOperatorManifestWorks(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// triggerReconcileForBlockedMeshes triggers reconciliation for blocked meshes targeting the same ClusterSet.
+// The other meshes need to be re-reconciled to detect the conflict is gone.
+func (r *Reconciler) triggerReconcileForBlockedMeshes(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) {
+	meshList := &meshv1alpha1.MultiClusterMeshList{}
+	if err := r.List(ctx, meshList, client.MatchingFields{"spec.clusterSet": mesh.Spec.ClusterSet}); err != nil {
+		klog.Errorf("Failed to list peer meshes for ClusterSet %s: %v", mesh.Spec.ClusterSet, err)
+		return
+	}
+
+	for _, other := range meshList.Items {
+		if other.UID == mesh.UID {
+			continue
+		}
+		readyCondition := meta.FindStatusCondition(other.Status.Conditions, meshv1alpha1.ConditionReady)
+		if readyCondition == nil || readyCondition.Reason != meshv1alpha1.ReasonOperatorConfigConflict {
+			continue
+		}
+
+		patch := client.MergeFrom(other.DeepCopy())
+		metav1.SetMetaDataAnnotation(&other.ObjectMeta, "mesh.open-cluster-management.io/reconcile-trigger", time.Now().Format(time.RFC3339Nano))
+		if err := r.Patch(ctx, &other, patch); err != nil {
+			klog.Errorf("Failed to trigger reconcile for peer mesh %s/%s: %v", other.Namespace, other.Name, err)
+		}
+	}
 }
 
 func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {

--- a/pkg/hub/mesh/controller_test.go
+++ b/pkg/hub/mesh/controller_test.go
@@ -3,6 +3,7 @@ package mesh
 import (
 	"context"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,5 +51,71 @@ func TestGetClustersFromSetReturnsSortedClusters(t *testing.T) {
 		if result[i].Name != name {
 			t.Errorf("expected cluster[%d] = %s, got %s", i, name, result[i].Name)
 		}
+	}
+}
+
+func TestIsOlderMesh(t *testing.T) {
+	now := metav1.Now()
+	later := metav1.NewTime(now.Add(time.Second))
+
+	tests := []struct {
+		name     string
+		a, b     *meshv1alpha1.MultiClusterMesh
+		expected bool
+	}{
+		{
+			name:     "a is older by timestamp",
+			a:        meshWith("ns", "mesh-a", now),
+			b:        meshWith("ns", "mesh-b", later),
+			expected: true,
+		},
+		{
+			name:     "b is older by timestamp",
+			a:        meshWith("ns", "mesh-a", later),
+			b:        meshWith("ns", "mesh-b", now),
+			expected: false,
+		},
+		{
+			name:     "same timestamp, a sorts first by name",
+			a:        meshWith("ns", "mesh-a", now),
+			b:        meshWith("ns", "mesh-b", now),
+			expected: true,
+		},
+		{
+			name:     "same timestamp, b sorts first by name",
+			a:        meshWith("ns", "mesh-b", now),
+			b:        meshWith("ns", "mesh-a", now),
+			expected: false,
+		},
+		{
+			name:     "same timestamp, a sorts first by namespace",
+			a:        meshWith("aaa", "mesh", now),
+			b:        meshWith("zzz", "mesh", now),
+			expected: true,
+		},
+		{
+			name:     "same timestamp and key",
+			a:        meshWith("ns", "mesh", now),
+			b:        meshWith("ns", "mesh", now),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isOlderMesh(tc.a, tc.b); got != tc.expected {
+				t.Errorf("isOlderMesh() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func meshWith(namespace, name string, ts metav1.Time) *meshv1alpha1.MultiClusterMesh {
+	return &meshv1alpha1.MultiClusterMesh{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: ts,
+		},
 	}
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -330,6 +330,44 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 	})
 
+	Context("Validation", func() {
+		var otherMesh string
+
+		BeforeEach(func() {
+			otherMesh = meshName + "-2"
+
+			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+			expectOperatorManifestWork(clusterName)
+		})
+
+		It("should allow two meshes with the same operator config", func() {
+			util.CreateMultiClusterMesh(ctx, k8sClient, otherMesh, testNs, testClusterSet, meshv1alpha1.OperatorConfig{})
+
+			expectMeshNotReady(otherMesh, testNs)
+			expectClusterOperatorConditionReason(otherMesh, testNs, clusterName, meshv1alpha1.ReasonManifestWorkCreated)
+		})
+
+		When("a newer mesh has a conflicting operator config", func() {
+			BeforeEach(func() {
+				util.CreateMultiClusterMesh(ctx, k8sClient, otherMesh, testNs, testClusterSet, meshv1alpha1.OperatorConfig{
+					Channel: "different-channel",
+				})
+			})
+
+			It("should block the newer mesh", func() {
+				expectMeshConditionReason(otherMesh, testNs, meshv1alpha1.ConditionReady, meshv1alpha1.ReasonOperatorConfigConflict)
+			})
+
+			It("should unblock the newer mesh when the older mesh is deleted", func() {
+				expectMeshConditionReason(otherMesh, testNs, meshv1alpha1.ConditionReady, meshv1alpha1.ReasonOperatorConfigConflict)
+
+				util.DeleteResource(ctx, k8sClient, &meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
+				expectClusterOperatorConditionReason(otherMesh, testNs, clusterName, meshv1alpha1.ReasonManifestWorkCreated)
+			})
+		})
+	})
+
 	Context("Deleting MultiClusterMesh", func() {
 		It("should delete related ManifestWorks", func() {
 			cluster2 := util.UniqueName("cluster2")
@@ -695,4 +733,19 @@ func expectNoClusterStatus(meshName, namespace, clusterName string) {
 		}
 		return true
 	}).Should(BeTrue())
+}
+
+func expectMeshConditionReason(meshName, namespace, conditionType, reason string) {
+	Eventually(func() string {
+		mesh := &meshv1alpha1.MultiClusterMesh{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
+			return ""
+		}
+		for _, c := range mesh.Status.Conditions {
+			if c.Type == conditionType {
+				return c.Reason
+			}
+		}
+		return ""
+	}).Should(Equal(reason))
 }


### PR DESCRIPTION
Detects conflicts in operator config between meshes targeting the same ClusterSet. The oldest mesh (by creation timestamp) is considered source of truth. Conflicting meshes get a Ready=False condition with reason OperatorConfigConflict.

When the blocking mesh is deleted, blocked peers are automatically re-reconciled.

Depends-On: #70