### PR TITLE
Check work informer cache sync result

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -103,7 +103,11 @@ func RegisterController(mgr manager.Manager) error {
 
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		workInformerFactory.Start(ctx.Done())
-		workInformerFactory.WaitForCacheSync(ctx.Done())
+		for t, synced := range workInformerFactory.WaitForCacheSync(ctx.Done()) {
+			if !synced {
+				return fmt.Errorf("failed to sync work informer cache for %v", t)
+			}
+		}
 		<-ctx.Done()
 		return nil
 	})); err != nil {


### PR DESCRIPTION
The `WaitForCacheSync` return value was ignored.
If the cache fails to sync for a type, the WorkApplier's lister would silently return empty results, causing it to attempt unnecessary creates.