### PR TITLE
Add e2e test suite for operator lifecycle on Kind dev-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ deploy-addon: $(KIND) gen images $(KUSTOMIZE) ## Build and deploy addon to the h
 	@echo "==> Addon controller deployed successfully. Use KUBECONFIG=$(HUB_KUBECONFIG) to interact with the hub."
 
 .PHONY: dev-clean-meshes
-dev-clean-meshes: ## Delete all MultiClusterMesh CRs and addon ManifestWorks from dev-env
+dev-clean-meshes: ## Delete all addon resources from the dev-env whether user created, or "leaked" resources left by an aborted/failed test
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete multiclustermeshes -A --all --ignore-not-found=true
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete manifestwork -A -l app.kubernetes.io/managed-by=multicluster-mesh-addon --ignore-not-found=true
 

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ KIND_VERSION ?= v0.31.0
 CLUSTERADM_VERSION ?= v1.3.1
 K8S_VERSION ?= v1.35.0
 OLM_VERSION ?= v0.43.0
+CERT_MANAGER_VERSION ?= v1.20.2
 
 OS := $(shell go env GOOS)
 ARCH := $(shell go env GOARCH)
@@ -219,11 +220,11 @@ $(CLUSTERADM): | $(BIN_DIR)
 
 DEV_ENV_SCRIPT := $(CURDIR)/hack/dev-env.sh
 
-export DEV_KUBE_DIR K8S_VERSION OLM_VERSION
+export DEV_KUBE_DIR K8S_VERSION OLM_VERSION CERT_MANAGER_VERSION
 export KIND CLUSTERADM
 
 .PHONY: dev-env
-dev-env: create-clusters install-olm init-ocm join-clusters deploy-addon ## Provision full dev environment (Kind + OCM + addon)
+dev-env: create-clusters install-olm install-cert-manager init-ocm join-clusters deploy-addon ## Provision full dev environment (Kind + OCM + addon)
 
 .PHONY: create-clusters
 create-clusters: $(KIND) ## Create 3 Kind clusters (hub, cluster1, cluster2)
@@ -232,6 +233,10 @@ create-clusters: $(KIND) ## Create 3 Kind clusters (hub, cluster1, cluster2)
 .PHONY: install-olm
 install-olm: ## Install OLM on managed clusters (cluster1, cluster2)
 	$(DEV_ENV_SCRIPT) install-olm
+
+.PHONY: install-cert-manager
+install-cert-manager: ## Install cert-manager on the hub cluster
+	$(DEV_ENV_SCRIPT) install-cert-manager
 
 .PHONY: init-ocm
 init-ocm: $(CLUSTERADM) ## Initialize hub as OCM control plane

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,12 @@ test-integration: $(ENVTEST) gen-crds deps update-test-crds ## Run integration t
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
 	go run github.com/onsi/ginkgo/v2/ginkgo -v --tags=integration ./test/integration/...
 
-# TODO: Add test-e2e target for end-to-end tests against real cluster
+.PHONY: test-e2e
+test-e2e: ## Run e2e tests against dev-env clusters (requires make dev-env)
+	HUB_KUBECONFIG=$(HUB_KUBECONFIG) \
+	CLUSTER1_KUBECONFIG=$(DEV_KUBE_DIR)/cluster1.config \
+	CLUSTER2_KUBECONFIG=$(DEV_KUBE_DIR)/cluster2.config \
+	go run github.com/onsi/ginkgo/v2/ginkgo -v --fail-fast --tags=e2e ./test/e2e/...
 
 .PHONY: build
 build: $(BIN_DIR) ## Build addon binary
@@ -260,6 +265,11 @@ deploy-addon: $(KIND) gen images $(KUSTOMIZE) ## Build and deploy addon to the h
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) rollout status deployment/multicluster-mesh-controller \
 		-n multicluster-mesh-system --timeout=180s
 	@echo "==> Addon controller deployed successfully. Use KUBECONFIG=$(HUB_KUBECONFIG) to interact with the hub."
+
+.PHONY: dev-clean-meshes
+dev-clean-meshes: ## Delete all MultiClusterMesh CRs and addon ManifestWorks from dev-env
+	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete multiclustermeshes -A --all --ignore-not-found=true
+	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete manifestwork -A -l app.kubernetes.io/managed-by=multicluster-mesh-addon --ignore-not-found=true
 
 .PHONY: dev-clean
 dev-clean: ## Destroy dev clusters and remove .kube/ folder

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -3,7 +3,7 @@
 # This file is invoked by Makefile targets with an action argument.
 #
 # Usage: hack/dev-env.sh <action>
-# Actions: create-clusters, install-olm, init-ocm, join-clusters, clean
+# Actions: create-clusters, install-olm, install-cert-manager, init-ocm, join-clusters, clean
 
 set -euo pipefail
 
@@ -97,6 +97,30 @@ install_olm() {
         log "Granting klusterlet-work-sa OLM permissions on ${cluster}"
         kubectl --kubeconfig="$(kubeconfig_for "${cluster}")" apply -f "${SCRIPT_DIR}/config/deploy/overlays/kind/klusterlet-work-olm.yaml"
     done
+}
+
+install_cert_manager() {
+    local hub_kubeconfig
+    hub_kubeconfig="$(kubeconfig_for "${HUB}")"
+
+    if [[ ! -f "${hub_kubeconfig}" ]]; then
+        err "Hub kubeconfig not found at ${hub_kubeconfig}. Run 'make create-clusters' first."
+    fi
+
+    if kubectl --kubeconfig="${hub_kubeconfig}" get deployment cert-manager -n cert-manager &>/dev/null; then
+        log "cert-manager already installed on hub, skipping"
+        return
+    fi
+
+    log "Installing cert-manager ${CERT_MANAGER_VERSION} on hub..."
+    kubectl --kubeconfig="${hub_kubeconfig}" apply -f \
+        "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+
+    log "Waiting for cert-manager to be ready..."
+    kubectl --kubeconfig="${hub_kubeconfig}" rollout status deployment/cert-manager -n cert-manager --timeout=120s
+    kubectl --kubeconfig="${hub_kubeconfig}" rollout status deployment/cert-manager-webhook -n cert-manager --timeout=120s
+
+    log "cert-manager ${CERT_MANAGER_VERSION} installed on hub"
 }
 
 init_ocm() {
@@ -220,10 +244,12 @@ clean() {
 
 ACTION="${1:-}"
 case "${ACTION}" in
-    create-clusters) create_clusters ;;
-    install-olm)     install_olm ;;
-    init-ocm)        init_ocm ;;
-    join-clusters)   join_clusters ;;
-    clean)           clean ;;
-    *)               err "Unknown action: '${ACTION}'. Valid: create-clusters, install-olm, init-ocm, join-clusters, clean" ;;
+    create-clusters)       create_clusters ;;
+    install-olm)           install_olm ;;
+    install-cert-manager)  install_cert_manager ;;
+    init-ocm)              init_ocm ;;
+    join-clusters)         join_clusters ;;
+    clean)                 clean ;;
+    *)
+        err "Unknown action: '${ACTION}'. Valid: create-clusters, install-olm, install-cert-manager, init-ocm, join-clusters, clean" ;;
 esac

--- a/test/e2e/mesh_lifecycle_test.go
+++ b/test/e2e/mesh_lifecycle_test.go
@@ -34,34 +34,47 @@ var _ = Describe("Controller health", func() {
 		deploy := &appsv1.Deployment{}
 		err := hubClient.Get(ctx, types.NamespacedName{Name: controllerName, Namespace: controllerNamespace}, deploy)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(deploy.Status.AvailableReplicas).To(Not(BeZero()))
+		Expect(deploy.Status.Conditions).To(ContainElement(And(
+			HaveField("Type", appsv1.DeploymentAvailable),
+			HaveField("Status", corev1.ConditionTrue),
+		)))
 	})
 })
 
-var _ = Describe("MultiClusterMesh lifecycle", func() {
+var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 	var (
 		mesh *meshv1alpha1.MultiClusterMesh
 		ns   string
 	)
 
-	BeforeEach(func(ctx SpecContext) {
-		Step("Creating test resources")
+	BeforeAll(func(ctx SpecContext) {
 		ns = util.UniqueName("test-ns")
 		util.CreateNamespace(ctx, hubClient, ns)
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		Step("Deleting test namespace %s", ns)
+		err := client.IgnoreNotFound(hubClient.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	BeforeEach(func(ctx SpecContext) {
+		Step("Creating test mesh")
 		mesh = util.CreateMultiClusterMesh(ctx, hubClient, util.UniqueName("test-mesh"), ns, "mesh-cluster-set")
 
 		Step("Waiting for controller to reconcile")
 		Eventually(func(g Gomega) {
-			g.Expect(refreshMesh(ctx, mesh)).To(Succeed())
+			g.Expect(getMesh(ctx, mesh)).To(Succeed())
+			// TODO(mkolesni): Once feedback rules are implemented (#89), check for Status=True instead of just existence.
 			g.Expect(meta.FindStatusCondition(mesh.Status.Conditions, meshv1alpha1.ConditionReady)).NotTo(BeNil())
 		}).Should(Succeed())
 	})
 
 	AfterEach(func(ctx SpecContext) {
-		Step("Deleting test namespace %s", ns)
-		err := client.IgnoreNotFound(hubClient.Delete(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: ns},
-		}))
+		Step("Deleting test mesh %s", mesh.Name)
+		err := client.IgnoreNotFound(hubClient.Delete(ctx, mesh))
 		Expect(err).NotTo(HaveOccurred())
 
 		Step("Waiting for ManifestWorks to be cleaned up")
@@ -96,14 +109,18 @@ var _ = Describe("MultiClusterMesh lifecycle", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ogList.Items).To(HaveLen(1))
 
-			Step("Verifying Subscription exists on %s", cluster)
-			Expect(getSubscription(ctx, spokeClient)).NotTo(BeNil())
+			Step("Verifying Subscription content on %s", cluster)
+			sub, err := getSubscription(ctx, spokeClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sub.Spec.Package).To(Equal(meshcontroller.OperatorNameSail))
+			Expect(sub.Spec.Channel).To(Equal(meshcontroller.DefaultChannel))
+			Expect(sub.Spec.CatalogSource).To(Equal(meshcontroller.DefaultCatalogSource))
 		}
 	})
 
 	It("updates spoke resources when operator config changes", func(ctx SpecContext) {
 		Step("Updating mesh operator channel")
-		Expect(refreshMesh(ctx, mesh)).To(Succeed())
+		Expect(getMesh(ctx, mesh)).To(Succeed())
 		mesh.Spec.Operator.Channel = "candidate"
 		Expect(hubClient.Update(ctx, mesh)).To(Succeed())
 
@@ -132,7 +149,7 @@ var _ = Describe("MultiClusterMesh lifecycle", func() {
 	})
 })
 
-func refreshMesh(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
+func getMesh(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
 	return hubClient.Get(ctx, types.NamespacedName{Name: mesh.Name, Namespace: mesh.Namespace}, mesh)
 }
 

--- a/test/e2e/mesh_lifecycle_test.go
+++ b/test/e2e/mesh_lifecycle_test.go
@@ -1,0 +1,155 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	workv1 "open-cluster-management.io/api/work/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
+	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
+	"github.com/stolostron/multicluster-mesh-addon/test/util"
+)
+
+const (
+	controllerNamespace = "multicluster-mesh-system"
+	controllerName      = "multicluster-mesh-controller"
+)
+
+var clusters = []string{"cluster1", "cluster2"}
+
+var _ = Describe("Controller health", func() {
+	It("should have the controller deployment available", func(ctx SpecContext) {
+		deploy := &appsv1.Deployment{}
+		err := hubClient.Get(ctx, types.NamespacedName{Name: controllerName, Namespace: controllerNamespace}, deploy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deploy.Status.AvailableReplicas).To(Not(BeZero()))
+	})
+})
+
+var _ = Describe("MultiClusterMesh lifecycle", func() {
+	var (
+		mesh *meshv1alpha1.MultiClusterMesh
+		ns   string
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		Step("Creating test resources")
+		ns = util.UniqueName("test-ns")
+		util.CreateNamespace(ctx, hubClient, ns)
+		mesh = util.CreateMultiClusterMesh(ctx, hubClient, util.UniqueName("test-mesh"), ns, "mesh-cluster-set")
+
+		Step("Waiting for controller to reconcile")
+		Eventually(func(g Gomega) {
+			g.Expect(refreshMesh(ctx, mesh)).To(Succeed())
+			g.Expect(meta.FindStatusCondition(mesh.Status.Conditions, meshv1alpha1.ConditionReady)).NotTo(BeNil())
+		}).Should(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Step("Deleting test namespace %s", ns)
+		err := client.IgnoreNotFound(hubClient.Delete(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}))
+		Expect(err).NotTo(HaveOccurred())
+
+		Step("Waiting for ManifestWorks to be cleaned up")
+		Eventually(func(g Gomega) {
+			mwList := &workv1.ManifestWorkList{}
+			err := hubClient.List(ctx, mwList, client.MatchingLabels{meshcontroller.ManagedByLabel: meshcontroller.ManagedByValue})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(mwList.Items).To(BeEmpty(), "ManifestWorks still exist")
+		}).Should(Succeed())
+	})
+
+	// TODO(mkolesni): Once feedback rules are implemented (#89), replace MW/spoke checks
+	// with mesh status assertions (ConditionOperatorInstalled=True per cluster).
+	It("creates operator resources on spoke clusters", func(ctx SpecContext) {
+		for cluster, spokeClient := range spokeClients {
+			Step("Verifying ManifestWork is Available on hub for %s", cluster)
+			Eventually(func(g Gomega) {
+				mw, err := getOperatorMW(ctx, cluster)
+				g.Expect(err).NotTo(HaveOccurred())
+				available := meta.FindStatusCondition(mw.Status.Conditions, string(workv1.WorkAvailable))
+				g.Expect(available).NotTo(BeNil())
+				g.Expect(available.Status).To(Equal(metav1.ConditionTrue))
+			}).Should(Succeed())
+
+			Step("Verifying operator namespace exists on %s", cluster)
+			err := spokeClient.Get(ctx, types.NamespacedName{Name: meshcontroller.DefaultOperatorNs}, &corev1.Namespace{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Step("Verifying OperatorGroup exists on %s", cluster)
+			ogList := &operatorsv1.OperatorGroupList{}
+			err = spokeClient.List(ctx, ogList, client.InNamespace(meshcontroller.DefaultOperatorNs))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ogList.Items).To(HaveLen(1))
+
+			Step("Verifying Subscription exists on %s", cluster)
+			Expect(getSubscription(ctx, spokeClient)).NotTo(BeNil())
+		}
+	})
+
+	It("updates spoke resources when operator config changes", func(ctx SpecContext) {
+		Step("Updating mesh operator channel")
+		Expect(refreshMesh(ctx, mesh)).To(Succeed())
+		mesh.Spec.Operator.Channel = "candidate"
+		Expect(hubClient.Update(ctx, mesh)).To(Succeed())
+
+		Step("Verifying Subscription channel is updated on spoke clusters")
+		for cluster, spokeClient := range spokeClients {
+			Eventually(func(g Gomega) {
+				g.Expect(getSubscription(ctx, spokeClient)).To(HaveField("Spec.Channel", "candidate"),
+					"expected Subscription channel on %s to be updated", cluster)
+			}).Should(Succeed())
+		}
+	})
+
+	It("cleans up resources on mesh deletion", func(ctx SpecContext) {
+		Step("Deleting the mesh CR")
+		util.DeleteResource(ctx, hubClient, mesh, mesh.Name, mesh.Namespace)
+
+		Step("Verifying ManifestWorks are removed from hub")
+		for _, cluster := range clusters {
+			util.ExpectResourceDeleted(ctx, hubClient, &workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, cluster)
+		}
+
+		Step("Verifying Subscriptions are removed from spoke clusters")
+		for _, spokeClient := range spokeClients {
+			util.ExpectResourceDeleted(ctx, spokeClient, &operatorsv1alpha1.Subscription{}, meshcontroller.OperatorNameSail, meshcontroller.DefaultOperatorNs)
+		}
+	})
+})
+
+func refreshMesh(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
+	return hubClient.Get(ctx, types.NamespacedName{Name: mesh.Name, Namespace: mesh.Namespace}, mesh)
+}
+
+func getOperatorMW(ctx context.Context, cluster string) (*workv1.ManifestWork, error) {
+	mw := &workv1.ManifestWork{}
+	err := hubClient.Get(ctx, types.NamespacedName{
+		Name:      meshcontroller.OperatorManifestWorkName,
+		Namespace: cluster,
+	}, mw)
+	return mw, err
+}
+
+func getSubscription(ctx context.Context, spokeClient client.Client) (*operatorsv1alpha1.Subscription, error) {
+	sub := &operatorsv1alpha1.Subscription{}
+	err := spokeClient.Get(ctx, types.NamespacedName{
+		Name:      meshcontroller.OperatorNameSail,
+		Namespace: meshcontroller.DefaultOperatorNs,
+	}, sub)
+	return sub, err
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,105 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+	workv1 "open-cluster-management.io/api/work/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
+	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
+	"github.com/stolostron/multicluster-mesh-addon/test/util"
+)
+
+var (
+	hubClient    client.Client
+	spokeClients map[string]client.Client
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Test Suite")
+}
+
+var _ = BeforeSuite(func(ctx context.Context) {
+	SetDefaultEventuallyTimeout(30 * time.Second)
+	SetDefaultEventuallyPollingInterval(250 * time.Millisecond)
+
+	util.MustAddToScheme(
+		meshv1alpha1.Install,
+		clusterv1.Install,
+		clusterv1beta2.Install,
+		workv1.Install,
+		operatorsv1.AddToScheme,
+		operatorsv1alpha1.AddToScheme,
+	)
+
+	hubKubeconfig := env("HUB_KUBECONFIG", ".kube/hub.config")
+	cluster1Kubeconfig := env("CLUSTER1_KUBECONFIG", ".kube/cluster1.config")
+	cluster2Kubeconfig := env("CLUSTER2_KUBECONFIG", ".kube/cluster2.config")
+
+	hubClient = clientFrom(hubKubeconfig)
+	spokeClients = map[string]client.Client{
+		"cluster1": clientFrom(cluster1Kubeconfig),
+		"cluster2": clientFrom(cluster2Kubeconfig),
+	}
+
+	Step("Verifying cluster connectivity")
+	verifyConnection(ctx, hubClient, "hub")
+	for name, c := range spokeClients {
+		verifyConnection(ctx, c, name)
+	}
+
+	Step("Checking for existing resources that can interfere with our testing")
+	checkNoExistingResources(ctx, hubClient)
+})
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func clientFrom(kubeconfig string) client.Client {
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	Expect(err).NotTo(HaveOccurred(), "failed to load kubeconfig from %s", kubeconfig)
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred(), "failed to create client from %s", kubeconfig)
+	return c
+}
+
+func Step(format string, args ...any) {
+	By(fmt.Sprintf(format, args...))
+}
+
+func verifyConnection(ctx context.Context, c client.Client, name string) {
+	nsList := &corev1.NamespaceList{}
+	Expect(c.List(ctx, nsList)).To(Succeed(),
+		"failed to connect to %s cluster", name)
+	GinkgoWriter.Printf("Connected to %s cluster (%d namespaces)\n", name, len(nsList.Items))
+}
+
+func checkNoExistingResources(ctx context.Context, c client.Client) {
+	mwList := &workv1.ManifestWorkList{}
+	err := c.List(ctx, mwList, client.MatchingLabels{meshcontroller.ManagedByLabel: meshcontroller.ManagedByValue})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mwList.Items).To(BeEmpty(),
+		"existing ManifestWorks found; run 'make dev-clean-meshes' to clean up")
+}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/gomega"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
@@ -25,6 +24,7 @@ import (
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
+	"github.com/stolostron/multicluster-mesh-addon/test/util"
 )
 
 var (
@@ -37,11 +37,6 @@ var (
 func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration Test Suite")
-}
-
-// mustAddToScheme registers a scheme and fails the test if it errors
-func mustAddToScheme(fn func(*runtime.Scheme) error, s *runtime.Scheme) {
-	Expect(fn(s)).To(Succeed())
 }
 
 var _ = BeforeSuite(func() {
@@ -66,14 +61,15 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	// Register schemes
-	mustAddToScheme(meshv1alpha1.Install, scheme.Scheme)
-	mustAddToScheme(clusterv1.Install, scheme.Scheme)
-	mustAddToScheme(clusterv1beta2.Install, scheme.Scheme)
-	mustAddToScheme(workv1.Install, scheme.Scheme)
-	mustAddToScheme(operatorsv1.AddToScheme, scheme.Scheme)
-	mustAddToScheme(operatorsv1alpha1.AddToScheme, scheme.Scheme)
-	mustAddToScheme(certmanagerv1.AddToScheme, scheme.Scheme)
+	util.MustAddToScheme(
+		meshv1alpha1.Install,
+		clusterv1.Install,
+		clusterv1beta2.Install,
+		workv1.Install,
+		operatorsv1.AddToScheme,
+		operatorsv1alpha1.AddToScheme,
+		certmanagerv1.AddToScheme,
+	)
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/test/util/k8s.go
+++ b/test/util/k8s.go
@@ -8,12 +8,21 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
 )
+
+// MustAddToScheme registers types with the global scheme, failing the test on error.
+func MustAddToScheme(fns ...func(*runtime.Scheme) error) {
+	for _, fn := range fns {
+		Expect(fn(scheme.Scheme)).To(Succeed())
+	}
+}
 
 // UniqueName generates a unique name with the given prefix.
 func UniqueName(prefix string) string {

--- a/test/util/mesh.go
+++ b/test/util/mesh.go
@@ -12,7 +12,7 @@ import (
 
 // CreateMultiClusterMesh creates a MultiClusterMesh resource.
 // An optional MeshSpec can be passed to override fields beyond clusterSet.
-func CreateMultiClusterMesh(ctx context.Context, k8sClient client.Client, name, namespace, clusterSet string, spec ...meshv1alpha1.MultiClusterMeshSpec) {
+func CreateMultiClusterMesh(ctx context.Context, k8sClient client.Client, name, namespace, clusterSet string, spec ...meshv1alpha1.MultiClusterMeshSpec) *meshv1alpha1.MultiClusterMesh {
 	var meshSpec meshv1alpha1.MultiClusterMeshSpec
 	if len(spec) > 0 {
 		meshSpec = spec[0]
@@ -27,6 +27,7 @@ func CreateMultiClusterMesh(ctx context.Context, k8sClient client.Client, name, 
 		Spec: meshSpec,
 	}
 	Expect(k8sClient.Create(ctx, mesh)).To(Succeed())
+	return mesh
 }
 
 // CertManagerSpec returns a MeshSpec with cert-manager issuer configuration.


### PR DESCRIPTION
Tests the full hub-to-spoke round-trip via real OCM work agents:
- Mesh creation deploys operator on both spokes
- Config changes propagate to spoke Subscriptions
- Mesh deletion cleans up ManifestWorks and spoke resources

Adds `make test-e2e` and `make dev-clean-meshes` targets.

Depends-On: #113