### PR TITLE
Skip cacerts distribution for clusters without product claims

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -273,28 +273,26 @@ func (r *Reconciler) operatorConfigConflicts(a, b meshv1alpha1.OperatorConfig) b
 
 func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) (reconcile.Result, error) {
 	for _, cluster := range clusters {
-		klog.V(4).Infof("Reconciling cluster %s", cluster.Name)
-
 		if getProductClaim(&cluster) == "" {
 			klog.V(4).Infof("Cluster %s missing product claim (needed for platform detection), skipping", cluster.Name)
 			continue
 		}
+
+		klog.V(4).Infof("Reconciling cluster %s", cluster.Name)
 
 		work, err := r.workApplier.Apply(ctx, r.buildOperatorManifestWork(mesh, &cluster))
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to apply operator ManifestWork on cluster %s: %w", cluster.Name, err)
 		}
 		klog.V(4).Infof("Applied operator ManifestWork %s/%s", work.Namespace, work.Name)
-	}
 
-	// Create certificates for each cluster if cert-manager is configured
-	if mesh.Spec.Security.Trust.CertManager.IssuerRef.Name != "" {
-		if err := r.ensureCertificatesCreated(ctx, mesh, clusters); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		if err := r.ensureCacertsDistributed(ctx, mesh, clusters); err != nil {
-			return reconcile.Result{}, err
+		if mesh.Spec.Security.Trust.CertManager.IssuerRef.Name != "" {
+			if err := r.ensureCertificateForCluster(ctx, mesh, &cluster); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to ensure certificate for cluster %s: %w", cluster.Name, err)
+			}
+			if err := r.ensureCacertsManifestWork(ctx, mesh, &cluster); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to ensure cacerts ManifestWork for cluster %s: %w", cluster.Name, err)
+			}
 		}
 	}
 
@@ -753,16 +751,6 @@ func getCacertsName(clusterName string) string {
 	return fmt.Sprintf("cacerts-%s", clusterName)
 }
 
-// ensureCertificatesCreated creates Certificate resources for each cluster in the mesh
-func (r *Reconciler) ensureCertificatesCreated(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
-	for _, cluster := range clusters {
-		if err := r.ensureCertificateForCluster(ctx, mesh, &cluster); err != nil {
-			return fmt.Errorf("failed to ensure certificate for cluster %s: %w", cluster.Name, err)
-		}
-	}
-	return nil
-}
-
 // ensureCertificateForCluster applies the desired Certificate state for a specific cluster using server-side apply.
 func (r *Reconciler) ensureCertificateForCluster(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) error {
 	certName := getCacertsName(cluster.Name)
@@ -807,16 +795,6 @@ func (r *Reconciler) ensureCertificateForCluster(ctx context.Context, mesh *mesh
 	}
 
 	klog.Infof("Successfully applied Certificate %s/%s", mesh.Namespace, certName)
-	return nil
-}
-
-// ensureCacertsDistributed creates ManifestWorks to distribute cacerts secrets to clusters
-func (r *Reconciler) ensureCacertsDistributed(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
-	for _, cluster := range clusters {
-		if err := r.ensureCacertsManifestWork(ctx, mesh, &cluster); err != nil {
-			return fmt.Errorf("failed to ensure cacerts ManifestWork for cluster %s: %w", cluster.Name, err)
-		}
-	}
 	return nil
 }
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
@@ -560,7 +562,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should create Certificate resource with owner reference", func() {
-				cert := expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
+				cert := expectCertificate(testNs, clusterName, meshName, "mesh-issuer", "Issuer")
 
 				mesh := &meshv1alpha1.MultiClusterMesh{}
 				Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
@@ -576,7 +578,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should set Subject and URI SAN on Certificate", func() {
-				cert := expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
+				cert := expectCertificate(testNs, clusterName, meshName, "mesh-issuer", "Issuer")
 
 				Expect(cert.Spec.Subject).NotTo(BeNil())
 				Expect(cert.Spec.Subject.Organizations).To(ConsistOf(meshName))
@@ -587,7 +589,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should restore Certificate spec when externally modified", func() {
-				cert := expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
+				cert := expectCertificate(testNs, clusterName, meshName, "mesh-issuer", "Issuer")
 
 				cert.Spec.CommonName = "tampered"
 				Expect(k8sClient.Update(ctx, cert)).To(Succeed())
@@ -602,12 +604,12 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should recreate Certificate when it is externally deleted", func() {
-				cert := expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
+				cert := expectCertificate(testNs, clusterName, meshName, "mesh-issuer", "Issuer")
 				originalUID := cert.UID
 				Expect(k8sClient.Delete(ctx, cert)).To(Succeed())
 
 				Eventually(func() types.UID {
-					return expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer").UID
+					return expectCertificate(testNs, clusterName, meshName, "mesh-issuer", "Issuer").UID
 				}).ShouldNot(Equal(originalUID))
 			})
 
@@ -650,7 +652,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should create Certificate with ClusterIssuer kind", func() {
-				expectCertificate(testNs, clusterName, "cluster-issuer", "ClusterIssuer")
+				expectCertificate(testNs, clusterName, meshName, "cluster-issuer", "ClusterIssuer")
 			})
 		})
 
@@ -675,7 +677,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			It("should cleanup Certificate for that cluster", func() {
 				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, util.CertManagerSpec("mesh-issuer"))
-				expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
+				expectCertificate(testNs, clusterName, meshName, "mesh-issuer", "Issuer")
 
 				updateClusterSetLabel(clusterName, "")
 
@@ -688,7 +690,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			It("should cleanup all Certificates", func() {
 				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, util.CertManagerSpec("mesh-issuer"))
-				expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
+				expectCertificate(testNs, clusterName, meshName, "mesh-issuer", "Issuer")
 
 				updateMesh(meshName, testNs, func(mesh *meshv1alpha1.MultiClusterMesh) {
 					mesh.Spec.Security.Trust.CertManager.IssuerRef.Name = ""
@@ -719,15 +721,15 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should not create Certificate", func() {
 				expectMeshNotReady(meshName, testNs)
-				expectNoCertificate(testNs, clusterName)
+				expectNoCertificate(testNs, meshName)
 			})
 
 			It("should create Certificate when product claim is added", func() {
 				expectMeshNotReady(meshName, testNs)
-				expectNoCertificate(testNs, clusterName)
+				expectNoCertificate(testNs, meshName)
 
 				util.SetProductClaim(ctx, k8sClient, clusterName, "Other")
-				expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
+				expectCertificate(testNs, clusterName, meshName, "mesh-issuer", "Issuer")
 			})
 		})
 	})
@@ -846,15 +848,15 @@ func expectCacertsManifestWork(clusterNamespace string) *workv1.ManifestWork {
 	return expectManifestWork(meshcontroller.ManifestWorkNameCacerts, clusterNamespace)
 }
 
-func expectNoCertificate(namespace, clusterName string) {
-	Consistently(func() bool {
-		cert := &certmanagerv1.Certificate{}
-		err := k8sClient.Get(ctx, types.NamespacedName{
-			Name:      fmt.Sprintf("cacerts-%s", clusterName),
-			Namespace: namespace,
-		}, cert)
-		return errors.IsNotFound(err)
-	}).Should(BeTrue())
+func expectNoCertificate(namespace, meshName string) {
+	Consistently(func() []certmanagerv1.Certificate {
+		certList := &certmanagerv1.CertificateList{}
+		Expect(k8sClient.List(ctx, certList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{meshcontroller.MeshNameLabel: meshName},
+		)).To(Succeed())
+		return certList.Items
+	}).Should(BeEmpty())
 }
 
 func expectNoCacertsManifestWork(clusterNamespace string) {
@@ -865,12 +867,20 @@ func expectNoCacertsManifestWork(clusterNamespace string) {
 	}).Should(BeTrue())
 }
 
-func expectCertificate(namespace, clusterName, issuerName, issuerKind string) *certmanagerv1.Certificate {
-	cert := &certmanagerv1.Certificate{}
-	Eventually(func() error {
-		return k8sClient.Get(ctx, key.Of(fmt.Sprintf("cacerts-%s", clusterName), namespace), cert)
-	}).Should(Succeed())
+func expectCertificate(namespace, clusterName, meshName, issuerName, issuerKind string) *certmanagerv1.Certificate {
+	certList := &certmanagerv1.CertificateList{}
+	Eventually(func() int {
+		Expect(k8sClient.List(ctx, certList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{
+				meshcontroller.MeshNameLabel:    meshName,
+				meshcontroller.ClusterNameLabel: clusterName,
+			},
+		)).To(Succeed())
+		return len(certList.Items)
+	}).Should(Equal(1), "expected exactly one Certificate for cluster %s", clusterName)
 
+	cert := &certList.Items[0]
 	Expect(cert.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
 	Expect(cert.Spec.SecretName).To(Equal(fmt.Sprintf("cacerts-%s", clusterName)))
 	Expect(cert.Spec.IsCA).To(BeTrue())

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -710,6 +710,26 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectNoCacertsManifestWork(clusterName)
 			})
 		})
+
+		When("cluster has no product claim and issuer is configured", func() {
+			BeforeEach(func() {
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, util.CertManagerSpec("mesh-issuer"))
+			})
+
+			It("should not create Certificate", func() {
+				expectMeshNotReady(meshName, testNs)
+				expectNoCertificate(testNs, clusterName)
+			})
+
+			It("should create Certificate when product claim is added", func() {
+				expectMeshNotReady(meshName, testNs)
+				expectNoCertificate(testNs, clusterName)
+
+				util.SetProductClaim(ctx, k8sClient, clusterName, "Other")
+				expectCertificate(testNs, clusterName, "mesh-issuer")
+			})
+		})
 	})
 
 	Context("Platform detection", func() {
@@ -824,6 +844,17 @@ func expectOperatorManifestWork(clusterNamespace string) *workv1.ManifestWork {
 
 func expectCacertsManifestWork(clusterNamespace string) *workv1.ManifestWork {
 	return expectManifestWork(meshcontroller.ManifestWorkNameCacerts, clusterNamespace)
+}
+
+func expectNoCertificate(namespace, clusterName string) {
+	Consistently(func() bool {
+		cert := &certmanagerv1.Certificate{}
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      fmt.Sprintf("cacerts-%s", clusterName),
+			Namespace: namespace,
+		}, cert)
+		return errors.IsNotFound(err)
+	}).Should(BeTrue())
 }
 
 func expectNoCacertsManifestWork(clusterNamespace string) {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -727,7 +727,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectNoCertificate(testNs, clusterName)
 
 				util.SetProductClaim(ctx, k8sClient, clusterName, "Other")
-				expectCertificate(testNs, clusterName, "mesh-issuer")
+				expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
 			})
 		})
 	})

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -869,7 +869,7 @@ func expectNoCacertsManifestWork(clusterNamespace string) {
 
 func expectCertificate(namespace, clusterName, meshName, issuerName, issuerKind string) *certmanagerv1.Certificate {
 	certList := &certmanagerv1.CertificateList{}
-	Eventually(func() int {
+	Eventually(func() []certmanagerv1.Certificate {
 		Expect(k8sClient.List(ctx, certList,
 			client.InNamespace(namespace),
 			client.MatchingLabels{
@@ -877,8 +877,8 @@ func expectCertificate(namespace, clusterName, meshName, issuerName, issuerKind 
 				meshcontroller.ClusterNameLabel: clusterName,
 			},
 		)).To(Succeed())
-		return len(certList.Items)
-	}).Should(Equal(1), "expected exactly one Certificate for cluster %s", clusterName)
+		return certList.Items
+	}).Should(HaveLen(1), "expected exactly one Certificate for cluster %s", clusterName)
 
 	cert := &certList.Items[0]
 	Expect(cert.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))


### PR DESCRIPTION
The operator installation code skips clusters that are
missing their product claim, but ensureCertificatesCreated
and ensureCacertsDistributed were still processing them.
This PR avoids creating certs and cacerts ManifestWorks
for clusters without the product claims.