### PR TITLE
Fix namespace read from the service account file

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	goflag "flag"
 	"fmt"
 	"os"
+	"strings"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -118,7 +119,7 @@ func runController(ctx context.Context, controllerContext *controllercmd.Control
 	if controllerNamespace == "" {
 		// Fallback to reading from service account namespace file
 		if namespaceBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
-			controllerNamespace = string(namespaceBytes)
+			controllerNamespace = strings.TrimSpace(string(namespaceBytes))
 			klog.Info("POD_NAMESPACE not set, using namespace from service account: ", controllerNamespace)
 		} else {
 			// Final fallback to default namespace


### PR DESCRIPTION
The service account namespace file at
/var/run/secrets/kubernetes.io/serviceaccount/namespace can contain a trailing newline. Without trimming, the leader election lease gets created in a namespace like "open-cluster-management\n", which fails silently.

This PR matches how [client-go](https://github.com/kubernetes/client-go/blob/5d252d37f7301d279fc55030c9f8e0e1688a6985/tools/clientcmd/client_config.go#L654) handles the same file.