### PR TITLE
Work around dual-cache race in MW drift detection test

### DIFF
--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -288,6 +288,9 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				}
 				Expect(k8sClient.Update(ctx, work)).To(Succeed())
 
+				// Ensure reconciliation after tamper (dual-cache race, #109).
+				triggerReconcile(meshName, testNs)
+
 				Eventually(func() string {
 					work := expectOperatorManifestWork(clusterName)
 					sub := &operatorsv1alpha1.Subscription{}
@@ -597,6 +600,21 @@ func expectNoManifestWorks() {
 		Expect(k8sClient.List(ctx, workList)).To(Succeed())
 		return workList.Items
 	}).Should(BeEmpty())
+}
+
+// triggerReconcile forces a reconciliation by touching the mesh CR's annotations.
+// Workaround for the dual-cache race (#109): the controller-runtime MW watch may
+// trigger a reconcile before the WorkApplier's work informer lister syncs the update,
+// causing safeToSkipApply to read stale generation and skip the patch.
+// TODO(mkolesnik): Remove once WorkApplier uses the CR cache (sdk-go#226).
+func triggerReconcile(meshName, namespace string) {
+	mesh := &meshv1alpha1.MultiClusterMesh{}
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh)).To(Succeed())
+	if mesh.Annotations == nil {
+		mesh.Annotations = map[string]string{}
+	}
+	mesh.Annotations["test.reconcile-trigger"] = mesh.ResourceVersion
+	Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
 }
 
 // expectAllManifestWorksDeleted makes sure ManifestWorks are deleted and none remain


### PR DESCRIPTION
Work around the dual-cache race (#109) that causes the "should restore ManifestWork spec when externally modified" test to flake.

Touch the mesh CR after tampering the MW to guarantee a fresh reconciliation with an up-to-date work informer lister.

Refs: #109, open-cluster-management-io/sdk-go#226