### PR TITLE
Install cert-manager on the hub in dev-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ KIND_VERSION ?= v0.31.0
 CLUSTERADM_VERSION ?= v1.3.1
 K8S_VERSION ?= v1.35.0
 OLM_VERSION ?= v0.43.0
+CERT_MANAGER_VERSION ?= v1.20.2
 
 OS := $(shell go env GOOS)
 ARCH := $(shell go env GOARCH)
@@ -219,11 +220,11 @@ $(CLUSTERADM): | $(BIN_DIR)
 
 DEV_ENV_SCRIPT := $(CURDIR)/hack/dev-env.sh
 
-export DEV_KUBE_DIR K8S_VERSION OLM_VERSION
+export DEV_KUBE_DIR K8S_VERSION OLM_VERSION CERT_MANAGER_VERSION
 export KIND CLUSTERADM
 
 .PHONY: dev-env
-dev-env: create-clusters install-olm init-ocm join-clusters deploy-addon ## Provision full dev environment (Kind + OCM + addon)
+dev-env: create-clusters install-olm install-cert-manager init-ocm join-clusters deploy-addon ## Provision full dev environment (Kind + OCM + addon)
 
 .PHONY: create-clusters
 create-clusters: $(KIND) ## Create 3 Kind clusters (hub, cluster1, cluster2)
@@ -232,6 +233,10 @@ create-clusters: $(KIND) ## Create 3 Kind clusters (hub, cluster1, cluster2)
 .PHONY: install-olm
 install-olm: ## Install OLM on managed clusters (cluster1, cluster2)
 	$(DEV_ENV_SCRIPT) install-olm
+
+.PHONY: install-cert-manager
+install-cert-manager: ## Install cert-manager on the hub cluster
+	$(DEV_ENV_SCRIPT) install-cert-manager
 
 .PHONY: init-ocm
 init-ocm: $(CLUSTERADM) ## Initialize hub as OCM control plane

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -3,7 +3,7 @@
 # This file is invoked by Makefile targets with an action argument.
 #
 # Usage: hack/dev-env.sh <action>
-# Actions: create-clusters, install-olm, init-ocm, join-clusters, clean
+# Actions: create-clusters, install-olm, install-cert-manager, init-ocm, join-clusters, clean
 
 set -euo pipefail
 
@@ -97,6 +97,30 @@ install_olm() {
         log "Granting klusterlet-work-sa OLM permissions on ${cluster}"
         kubectl --kubeconfig="$(kubeconfig_for "${cluster}")" apply -f "${SCRIPT_DIR}/config/deploy/overlays/kind/klusterlet-work-olm.yaml"
     done
+}
+
+install_cert_manager() {
+    local hub_kubeconfig
+    hub_kubeconfig="$(kubeconfig_for "${HUB}")"
+
+    if [[ ! -f "${hub_kubeconfig}" ]]; then
+        err "Hub kubeconfig not found at ${hub_kubeconfig}. Run 'make create-clusters' first."
+    fi
+
+    if kubectl --kubeconfig="${hub_kubeconfig}" get deployment cert-manager -n cert-manager &>/dev/null; then
+        log "cert-manager already installed on hub, skipping"
+        return
+    fi
+
+    log "Installing cert-manager ${CERT_MANAGER_VERSION} on hub..."
+    kubectl --kubeconfig="${hub_kubeconfig}" apply -f \
+        "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+
+    log "Waiting for cert-manager to be ready..."
+    kubectl --kubeconfig="${hub_kubeconfig}" rollout status deployment/cert-manager -n cert-manager --timeout=120s
+    kubectl --kubeconfig="${hub_kubeconfig}" rollout status deployment/cert-manager-webhook -n cert-manager --timeout=120s
+
+    log "cert-manager ${CERT_MANAGER_VERSION} installed on hub"
 }
 
 init_ocm() {
@@ -220,10 +244,12 @@ clean() {
 
 ACTION="${1:-}"
 case "${ACTION}" in
-    create-clusters) create_clusters ;;
-    install-olm)     install_olm ;;
-    init-ocm)        init_ocm ;;
-    join-clusters)   join_clusters ;;
-    clean)           clean ;;
-    *)               err "Unknown action: '${ACTION}'. Valid: create-clusters, install-olm, init-ocm, join-clusters, clean" ;;
+    create-clusters)       create_clusters ;;
+    install-olm)           install_olm ;;
+    install-cert-manager)  install_cert_manager ;;
+    init-ocm)              init_ocm ;;
+    join-clusters)         join_clusters ;;
+    clean)                 clean ;;
+    *)
+        err "Unknown action: '${ACTION}'. Valid: create-clusters, install-olm, install-cert-manager, init-ocm, join-clusters, clean" ;;
 esac


### PR DESCRIPTION
The controller creates Certificate resources on the hub and watches them for status changes.
Without cert-manager, the controller blocks on startup and the trust integration can't be tested.

Adds an `install-cert-manager` step to the dev-env pipeline between `install-olm` and `init-ocm`.