### PR TITLE
Set ObservedGeneration on status conditions

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -229,9 +229,10 @@ func (r *Reconciler) validate(ctx context.Context, mesh *meshv1alpha1.MultiClust
 		}
 		if isOlderMesh(other, mesh) && r.operatorConfigConflicts(mesh.Spec.Operator, other.Spec.Operator) {
 			conflict = &metav1.Condition{
-				Type:   meshv1alpha1.ConditionReady,
-				Status: metav1.ConditionFalse,
-				Reason: meshv1alpha1.ReasonOperatorConfigConflict,
+				Type:               meshv1alpha1.ConditionReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             meshv1alpha1.ReasonOperatorConfigConflict,
+				ObservedGeneration: mesh.Generation,
 				Message: fmt.Sprintf("operator config conflicts with older mesh %s/%s targeting the same ClusterSet %s",
 					other.Namespace, other.Name, mesh.Spec.ClusterSet),
 			}
@@ -484,10 +485,11 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 		if getProductClaim(&cluster) == "" {
 			allReady = false
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
-				Type:    meshv1alpha1.ConditionOperatorInstalled,
-				Status:  metav1.ConditionFalse,
-				Reason:  meshv1alpha1.ReasonMissingProductClaim,
-				Message: "Cluster is missing product claim, cannot determine platform",
+				Type:               meshv1alpha1.ConditionOperatorInstalled,
+				Status:             metav1.ConditionFalse,
+				Reason:             meshv1alpha1.ReasonMissingProductClaim,
+				ObservedGeneration: mesh.Generation,
+				Message:            "Cluster is missing product claim, cannot determine platform",
 			})
 			clusterStatuses = append(clusterStatuses, status)
 			continue
@@ -503,10 +505,11 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 			// TODO: Set to actual status when operator installation is confirmed via ManifestWork status feedback
 			allReady = false
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
-				Type:    meshv1alpha1.ConditionOperatorInstalled,
-				Status:  metav1.ConditionFalse,
-				Reason:  meshv1alpha1.ReasonManifestWorkCreated,
-				Message: "Operator ManifestWork has been created, awaiting installation confirmation",
+				Type:               meshv1alpha1.ConditionOperatorInstalled,
+				Status:             metav1.ConditionFalse,
+				Reason:             meshv1alpha1.ReasonManifestWorkCreated,
+				ObservedGeneration: mesh.Generation,
+				Message:            "Operator ManifestWork has been created, awaiting installation confirmation",
 			})
 		} else {
 			return fmt.Errorf("failed to get operator ManifestWork for cluster %s: %w", cluster.Name, err)
@@ -517,7 +520,7 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 
 	mesh.Status.ClusterStatus = clusterStatuses
 
-	readyCondition := metav1.Condition{Type: meshv1alpha1.ConditionReady}
+	readyCondition := metav1.Condition{Type: meshv1alpha1.ConditionReady, ObservedGeneration: mesh.Generation}
 	if allReady {
 		readyCondition.Status = metav1.ConditionTrue
 		readyCondition.Reason = meshv1alpha1.ReasonAllClustersReady
@@ -534,10 +537,11 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 
 func (r *Reconciler) setErrorStatus(mesh *meshv1alpha1.MultiClusterMesh, reconcileErr error) {
 	meta.SetStatusCondition(&mesh.Status.Conditions, metav1.Condition{
-		Type:    meshv1alpha1.ConditionReady,
-		Status:  metav1.ConditionFalse,
-		Reason:  meshv1alpha1.ReasonReconcileError,
-		Message: reconcileErr.Error(),
+		Type:               meshv1alpha1.ConditionReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             meshv1alpha1.ReasonReconcileError,
+		ObservedGeneration: mesh.Generation,
+		Message:            reconcileErr.Error(),
 	})
 }
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -102,6 +102,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			expectMeshNotReady(meshName, testNs)
 			expectClusterOperatorConditionReason(meshName, testNs, cluster1, meshv1alpha1.ReasonManifestWorkCreated)
 			expectClusterOperatorConditionReason(meshName, testNs, cluster2, meshv1alpha1.ReasonManifestWorkCreated)
+			expectConditionsObservedGeneration(meshName, testNs)
 		})
 
 		It("should use custom operator configuration on K8s when specified", func() {
@@ -225,6 +226,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectMeshNotReady(meshName, testNs)
 				expectNoManifestWorks()
 				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonMissingProductClaim)
+				expectConditionsObservedGeneration(meshName, testNs)
 			})
 
 			It("should process it when a claim is set", func() {
@@ -274,6 +276,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 					Expect(unmarshalManifest(work.Spec.Workload.Manifests[2], sub)).To(Succeed())
 					return sub.Spec.Channel
 				}).Should(Equal("tech-preview"))
+				expectConditionsObservedGeneration(meshName, testNs)
 			})
 
 			It("should restore ManifestWork spec when externally modified", func() {
@@ -421,6 +424,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should block the newer mesh", func() {
 				expectMeshConditionReason(otherMesh, testNs, meshv1alpha1.ConditionReady, meshv1alpha1.ReasonOperatorConfigConflict)
+				expectConditionsObservedGeneration(otherMesh, testNs)
 			})
 
 			It("should unblock the newer mesh when the older mesh is deleted", func() {
@@ -600,62 +604,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectMeshNotReady(meshName, testNs)
 				expectNoCacertsManifestWork(clusterName)
 			})
-		})
-	})
-
-	Context("ObservedGeneration", func() {
-		It("should set ObservedGeneration on mesh-level and cluster-level conditions", func() {
-			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-
-			expectMeshNotReady(meshName, testNs)
-			expectConditionsObservedGeneration(meshName, testNs)
-		})
-
-		It("should update ObservedGeneration after a spec change", func() {
-			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-			expectMeshNotReady(meshName, testNs)
-
-			mesh := &meshv1alpha1.MultiClusterMesh{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
-			mesh.Spec.Operator.Channel = "updated-channel"
-			Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
-
-			Eventually(func() int64 {
-				m := &meshv1alpha1.MultiClusterMesh{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, m); err != nil {
-					return 0
-				}
-				for _, c := range m.Status.Conditions {
-					if c.Type == meshv1alpha1.ConditionReady {
-						return c.ObservedGeneration
-					}
-				}
-				return 0
-			}).Should(Equal(int64(2)))
-		})
-
-		It("should set ObservedGeneration on conflict conditions", func() {
-			otherMesh := meshName + "-conflict"
-			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-			expectOperatorManifestWork(clusterName)
-
-			util.CreateMultiClusterMesh(ctx, k8sClient, otherMesh, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
-				Operator: meshv1alpha1.OperatorConfig{Channel: "different-channel"},
-			})
-
-			expectMeshConditionReason(otherMesh, testNs, meshv1alpha1.ConditionReady, meshv1alpha1.ReasonOperatorConfigConflict)
-			expectConditionsObservedGeneration(otherMesh, testNs)
-		})
-
-		It("should set ObservedGeneration on missing product claim conditions", func() {
-			util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-
-			expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonMissingProductClaim)
-			expectConditionsObservedGeneration(meshName, testNs)
 		})
 	})
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -603,6 +603,62 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 		})
 	})
 
+	Context("ObservedGeneration", func() {
+		It("should set ObservedGeneration on mesh-level and cluster-level conditions", func() {
+			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+
+			expectMeshNotReady(meshName, testNs)
+			expectConditionsObservedGeneration(meshName, testNs)
+		})
+
+		It("should update ObservedGeneration after a spec change", func() {
+			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+			expectMeshNotReady(meshName, testNs)
+
+			mesh := &meshv1alpha1.MultiClusterMesh{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+			mesh.Spec.Operator.Channel = "updated-channel"
+			Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
+
+			Eventually(func() int64 {
+				m := &meshv1alpha1.MultiClusterMesh{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, m); err != nil {
+					return 0
+				}
+				for _, c := range m.Status.Conditions {
+					if c.Type == meshv1alpha1.ConditionReady {
+						return c.ObservedGeneration
+					}
+				}
+				return 0
+			}).Should(Equal(int64(2)))
+		})
+
+		It("should set ObservedGeneration on conflict conditions", func() {
+			otherMesh := meshName + "-conflict"
+			util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+			expectOperatorManifestWork(clusterName)
+
+			util.CreateMultiClusterMesh(ctx, k8sClient, otherMesh, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
+				Operator: meshv1alpha1.OperatorConfig{Channel: "different-channel"},
+			})
+
+			expectMeshConditionReason(otherMesh, testNs, meshv1alpha1.ConditionReady, meshv1alpha1.ReasonOperatorConfigConflict)
+			expectConditionsObservedGeneration(otherMesh, testNs)
+		})
+
+		It("should set ObservedGeneration on missing product claim conditions", func() {
+			util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+
+			expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonMissingProductClaim)
+			expectConditionsObservedGeneration(meshName, testNs)
+		})
+	})
+
 	Context("Platform detection", func() {
 		DescribeTable("should detect OpenShift variants and use OSSM operator",
 			func(productClaim string) {
@@ -891,4 +947,24 @@ func expectMeshConditionReason(meshName, namespace, conditionType, reason string
 		}
 		return ""
 	}).Should(Equal(reason))
+}
+
+func expectConditionsObservedGeneration(meshName, namespace string) {
+	Eventually(func(g Gomega) {
+		mesh := &meshv1alpha1.MultiClusterMesh{}
+		g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh)).To(Succeed())
+		g.Expect(mesh.Status.Conditions).NotTo(BeEmpty())
+
+		for _, c := range mesh.Status.Conditions {
+			g.Expect(c.ObservedGeneration).To(Equal(mesh.Generation),
+				"mesh-level condition %s should have ObservedGeneration=%d", c.Type, mesh.Generation)
+		}
+
+		for _, cs := range mesh.Status.ClusterStatus {
+			for _, c := range cs.Conditions {
+				g.Expect(c.ObservedGeneration).To(Equal(mesh.Generation),
+					"cluster %s condition %s should have ObservedGeneration=%d", cs.ClusterName, c.Type, mesh.Generation)
+			}
+		}
+	}).Should(Succeed())
 }


### PR DESCRIPTION
Standard k8s convention is to set ObservedGeneration to .metadata.generation when writing conditions, so consumers can compare it against the resource's current generation. This PR implements the necessary changes.

Fixes: https://github.com/stolostron/multicluster-mesh-addon/issues/99