### PR TITLE
Fix klog verbosity flag to enable debug logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	utilflag "k8s.io/component-base/cli/flag"
-	logs "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -49,10 +48,9 @@ func init() {
 }
 
 func main() {
+	klog.InitFlags(nil)
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-
-	logs.AddFlags(logs.NewLoggingConfiguration(), pflag.CommandLine)
 
 	command := newCommand()
 	if err := command.Execute(); err != nil {


### PR DESCRIPTION
The current code was using logs.AddFlags which registers
a -v flag backed by a local LoggingConfiguration struct and
not klog's internal verbosity. Due to this, klog.V(n) calls remain
suppressed regardless of --v=N config.

This PR replaces it with klog.InitFlags(nil) which registers klog's
native -v flag directly on Go's standard flag.CommandLine, which
is then bridged into pflag. This ensures --v=4 actually controls klog
verbosity.

```
# To verify the fix, we can patch the operator as follows.
KUBECONFIG=.kube/hub.config kubectl patch deployment multicluster-mesh-controller -n multicluster-mesh-system   --type=json   -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--v=4"}]'
deployment.apps/multicluster-mesh-controller patched
```
