### PR TITLE
Simplify operator config by defaulting to OSSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ kubectl apply -n mesh-system -f samples/basic.yaml
 
 For more configuration options, see the [samples](./samples/) directory:
 
-- **[basic.yaml](./samples/basic.yaml)** - Minimal configuration using defaults
+- **[basic.yaml](./samples/basic.yaml)** - Minimal configuration for K8s clusters (Sail operator)
 - **[complete.yaml](./samples/complete.yaml)** - All available fields with documentation
 - **[openshift.yaml](./samples/openshift.yaml)** - OpenShift-specific configuration
 - **[pinned-version.yaml](./samples/pinned-version.yaml)** - Version pinning with manual approval

--- a/chart/crds/mesh.open-cluster-management.io_multiclustermeshes.yaml
+++ b/chart/crds/mesh.open-cluster-management.io_multiclustermeshes.yaml
@@ -59,7 +59,8 @@ spec:
                     type: string
                 type: object
               operator:
-                description: Operator defines the Sail Operator installation configuration
+                description: Operator defines the service mesh operator installation
+                  configuration
                 properties:
                   channel:
                     default: stable
@@ -74,20 +75,22 @@ spec:
                     - Automatic
                     - Manual
                     type: string
+                  name:
+                    default: servicemeshoperator3
+                    description: Name is the OLM package name of the operator
+                    type: string
                   namespace:
-                    description: |-
-                      Namespace is the namespace where the Sail Operator will be installed
-                      Defaults to "openshift-operators" on OpenShift, "sail-operator" on vanilla Kubernetes
+                    default: openshift-operators
+                    description: Namespace is the namespace where the operator will
+                      be installed
                     type: string
                   source:
-                    description: |-
-                      Source is the CatalogSource name
-                      Defaults to "redhat-operators" on OpenShift, "operatorhubio-catalog" on vanilla Kubernetes
+                    default: redhat-operators
+                    description: Source is the CatalogSource name
                     type: string
                   sourceNamespace:
-                    description: |-
-                      SourceNamespace is the namespace of the CatalogSource
-                      Defaults to "openshift-marketplace" on OpenShift, "olm" on vanilla Kubernetes
+                    default: openshift-marketplace
+                    description: SourceNamespace is the namespace of the CatalogSource
                     type: string
                   startingCSV:
                     description: |-

--- a/docs/design.md
+++ b/docs/design.md
@@ -188,14 +188,14 @@ The add-on follows a **Do No Harm** strategy: it never forcibly uninstalls or do
 
 1. **Pre-existing operator detection**: The controller creates a [ManagedClusterView] to check if a Sail/OSSM Subscription already exists on the managed cluster. This is necessary because ManifestWork claims ownership of any resource it applies, and deleting the ManifestWork would remove a pre-existing Subscription, potentially disrupting other components that depend on it (e.g., OpenShift Gateway API).
 2. **Adoption (operator already present)**: If a compatible Subscription is found, the add-on skips ManifestWork creation. If the configuration is incompatible, the add-on reports a conflict.
-3. **Installation (operator missing)**: If no Subscription is found, the controller creates a [ManifestWork] containing the OLM objects (Namespace, OperatorGroup, Subscription) with platform-specific defaults.
+3. **Installation (operator missing)**: If no Subscription is found, the controller creates a [ManifestWork] containing the OLM objects (Namespace, OperatorGroup, Subscription) using the operator configuration from `spec.operator`.
 
 ### Collision Handling
 
 The controller handles two types of collisions:
 
 1. **Hub-side (between meshes)**: If two `MultiClusterMesh` resources target the same cluster but request different operator configurations (e.g., different channels or catalog sources), the oldest mesh (by creation timestamp) takes precedence. Newer meshes with conflicting configs are halted with a `ConfigurationConflict` status.
-2. **Spoke-side (pre-existing operator)**: If the ManagedClusterView detects an existing Subscription not created by the add-on, the controller compares the installed configuration against the resolved defaults for the requesting mesh. If compatible, the operator is adopted. If incompatible, the controller halts and reports a `ConfigurationConflict`.
+2. **Spoke-side (pre-existing operator)**: If the ManagedClusterView detects an existing Subscription not created by the add-on, the controller compares the installed configuration against the mesh's `spec.operator`. If compatible, the operator is adopted. If incompatible, the controller halts and reports a `ConfigurationConflict`.
 
 In both cases, the add-on will never forcibly uninstall, downgrade, or overwrite an existing operator. The user must resolve conflicts manually.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -18,7 +18,7 @@
 
 The OCM Service Mesh Add-on automates multi-cluster Istio service mesh setup via [OCM]. It manages the `MultiClusterMesh` custom resource on the hub cluster to orchestrate three concerns across managed clusters:
 
-1. **Operator Lifecycle** - Installing and managing the [Sail]/OSSM operator
+1. **Operator Lifecycle** - Installing and managing the service mesh operator ([OSSM]/[Sail])
 2. **Trust Distribution** - Establishing mTLS trust via [cert-manager]
 3. **Endpoint Discovery** - Exchanging discovery credentials via [ManagedServiceAccount]
 
@@ -29,7 +29,7 @@ Without this add-on, multi-cluster mesh setup is a manual process involving cert
 The add-on follows OCM's hub-and-spoke model:
 
 - **Hub**: The Mesh Add-on controller watches `MultiClusterMesh` resources and creates [ManifestWorks][ManifestWork], orchestrates cert-manager and ManagedServiceAccount
-- **Spoke** (managed clusters): Receives ManifestWorks from the hub, runs the Sail/OSSM operator and Istio control plane
+- **Spoke** (managed clusters): Receives ManifestWorks from the hub, runs the service mesh operator and Istio control plane
 
 ```mermaid
 flowchart TD
@@ -98,7 +98,7 @@ flowchart TD
 
 ### What the add-on does (Plumbing)
 
-- Installs the Sail/OSSM operator on managed clusters via OLM
+- Installs the service mesh operator (OSSM by default) on managed clusters via OLM
 - Distributes intermediate CA certificates for mTLS trust
 - Exchanges discovery tokens between peer clusters
 - Handles lifecycle events (cluster add/remove, mesh creation/deletion)
@@ -128,10 +128,11 @@ The resource name (`metadata.name`) is limited to 63 characters because it is us
 |-------|----------|-------------|
 | `spec.clusterSet` | Yes | Name of the [ManagedClusterSet] defining cluster membership (immutable after creation) |
 | `spec.controlPlane.namespace` | No | Namespace where Istio is installed on each cluster (default: `istio-system`) |
-| `spec.operator.namespace` | No | Namespace where the operator is installed (default: `openshift-operators` on OCP, `sail-operator` on K8s) |
+| `spec.operator.name` | No | OLM package name (default: `servicemeshoperator3`) |
+| `spec.operator.namespace` | No | Namespace where the operator is installed (default: `openshift-operators`) |
 | `spec.operator.channel` | No | OLM subscription channel (default: `stable`) |
-| `spec.operator.source` | No | CatalogSource name (default: `redhat-operators` on OCP, `operatorhubio-catalog` on K8s) |
-| `spec.operator.sourceNamespace` | No | CatalogSource namespace (default: `openshift-marketplace` on OCP, `olm` on K8s) |
+| `spec.operator.source` | No | CatalogSource name (default: `redhat-operators`) |
+| `spec.operator.sourceNamespace` | No | CatalogSource namespace (default: `openshift-marketplace`) |
 | `spec.operator.startingCSV` | No | Pin to a specific operator version |
 | `spec.operator.installPlanApproval` | No | `Automatic` or `Manual` (default: `Automatic`) |
 | `spec.security.trust.certManager.issuerRef.name` | No | cert-manager Issuer name for Root CA |
@@ -151,6 +152,7 @@ spec:
   controlPlane:
     namespace: istio-system
   operator:
+    name: servicemeshoperator3
     channel: "stable"
     source: redhat-operators
     sourceNamespace: openshift-marketplace
@@ -172,13 +174,13 @@ The `spec.clusterSet` field is immutable after creation. With exclusive ClusterS
 
 `MultiClusterMesh` is namespace-scoped, enabling tenant isolation on the hub. Each mesh operates independently - its certificates, discovery tokens, and operator configuration are scoped to its namespace. Multiple meshes can target the same ClusterSet, provided they use different control plane namespaces. For example, Mesh A targets ClusterSet X with namespace `istio-system-a`, while Mesh B targets the same ClusterSet X with namespace `istio-system-b`. Each mesh gets its own trust domain, certificates, and discovery tokens. If two meshes target the same control plane namespace on the same ClusterSet, the older resource (by creation timestamp) wins and the newer one is rejected.
 
-The add-on detects the cluster platform via [OCM cluster claims][ClusterClaim]. OpenShift variants (OCP, ROSA, ARO, ROKS, OSD) get OSSM with OCP-specific defaults. Vanilla Kubernetes gets the Sail operator with upstream defaults. Detection happens per-cluster, so mixed ClusterSets work correctly.
+The add-on defaults to OSSM (OpenShift Service Mesh) operator configuration. All `spec.operator` fields can be overridden to use a different operator (e.g., upstream Sail on non-OCP clusters).
 
 Plumbing resources (ManifestWorks, ManagedServiceAccounts) must use a deterministic naming strategy scoped to the owning mesh, so that multiple meshes on the same cluster don't collide. The operator ManifestWork is an exception - it is shared across meshes since the operator is a cluster-wide singleton. See [#72] for the naming convention discussion.
 
 ## Operator Lifecycle
 
-The Sail/OSSM operator is a cluster-scoped singleton - only one instance can run per cluster. The operator is therefore a **shared resource** across meshes, not owned by any individual mesh. Multiple meshes targeting the same cluster share the operator installation. Cleanup is scoped to the ClusterSet: when a cluster is no longer needed by any mesh in its ClusterSet, the operator ManifestWork is removed. If the cluster moves to a different ClusterSet with a mesh, the new mesh bootstraps a fresh operator installation with its own configuration.
+The service mesh operator is a cluster-scoped singleton - only one instance can run per cluster. The operator is therefore a **shared resource** across meshes, not owned by any individual mesh. Multiple meshes targeting the same cluster share the operator installation. Cleanup is scoped to the ClusterSet: when a cluster is no longer needed by any mesh in its ClusterSet, the operator ManifestWork is removed. If the cluster moves to a different ClusterSet with a mesh, the new mesh bootstraps a fresh operator installation with its own configuration.
 
 The add-on follows a **Do No Harm** strategy: it never forcibly uninstalls or downgrades an existing operator. If the operator is already present with a compatible configuration, the add-on adopts it. If there's a conflict (e.g., different channel), the add-on reports an error and halts reconciliation for that cluster.
 
@@ -248,6 +250,7 @@ Potential additions include ACM addon lifecycle integration (i.e. via `ClusterMa
 
 <!-- Reference links -->
 [OCM]: https://open-cluster-management.io/
+[OSSM]: https://docs.openshift.com/service-mesh/
 [Sail]: https://github.com/istio-ecosystem/sail-operator
 [cert-manager]: https://cert-manager.io/
 [ManagedServiceAccount]: https://open-cluster-management.io/docs/getting-started/integration/managed-serviceaccount/

--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -82,7 +82,7 @@ type MultiClusterMeshSpec struct {
 	// +optional
 	ControlPlane ControlPlaneConfig `json:"controlPlane,omitempty"`
 
-	// Operator defines the Sail Operator installation configuration
+	// Operator defines the service mesh operator installation configuration
 	// +optional
 	Operator OperatorConfig `json:"operator,omitempty"`
 
@@ -99,11 +99,17 @@ type ControlPlaneConfig struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
-// OperatorConfig defines the Sail Operator installation settings
+// OperatorConfig defines the service mesh operator installation settings.
+// Defaults target OSSM on OpenShift. Override fields to use a different operator variant (e.g. Sail).
 type OperatorConfig struct {
-	// Namespace is the namespace where the Sail Operator will be installed
-	// Defaults to "openshift-operators" on OpenShift, "sail-operator" on vanilla Kubernetes
+	// Name is the OLM package name of the operator
 	// +optional
+	// +kubebuilder:default="servicemeshoperator3"
+	Name string `json:"name,omitempty"`
+
+	// Namespace is the namespace where the operator will be installed
+	// +optional
+	// +kubebuilder:default="openshift-operators"
 	Namespace string `json:"namespace,omitempty"`
 
 	// Channel is the OLM subscription channel (e.g., "stable", "1.23")
@@ -112,13 +118,13 @@ type OperatorConfig struct {
 	Channel string `json:"channel,omitempty"`
 
 	// Source is the CatalogSource name
-	// Defaults to "redhat-operators" on OpenShift, "operatorhubio-catalog" on vanilla Kubernetes
 	// +optional
+	// +kubebuilder:default="redhat-operators"
 	Source string `json:"source,omitempty"`
 
 	// SourceNamespace is the namespace of the CatalogSource
-	// Defaults to "openshift-marketplace" on OpenShift, "olm" on vanilla Kubernetes
 	// +optional
+	// +kubebuilder:default="openshift-marketplace"
 	SourceNamespace string `json:"sourceNamespace,omitempty"`
 
 	// StartingCSV is the specific operator version to install
@@ -199,9 +205,6 @@ const (
 
 	// ReasonOperatorInstalled indicates the operator CSV has been successfully installed
 	ReasonOperatorInstalled = "Installed"
-
-	// ReasonMissingProductClaim indicates the cluster is missing its product claim
-	ReasonMissingProductClaim = "MissingProductClaim"
 
 	// ReasonReconcileError indicates an error occurred during reconciliation
 	ReasonReconcileError = "ReconcileError"

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -42,18 +42,9 @@ import (
 )
 
 const (
-	OperatorNameOSSM = "servicemeshoperator3"
-	OperatorNameSail = "sailoperator"
-
-	DefaultOCPOperatorNs = "openshift-operators"
-	DefaultOperatorNs    = "sail-operator"
-
-	DefaultOCPCatalogSource = "redhat-operators"
-	DefaultOCPCatalogNs     = "openshift-marketplace"
-	DefaultCatalogSource    = "operatorhubio-catalog"
-	DefaultCatalogNs        = "olm"
-
-	DefaultChannel = "stable"
+	// BuiltinOperatorNamespace is the namespace that already has a global OperatorGroup on OCP.
+	// When the operator targets this namespace, the controller skips creating Namespace and OperatorGroup.
+	BuiltinOperatorNamespace = "openshift-operators"
 
 	OperatorManifestWorkName = "multicluster-mesh-operator"
 	ManifestWorkNameCacerts  = "multicluster-mesh-cacerts"
@@ -70,15 +61,7 @@ const (
 	MeshNameLabel      = "mesh.open-cluster-management.io/mesh-name"
 	MeshNamespaceLabel = "mesh.open-cluster-management.io/mesh-namespace"
 
-	ClusterSetLabel     = "cluster.open-cluster-management.io/clusterset"
-	clusterClaimProduct = "product.open-cluster-management.io"
-
-	// Product claim values from github.com/stolostron/multicloud-operators-foundation/pkg/klusterlet/clusterclaim
-	ProductOCP  = "OpenShift"
-	ProductROSA = "ROSA"
-	ProductARO  = "ARO"
-	ProductROKS = "ROKS"
-	ProductOSD  = "OpenShiftDedicated"
+	ClusterSetLabel = "cluster.open-cluster-management.io/clusterset"
 
 	Day = 24 * time.Hour
 )
@@ -244,7 +227,7 @@ func (r *Reconciler) validate(ctx context.Context, mesh *meshv1alpha1.MultiClust
 			conflict = true
 			return
 		}
-		if r.operatorConfigConflicts(mesh.Spec.Operator, other.Spec.Operator) {
+		if mesh.Spec.Operator != other.Spec.Operator {
 			mesh.SetReadyCondition(metav1.ConditionFalse, meshv1alpha1.ReasonOperatorConfigConflict,
 				"operator config conflicts with older mesh %s/%s targeting the same ClusterSet %s",
 				other.Namespace, other.Name, mesh.Spec.ClusterSet)
@@ -264,21 +247,9 @@ func isOlderMesh(a, b *meshv1alpha1.MultiClusterMesh) bool {
 			key.For(a).String() < key.For(b).String())
 }
 
-// operatorConfigConflicts compares two operator configs after applying defaults to detect real conflicts.
-// This avoids false positives when one mesh explicitly sets a value that matches the other's default.
-func (r *Reconciler) operatorConfigConflicts(a, b meshv1alpha1.OperatorConfig) bool {
-	return r.applyOperatorDefaults(a, false) != r.applyOperatorDefaults(b, false) ||
-		r.applyOperatorDefaults(a, true) != r.applyOperatorDefaults(b, true)
-}
-
 func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) (reconcile.Result, error) {
 	for _, cluster := range clusters {
 		klog.V(4).Infof("Reconciling cluster %s", cluster.Name)
-
-		if getProductClaim(&cluster) == "" {
-			klog.V(4).Infof("Cluster %s missing product claim (needed for platform detection), skipping", cluster.Name)
-			continue
-		}
 
 		work, err := r.workApplier.Apply(ctx, r.buildOperatorManifestWork(mesh, &cluster))
 		if err != nil {
@@ -474,12 +445,6 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 	allReady := len(clusters) > 0
 
 	for _, cluster := range clusters {
-		if getProductClaim(&cluster) == "" {
-			allReady = false
-			mesh.SetClusterCondition(cluster.Name, meshv1alpha1.ConditionOperatorInstalled, metav1.ConditionFalse,
-				meshv1alpha1.ReasonMissingProductClaim, "Cluster is missing product claim, cannot determine platform")
-			continue
-		}
 
 		operatorWork := &workv1.ManifestWork{}
 		if err := r.Get(ctx, key.Of(OperatorManifestWorkName, cluster.Name), operatorWork); err != nil {
@@ -549,16 +514,6 @@ func clusterNameSet(clusters []clusterv1.ManagedCluster) map[string]bool {
 	return set
 }
 
-// getProductClaim returns the value for the cluster, or empty string if not found
-func getProductClaim(cluster *clusterv1.ManagedCluster) string {
-	for _, claim := range cluster.Status.ClusterClaims {
-		if claim.Name == clusterClaimProduct {
-			return claim.Value
-		}
-	}
-	return ""
-}
-
 func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName string) ([]clusterv1.ManagedCluster, error) {
 	clusterSet := &clusterv1beta2.ManagedClusterSet{}
 	if err := r.Get(ctx, key.Of(clusterSetName), clusterSet); err != nil {
@@ -594,17 +549,10 @@ func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName stri
 }
 
 func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) *workv1.ManifestWork {
+	config := mesh.Spec.Operator
 	manifests := []workv1.Manifest{}
-	isOCP := false
-	switch getProductClaim(cluster) {
-	case ProductOCP, ProductROSA, ProductARO, ProductROKS, ProductOSD:
-		isOCP = true
-	}
 
-	config := r.applyOperatorDefaults(mesh.Spec.Operator, isOCP)
-
-	// openshift-operators exists by default on OCP and already has a global OperatorGroup
-	if config.Namespace != DefaultOCPOperatorNs {
+	if config.Namespace != BuiltinOperatorNamespace {
 		manifests = append(manifests, workv1.Manifest{
 			RawExtension: runtime.RawExtension{Object: &corev1.Namespace{
 				TypeMeta: metav1.TypeMeta{
@@ -634,11 +582,6 @@ func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMe
 		})
 	}
 
-	packageName := OperatorNameSail
-	if isOCP {
-		packageName = OperatorNameOSSM
-	}
-
 	manifests = append(manifests, workv1.Manifest{
 		RawExtension: runtime.RawExtension{Object: &operatorsv1alpha1.Subscription{
 			TypeMeta: metav1.TypeMeta{
@@ -646,13 +589,13 @@ func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMe
 				Kind:       "Subscription",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      packageName,
+				Name:      config.Name,
 				Namespace: config.Namespace,
 			},
 			Spec: &operatorsv1alpha1.SubscriptionSpec{
 				Channel:                config.Channel,
 				InstallPlanApproval:    config.InstallPlanApproval,
-				Package:                packageName,
+				Package:                config.Name,
 				CatalogSource:          config.Source,
 				CatalogSourceNamespace: config.SourceNamespace,
 				StartingCSV:            config.StartingCSV,
@@ -680,7 +623,7 @@ func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMe
 				ResourceIdentifier: workv1.ResourceIdentifier{
 					Group:     "operators.coreos.com",
 					Resource:  "subscriptions",
-					Name:      packageName,
+					Name:      config.Name,
 					Namespace: config.Namespace,
 				},
 				FeedbackRules: []workv1.FeedbackRule{{
@@ -693,43 +636,6 @@ func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMe
 			}},
 		},
 	}
-}
-
-// applyOperatorDefaults applies platform-specific defaults for the given cluster to the operator config
-func (r *Reconciler) applyOperatorDefaults(config meshv1alpha1.OperatorConfig, isOCP bool) meshv1alpha1.OperatorConfig {
-	if config.Namespace == "" {
-		if isOCP {
-			config.Namespace = DefaultOCPOperatorNs
-		} else {
-			config.Namespace = DefaultOperatorNs
-		}
-	}
-
-	if config.Source == "" {
-		if isOCP {
-			config.Source = DefaultOCPCatalogSource
-		} else {
-			config.Source = DefaultCatalogSource
-		}
-	}
-
-	if config.SourceNamespace == "" {
-		if isOCP {
-			config.SourceNamespace = DefaultOCPCatalogNs
-		} else {
-			config.SourceNamespace = DefaultCatalogNs
-		}
-	}
-
-	if config.Channel == "" {
-		config.Channel = DefaultChannel
-	}
-
-	if config.InstallPlanApproval == "" {
-		config.InstallPlanApproval = operatorsv1alpha1.ApprovalAutomatic
-	}
-
-	return config
 }
 
 // mapSecretToMesh maps a Secret to the MultiClusterMesh that owns it

--- a/samples/basic.yaml
+++ b/samples/basic.yaml
@@ -6,6 +6,12 @@ spec:
   # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
   # NOTE: Update this to match your ManagedClusterSet name
   clusterSet: mesh-cluster-set
+  # Sail Operator for KIND (overrides the OSSM kubebuilder defaults)
+  operator:
+    name: sailoperator
+    namespace: sail-operator
+    source: operatorhubio-catalog
+    sourceNamespace: olm
   # Minimal security configuration using cert-manager for trust
   security:
     trust:

--- a/samples/complete.yaml
+++ b/samples/complete.yaml
@@ -12,24 +12,24 @@ spec:
     # Namespace where Istio will be installed on each cluster
     namespace: istio-system
 
-  # Sail Operator installation configuration
+  # Operator installation configuration (overrides the OSSM kubebuilder defaults)
   operator:
-    # Namespace where the Sail Operator will be installed
-    # Defaults to "openshift-operators" on OpenShift, "sail-operator" on vanilla Kubernetes
+    # OLM package name
+    name: sailoperator
+
+    # Namespace where the operator will be installed
     namespace: sail-operator
 
     # OLM subscription channel
     channel: stable
 
     # CatalogSource name
-    # Defaults to "redhat-operators" on OpenShift, "operatorhubio-catalog" on vanilla Kubernetes
     source: operatorhubio-catalog
 
     # CatalogSource namespace
-    # Defaults to "openshift-marketplace" on OpenShift, "olm" on vanilla Kubernetes
     sourceNamespace: olm
 
-    # Specific operator version (optional - pins to a specific CSV)
+    # Specific operator version (optional, pins to a specific CSV)
     # startingCSV: sail-operator.v1.23.0
 
     # Install plan approval strategy

--- a/samples/openshift.yaml
+++ b/samples/openshift.yaml
@@ -11,7 +11,7 @@ spec:
   controlPlane:
     namespace: istio-system
 
-  # OpenShift-specific operator configuration
+  # OSSM operator configuration (these values match the kubebuilder defaults)
   operator:
     # On OpenShift, the operator is typically installed in openshift-operators
     namespace: openshift-operators

--- a/samples/pinned-version.yaml
+++ b/samples/pinned-version.yaml
@@ -12,6 +12,7 @@ spec:
 
   # Operator configuration with version pinning and manual approval
   operator:
+    name: sailoperator
     namespace: sail-operator
     channel: stable
     source: operatorhubio-catalog

--- a/test/e2e/mesh_lifecycle_test.go
+++ b/test/e2e/mesh_lifecycle_test.go
@@ -26,6 +26,12 @@ import (
 const (
 	controllerNamespace = "multicluster-mesh-system"
 	controllerName      = "multicluster-mesh-controller"
+
+	testOperatorName      = "sailoperator"
+	testOperatorNamespace = "sail-operator"
+	testCatalogSource     = "operatorhubio-catalog"
+	testCatalogNamespace  = "olm"
+	testDefaultChannel    = "stable"
 )
 
 var clusters = []string{"cluster1", "cluster2"}
@@ -63,7 +69,15 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 
 	BeforeEach(func(ctx SpecContext) {
 		Step("Creating test mesh")
-		mesh = util.CreateMultiClusterMesh(ctx, hubClient, util.UniqueName("test-mesh"), ns, "mesh-cluster-set")
+		// Kind clusters don't have the OSSM catalog, so we override to use Sail from upstream.
+		mesh = util.CreateMultiClusterMesh(ctx, hubClient, util.UniqueName("test-mesh"), ns, "mesh-cluster-set",
+			meshv1alpha1.MultiClusterMeshSpec{
+				Operator: meshv1alpha1.OperatorConfig{
+					Name:            testOperatorName,
+					Namespace:       testOperatorNamespace,
+					Source:          testCatalogSource,
+					SourceNamespace: testCatalogNamespace,
+				}})
 
 		Step("Waiting for controller to reconcile")
 		Eventually(func(g Gomega) {
@@ -101,21 +115,21 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 			}).Should(Succeed())
 
 			Step("Verifying operator namespace exists on %s", cluster)
-			err := spokeClient.Get(ctx, key.Of(meshcontroller.DefaultOperatorNs), &corev1.Namespace{})
+			err := spokeClient.Get(ctx, key.Of(testOperatorNamespace), &corev1.Namespace{})
 			Expect(err).NotTo(HaveOccurred())
 
 			Step("Verifying OperatorGroup exists on %s", cluster)
 			ogList := &operatorsv1.OperatorGroupList{}
-			err = spokeClient.List(ctx, ogList, client.InNamespace(meshcontroller.DefaultOperatorNs))
+			err = spokeClient.List(ctx, ogList, client.InNamespace(testOperatorNamespace))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ogList.Items).To(HaveLen(1))
 
 			Step("Verifying Subscription content on %s", cluster)
 			sub, err := getSubscription(ctx, spokeClient)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(sub.Spec.Package).To(Equal(meshcontroller.OperatorNameSail))
-			Expect(sub.Spec.Channel).To(Equal(meshcontroller.DefaultChannel))
-			Expect(sub.Spec.CatalogSource).To(Equal(meshcontroller.DefaultCatalogSource))
+			Expect(sub.Spec.Package).To(Equal(testOperatorName))
+			Expect(sub.Spec.Channel).To(Equal(testDefaultChannel))
+			Expect(sub.Spec.CatalogSource).To(Equal(testCatalogSource))
 		}
 	})
 
@@ -148,7 +162,7 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 			// Spoke-side cleanup depends on the OCM work agent processing the
 			// ManifestWork deletion and OLM processing any Subscription finalizers,
 			// which can take longer than the default timeout in CI.
-			util.ExpectResourceDeleted(ctx, spokeClient, &operatorsv1alpha1.Subscription{}, meshcontroller.OperatorNameSail, meshcontroller.DefaultOperatorNs, 2*time.Minute)
+			util.ExpectResourceDeleted(ctx, spokeClient, &operatorsv1alpha1.Subscription{}, testOperatorName, testOperatorNamespace, 2*time.Minute)
 		}
 	})
 })
@@ -165,6 +179,6 @@ func getOperatorMW(ctx context.Context, cluster string) (*workv1.ManifestWork, e
 
 func getSubscription(ctx context.Context, spokeClient client.Client) (*operatorsv1alpha1.Subscription, error) {
 	sub := &operatorsv1alpha1.Subscription{}
-	err := spokeClient.Get(ctx, key.Of(meshcontroller.OperatorNameSail, meshcontroller.DefaultOperatorNs), sub)
+	err := spokeClient.Get(ctx, key.Of(testOperatorName, testOperatorNamespace), sub)
 	return sub, err
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -86,8 +86,8 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			BeforeEach(func() {
 				cluster2Name = util.UniqueName("cluster")
 
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-				util.CreateOCPManagedCluster(ctx, k8sClient, cluster2Name, testClusterSet, meshcontroller.ProductOCP)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, cluster2Name, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
 			})
 
@@ -138,8 +138,9 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 		})
 
-		It("should use custom operator configuration on K8s when specified", func() {
+		It("should use custom operator configuration when specified", func() {
 			customConfig := meshv1alpha1.OperatorConfig{
+				Name:                "sailoperator",
 				Namespace:           "custom-ns",
 				Channel:             "1.23",
 				Source:              "custom-catalog",
@@ -148,7 +149,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				InstallPlanApproval: operatorsv1alpha1.ApprovalManual,
 			}
 
-			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{Operator: customConfig})
 
 			work := expectOperatorManifestWork(clusterName)
@@ -156,50 +157,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			Expect(work.Spec.Workload.Manifests).To(HaveLen(3))
 			expectNamespace(work, 0, customConfig.Namespace)
 			expectOperatorGroup(work, 1, "operator-group", customConfig.Namespace)
-			expectSubscription(work, 2, false, operatorsv1alpha1.Subscription{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: customConfig.Namespace,
-				},
-				Spec: &operatorsv1alpha1.SubscriptionSpec{
-					Channel:                customConfig.Channel,
-					CatalogSource:          customConfig.Source,
-					CatalogSourceNamespace: customConfig.SourceNamespace,
-					StartingCSV:            customConfig.StartingCSV,
-					InstallPlanApproval:    customConfig.InstallPlanApproval,
-				},
-			})
-		})
-
-		It("should use custom operator configuration on OpenShift when specified", func() {
-			customConfig := meshv1alpha1.OperatorConfig{
-				Namespace:           "custom-ossm-ns",
-				Channel:             "tech-preview",
-				Source:              "custom-catalog",
-				SourceNamespace:     "custom-catalog-ns",
-				StartingCSV:         "servicemeshoperator3.v3.0.0",
-				InstallPlanApproval: operatorsv1alpha1.ApprovalManual,
-			}
-
-			util.CreateOCPManagedCluster(ctx, k8sClient, clusterName, testClusterSet, meshcontroller.ProductOCP)
-			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{Operator: customConfig})
-
-			work := expectOperatorManifestWork(clusterName)
-
-			Expect(work.Spec.Workload.Manifests).To(HaveLen(3))
-			expectNamespace(work, 0, customConfig.Namespace)
-			expectOperatorGroup(work, 1, "operator-group", customConfig.Namespace)
-			expectSubscription(work, 2, true, operatorsv1alpha1.Subscription{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: customConfig.Namespace,
-				},
-				Spec: &operatorsv1alpha1.SubscriptionSpec{
-					Channel:                customConfig.Channel,
-					CatalogSource:          customConfig.Source,
-					CatalogSourceNamespace: customConfig.SourceNamespace,
-					StartingCSV:            customConfig.StartingCSV,
-					InstallPlanApproval:    customConfig.InstallPlanApproval,
-				},
-			})
+			expectSubscription(work, 2, customConfig)
 		})
 
 		When("referencing a non-existent ClusterSet", func() {
@@ -217,7 +175,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should reconcile when the ClusterSet is created", func() {
 				expectMeshNotReady(meshName, testNs)
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, otherClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, otherClusterSet)
 				util.CreateManagedClusterSet(ctx, k8sClient, otherClusterSet)
 				expectOperatorManifestWork(clusterName)
 				expectMeshNotReady(meshName, testNs)
@@ -236,35 +194,15 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("shouldn't process a cluster without clusterset label", func() {
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, "")
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, "")
 				expectMeshNotReady(meshName, testNs)
 				expectNoManifestWorks()
 			})
 
 			It("should process a cluster when it's added", func() {
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-				expectOperatorManifestWork(clusterName)
-				expectMeshNotReady(meshName, testNs)
-				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonManifestWorkCreated)
-			})
-		})
-
-		When("referencing a cluster with no product claim", func() {
-			BeforeEach(func() {
 				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-			})
-
-			It("should skip it and report missing product claim", func() {
-				expectMeshNotReady(meshName, testNs)
-				expectNoManifestWorks()
-				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonMissingProductClaim)
-			})
-
-			It("should process it when a claim is set", func() {
-				expectMeshNotReady(meshName, testNs)
-				util.SetProductClaim(ctx, k8sClient, clusterName, "Other")
 				expectOperatorManifestWork(clusterName)
+				expectMeshNotReady(meshName, testNs)
 				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonManifestWorkCreated)
 			})
 		})
@@ -278,7 +216,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			var work *workv1.ManifestWork
 
 			BeforeEach(func() {
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
 				work = expectOperatorManifestWork(clusterName)
 			})
@@ -303,18 +241,18 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				Eventually(func() string {
 					work := expectOperatorManifestWork(clusterName)
 					sub := &operatorsv1alpha1.Subscription{}
-					Expect(unmarshalManifest(work.Spec.Workload.Manifests[2], sub)).To(Succeed())
+					Expect(unmarshalManifest(work.Spec.Workload.Manifests[0], sub)).To(Succeed())
 					return sub.Spec.Channel
 				}).Should(Equal("tech-preview"))
 			})
 
 			It("should restore ManifestWork spec when externally modified", func() {
 				sub := &operatorsv1alpha1.Subscription{}
-				Expect(unmarshalManifest(work.Spec.Workload.Manifests[2], sub)).To(Succeed())
+				Expect(unmarshalManifest(work.Spec.Workload.Manifests[0], sub)).To(Succeed())
 				originalChannel := sub.Spec.Channel
 
 				sub.Spec.Channel = "tampered"
-				work.Spec.Workload.Manifests[2] = workv1.Manifest{
+				work.Spec.Workload.Manifests[0] = workv1.Manifest{
 					RawExtension: runtime.RawExtension{Object: sub},
 				}
 				Expect(k8sClient.Update(ctx, work)).To(Succeed())
@@ -325,7 +263,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				Eventually(func() string {
 					work := expectOperatorManifestWork(clusterName)
 					sub := &operatorsv1alpha1.Subscription{}
-					Expect(unmarshalManifest(work.Spec.Workload.Manifests[2], sub)).To(Succeed())
+					Expect(unmarshalManifest(work.Spec.Workload.Manifests[0], sub)).To(Succeed())
 					return sub.Spec.Channel
 				}).Should(Equal(originalChannel))
 			})
@@ -432,7 +370,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 		BeforeEach(func() {
 			otherMesh = meshName + "-2"
 
-			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
 			expectOperatorManifestWork(clusterName)
 		})
@@ -532,8 +470,8 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 	Context("Deleting MultiClusterMesh", func() {
 		It("should delete related ManifestWorks", func() {
 			cluster2 := util.UniqueName("cluster2")
-			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-			util.CreateOCPManagedCluster(ctx, k8sClient, cluster2, testClusterSet, meshcontroller.ProductOCP)
+			util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateManagedCluster(ctx, k8sClient, cluster2, testClusterSet)
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
 			expectFinalizer(meshName, testNs)
 			expectOperatorManifestWork(clusterName)
@@ -555,7 +493,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 	Context("Certificate distribution", func() {
 		When("cert-manager issuer is configured", func() {
 			BeforeEach(func() {
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, util.CertManagerSpec("mesh-issuer"))
 			})
 
@@ -576,13 +514,16 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should set Subject and URI SAN on Certificate", func() {
-				cert := expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
+				longCluster := "ci-managed-cluster-with-a-long-generated-name-for-subject-test"
+				util.CreateManagedCluster(ctx, k8sClient, longCluster, testClusterSet)
+
+				cert := expectCertificate(testNs, longCluster, "mesh-issuer", "Issuer")
 
 				Expect(cert.Spec.Subject).NotTo(BeNil())
 				Expect(cert.Spec.Subject.Organizations).To(ConsistOf(meshName))
-				Expect(cert.Spec.Subject.OrganizationalUnits).To(ConsistOf(clusterName))
+				Expect(cert.Spec.Subject.OrganizationalUnits).To(ConsistOf(longCluster))
 
-				expectedSAN := "spiffe://" + meshName + "/cluster/" + clusterName + "/ca/istio-ca"
+				expectedSAN := "spiffe://" + meshName + "/cluster/" + longCluster + "/ca/istio-ca"
 				Expect(cert.Spec.URIs).To(ConsistOf(expectedSAN))
 			})
 
@@ -645,7 +586,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 		When("cert-manager ClusterIssuer is configured", func() {
 			BeforeEach(func() {
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, util.CertManagerSpecWithKind("cluster-issuer", "ClusterIssuer"))
 			})
 
@@ -659,8 +600,8 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				cluster1 := util.UniqueName("cluster")
 				cluster2 := util.UniqueName("cluster")
 
-				util.CreateK8sManagedCluster(ctx, k8sClient, cluster1, testClusterSet)
-				util.CreateK8sManagedCluster(ctx, k8sClient, cluster2, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, cluster1, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, cluster2, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, util.CertManagerSpec("mesh-issuer"))
 
 				util.CreateCacertsSecret(ctx, k8sClient, testNs, cluster1, meshName, testNs)
@@ -673,7 +614,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 		When("a cluster is removed from the ClusterSet", func() {
 			It("should cleanup Certificate for that cluster", func() {
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, util.CertManagerSpec("mesh-issuer"))
 				expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
 
@@ -686,7 +627,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 		When("issuer is removed after initial configuration", func() {
 			It("should cleanup all Certificates", func() {
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, util.CertManagerSpec("mesh-issuer"))
 				expectCertificate(testNs, clusterName, "mesh-issuer", "Issuer")
 
@@ -701,7 +642,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 		When("no issuer is configured", func() {
 			BeforeEach(func() {
-				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
 			})
 
@@ -712,40 +653,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 		})
 	})
 
-	Context("Platform detection", func() {
-		DescribeTable("should detect OpenShift variants and use OSSM operator",
-			func(productClaim string) {
-				util.CreateOCPManagedCluster(ctx, k8sClient, clusterName, testClusterSet, productClaim)
-				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-
-				work := expectOperatorManifestWork(clusterName)
-
-				// OpenShift: expect only Subscription (openshift-operators namespace/OperatorGroup exist by default)
-				Expect(work.Spec.Workload.Manifests).To(HaveLen(1))
-
-				expectSubscription(work, 0, true, operatorsv1alpha1.Subscription{})
-			},
-			Entry(meshcontroller.ProductOCP, meshcontroller.ProductOCP),
-			Entry(meshcontroller.ProductROSA, meshcontroller.ProductROSA),
-			Entry(meshcontroller.ProductARO, meshcontroller.ProductARO),
-			Entry(meshcontroller.ProductROKS, meshcontroller.ProductROKS),
-			Entry(meshcontroller.ProductOSD, meshcontroller.ProductOSD),
-		)
-
-		It("should detect vanilla Kubernetes and use Sail operator", func() {
-			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-
-			work := expectOperatorManifestWork(clusterName)
-
-			// Kubernetes: Namespace + OperatorGroup + Subscription (unlike OpenShift)
-			Expect(work.Spec.Workload.Manifests).To(HaveLen(3))
-
-			expectNamespace(work, 0, meshcontroller.DefaultOperatorNs)
-			expectOperatorGroup(work, 1, "operator-group", meshcontroller.DefaultOperatorNs)
-			expectSubscription(work, 2, false, operatorsv1alpha1.Subscription{})
-		})
-	})
 })
 
 func expectFinalizer(name, namespace string) {
@@ -877,68 +784,17 @@ func expectOperatorGroup(work *workv1.ManifestWork, index int, expectedName, exp
 	Expect(og.Namespace).To(Equal(expectedNamespace))
 }
 
-func expectSubscription(work *workv1.ManifestWork, index int, isOCP bool, expected operatorsv1alpha1.Subscription) {
+func expectSubscription(work *workv1.ManifestWork, index int, expected meshv1alpha1.OperatorConfig) {
 	sub := &operatorsv1alpha1.Subscription{}
 	Expect(unmarshalManifest(work.Spec.Workload.Manifests[index], sub)).To(Succeed())
 
-	expectedNamespace := expected.Namespace
-	if expectedNamespace == "" {
-		if isOCP {
-			expectedNamespace = meshcontroller.DefaultOCPOperatorNs
-		} else {
-			expectedNamespace = meshcontroller.DefaultOperatorNs
-		}
-	}
-
-	var expectedName, expectedPackage, expectedCatalogSource, expectedCatalogSourceNamespace, expectedChannel string
-	var expectedInstallPlanApproval operatorsv1alpha1.Approval
-
-	if expected.Spec != nil {
-		expectedCatalogSource = expected.Spec.CatalogSource
-		expectedCatalogSourceNamespace = expected.Spec.CatalogSourceNamespace
-		expectedChannel = expected.Spec.Channel
-		expectedInstallPlanApproval = expected.Spec.InstallPlanApproval
-	}
-
-	if isOCP {
-		expectedName = meshcontroller.OperatorNameOSSM
-		expectedPackage = meshcontroller.OperatorNameOSSM
-	} else {
-		expectedName = meshcontroller.OperatorNameSail
-		expectedPackage = meshcontroller.OperatorNameSail
-	}
-
-	if expectedCatalogSource == "" {
-		if isOCP {
-			expectedCatalogSource = meshcontroller.DefaultOCPCatalogSource
-		} else {
-			expectedCatalogSource = meshcontroller.DefaultCatalogSource
-		}
-	}
-
-	if expectedCatalogSourceNamespace == "" {
-		if isOCP {
-			expectedCatalogSourceNamespace = meshcontroller.DefaultOCPCatalogNs
-		} else {
-			expectedCatalogSourceNamespace = meshcontroller.DefaultCatalogNs
-		}
-	}
-
-	if expectedChannel == "" {
-		expectedChannel = meshcontroller.DefaultChannel
-	}
-
-	if expectedInstallPlanApproval == "" {
-		expectedInstallPlanApproval = operatorsv1alpha1.ApprovalAutomatic
-	}
-
-	Expect(sub.Name).To(Equal(expectedName))
-	Expect(sub.Namespace).To(Equal(expectedNamespace))
-	Expect(sub.Spec.Package).To(Equal(expectedPackage))
-	Expect(sub.Spec.CatalogSource).To(Equal(expectedCatalogSource))
-	Expect(sub.Spec.CatalogSourceNamespace).To(Equal(expectedCatalogSourceNamespace))
-	Expect(sub.Spec.Channel).To(Equal(expectedChannel))
-	Expect(sub.Spec.InstallPlanApproval).To(Equal(expectedInstallPlanApproval))
+	Expect(sub.Name).To(Equal(expected.Name))
+	Expect(sub.Namespace).To(Equal(expected.Namespace))
+	Expect(sub.Spec.Package).To(Equal(expected.Name))
+	Expect(sub.Spec.CatalogSource).To(Equal(expected.Source))
+	Expect(sub.Spec.CatalogSourceNamespace).To(Equal(expected.SourceNamespace))
+	Expect(sub.Spec.Channel).To(Equal(expected.Channel))
+	Expect(sub.Spec.InstallPlanApproval).To(Equal(expected.InstallPlanApproval))
 }
 
 func findCondition(g Gomega, conditions []metav1.Condition, conditionType string) *metav1.Condition {

--- a/test/util/ocm.go
+++ b/test/util/ocm.go
@@ -24,8 +24,7 @@ func CreateManagedClusterSet(ctx context.Context, k8sClient client.Client, name 
 	})).To(Succeed())
 }
 
-// CreateManagedCluster creates a ManagedCluster without any product claim.
-// Also creates the cluster namespace (required for ManifestWorks).
+// CreateManagedCluster creates a ManagedCluster and its namespace (required for ManifestWorks).
 func CreateManagedCluster(ctx context.Context, k8sClient client.Client, name, clusterSet string) {
 	CreateNamespace(ctx, k8sClient, name)
 	Expect(k8sClient.Create(ctx, &clusterv1.ManagedCluster{
@@ -36,28 +35,6 @@ func CreateManagedCluster(ctx context.Context, k8sClient client.Client, name, cl
 			},
 		},
 	})).To(Succeed())
-}
-
-// SetProductClaim sets the claim on an existing ManagedCluster to the given claim.
-func SetProductClaim(ctx context.Context, k8sClient client.Client, clusterName, productClaim string) {
-	cluster := &clusterv1.ManagedCluster{}
-	Expect(k8sClient.Get(ctx, key.Of(clusterName), cluster)).To(Succeed())
-	cluster.Status.ClusterClaims = []clusterv1.ManagedClusterClaim{
-		{Name: "product.open-cluster-management.io", Value: productClaim},
-	}
-	Expect(k8sClient.Status().Update(ctx, cluster)).To(Succeed())
-}
-
-// CreateK8sManagedCluster creates a vanilla Kubernetes ManagedCluster with product claim "Other".
-func CreateK8sManagedCluster(ctx context.Context, k8sClient client.Client, name, clusterSet string) {
-	CreateManagedCluster(ctx, k8sClient, name, clusterSet)
-	SetProductClaim(ctx, k8sClient, name, "Other")
-}
-
-// CreateOCPManagedCluster creates an OpenShift ManagedCluster with the specified product claim.
-func CreateOCPManagedCluster(ctx context.Context, k8sClient client.Client, name, clusterSet, product string) {
-	CreateManagedCluster(ctx, k8sClient, name, clusterSet)
-	SetProductClaim(ctx, k8sClient, name, product)
 }
 
 // SetManifestWorkFeedback updates a ManifestWork's status to include a string feedback value,


### PR DESCRIPTION
Removes platform branching from the controller.
Kubebuilder defaults now set OSSM values at admission time, so the controller reads `spec.operator` directly.
Users can override all fields to use a different operator (e.g. Sail on Kind for dev/testing).

Depends-On: #114