### PR TITLE
Add listType markers to status condition slices

### DIFF
--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -173,6 +173,7 @@ type MultiClusterMeshStatus struct {
 // ClusterMeshStatus tracks the mesh status for a specific cluster
 type ClusterMeshStatus struct {
 	// ClusterName is the name of the managed cluster
+	// +required
 	ClusterName string `json:"clusterName"`
 
 	// Conditions represent the latest available observations of this cluster's state

--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -158,10 +158,14 @@ const (
 // MultiClusterMeshStatus defines the observed state of MultiClusterMesh
 type MultiClusterMeshStatus struct {
 	// Conditions represent the latest available observations of the mesh state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ClusterStatus tracks the status of each cluster in the mesh
+	// +listType=map
+	// +listMapKey=clusterName
 	// +optional
 	ClusterStatus []ClusterMeshStatus `json:"clusterStatus,omitempty"`
 }
@@ -172,6 +176,8 @@ type ClusterMeshStatus struct {
 	ClusterName string `json:"clusterName"`
 
 	// Conditions represent the latest available observations of this cluster's state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }


### PR DESCRIPTION
The Conditions and ClusterStatus slices in `MultiClusterMeshStatus`,
and the nested Conditions in `ClusterMeshStatus`, were missing the
+listType=map and +listMapKey markers that K8s requires for proper
merge-patch and server-side apply behavior.