### PR TITLE
Extract key package for object key construction

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	applyconfigv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/klog/v2"
 	workclient "open-cluster-management.io/api/client/work/clientset/versioned"
@@ -38,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
+	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
 )
 
 const (
@@ -247,7 +247,7 @@ func (r *Reconciler) validate(ctx context.Context, mesh *meshv1alpha1.MultiClust
 func isOlderMesh(a, b *meshv1alpha1.MultiClusterMesh) bool {
 	return a.CreationTimestamp.Before(&b.CreationTimestamp) ||
 		(a.CreationTimestamp.Equal(&b.CreationTimestamp) &&
-			client.ObjectKeyFromObject(a).String() < client.ObjectKeyFromObject(b).String())
+			key.For(a).String() < key.For(b).String())
 }
 
 // operatorConfigConflicts compares two operator configs after applying defaults to detect real conflicts.
@@ -316,9 +316,7 @@ func (r *Reconciler) forEachMeshInClusterSet(ctx context.Context, clusterSet str
 func (r *Reconciler) reconcileRequestsForClusterSet(ctx context.Context, clusterSet string) []reconcile.Request {
 	var requests []reconcile.Request
 	if err := r.forEachMeshInClusterSet(ctx, clusterSet, func(mesh *meshv1alpha1.MultiClusterMesh) {
-		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{Name: mesh.Name, Namespace: mesh.Namespace},
-		})
+		requests = append(requests, reconcile.Request{NamespacedName: key.For(mesh)})
 	}); err != nil {
 		klog.Errorf("Error when trying to reconcile meshes for ClusterSet %s: %v", clusterSet, err)
 	}
@@ -348,7 +346,7 @@ func (r *Reconciler) findMeshesForClusterSet(ctx context.Context, obj client.Obj
 // findMeshesForManifestWork returns a list of all meshes to reconcile following a ManifestWork change
 func (r *Reconciler) findMeshesForManifestWork(ctx context.Context, obj client.Object) []reconcile.Request {
 	cluster := &clusterv1.ManagedCluster{}
-	if err := r.Get(ctx, types.NamespacedName{Name: obj.GetNamespace()}, cluster); err != nil {
+	if err := r.Get(ctx, key.By(obj.GetNamespace()), cluster); err != nil {
 		if !apierrors.IsNotFound(err) {
 			klog.Errorf("Failed to get ManagedCluster %s for ManifestWork %s: %v", obj.GetNamespace(), obj.GetName(), err)
 		}
@@ -494,10 +492,7 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 		}
 
 		work := &workv1.ManifestWork{}
-		err := r.Get(ctx, types.NamespacedName{
-			Name:      OperatorManifestWorkName,
-			Namespace: cluster.Name,
-		}, work)
+		err := r.Get(ctx, key.By(OperatorManifestWorkName, cluster.Name), work)
 
 		if err == nil {
 			// TODO: Set to actual status when operator installation is confirmed via ManifestWork status feedback
@@ -584,7 +579,7 @@ func getProductClaim(cluster *clusterv1.ManagedCluster) string {
 
 func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName string) ([]clusterv1.ManagedCluster, error) {
 	clusterSet := &clusterv1beta2.ManagedClusterSet{}
-	if err := r.Get(ctx, types.NamespacedName{Name: clusterSetName}, clusterSet); err != nil {
+	if err := r.Get(ctx, key.By(clusterSetName), clusterSet); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(4).Infof("ManagedClusterSet %s not found", clusterSetName)
 			return []clusterv1.ManagedCluster{}, nil
@@ -750,12 +745,7 @@ func (r *Reconciler) mapSecretToMesh(_ context.Context, obj client.Object) []rec
 	klog.V(4).Infof("Secret %s/%s triggered reconcile for mesh %s/%s",
 		secret.Namespace, secret.Name, meshNamespace, meshName)
 
-	return []reconcile.Request{{
-		NamespacedName: types.NamespacedName{
-			Name:      meshName,
-			Namespace: meshNamespace,
-		},
-	}}
+	return []reconcile.Request{{NamespacedName: key.By(meshName, meshNamespace)}}
 }
 
 // getCacertsName returns the name for the certificate and secret for a specific cluster
@@ -830,10 +820,7 @@ func (r *Reconciler) ensureCacertsDistributed(ctx context.Context, mesh *meshv1a
 func (r *Reconciler) ensureCacertsManifestWork(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) error {
 	secretName := getCacertsName(cluster.Name)
 	secret := &corev1.Secret{}
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      secretName,
-		Namespace: mesh.Namespace,
-	}, secret)
+	err := r.Get(ctx, key.By(secretName, mesh.Namespace), secret)
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -346,7 +346,7 @@ func (r *Reconciler) findMeshesForClusterSet(ctx context.Context, obj client.Obj
 // findMeshesForManifestWork returns a list of all meshes to reconcile following a ManifestWork change
 func (r *Reconciler) findMeshesForManifestWork(ctx context.Context, obj client.Object) []reconcile.Request {
 	cluster := &clusterv1.ManagedCluster{}
-	if err := r.Get(ctx, key.By(obj.GetNamespace()), cluster); err != nil {
+	if err := r.Get(ctx, key.Of(obj.GetNamespace()), cluster); err != nil {
 		if !apierrors.IsNotFound(err) {
 			klog.Errorf("Failed to get ManagedCluster %s for ManifestWork %s: %v", obj.GetNamespace(), obj.GetName(), err)
 		}
@@ -492,7 +492,7 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 		}
 
 		work := &workv1.ManifestWork{}
-		err := r.Get(ctx, key.By(OperatorManifestWorkName, cluster.Name), work)
+		err := r.Get(ctx, key.Of(OperatorManifestWorkName, cluster.Name), work)
 
 		if err == nil {
 			// TODO: Set to actual status when operator installation is confirmed via ManifestWork status feedback
@@ -579,7 +579,7 @@ func getProductClaim(cluster *clusterv1.ManagedCluster) string {
 
 func (r *Reconciler) getClustersFromSet(ctx context.Context, clusterSetName string) ([]clusterv1.ManagedCluster, error) {
 	clusterSet := &clusterv1beta2.ManagedClusterSet{}
-	if err := r.Get(ctx, key.By(clusterSetName), clusterSet); err != nil {
+	if err := r.Get(ctx, key.Of(clusterSetName), clusterSet); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(4).Infof("ManagedClusterSet %s not found", clusterSetName)
 			return []clusterv1.ManagedCluster{}, nil
@@ -745,7 +745,7 @@ func (r *Reconciler) mapSecretToMesh(_ context.Context, obj client.Object) []rec
 	klog.V(4).Infof("Secret %s/%s triggered reconcile for mesh %s/%s",
 		secret.Namespace, secret.Name, meshNamespace, meshName)
 
-	return []reconcile.Request{{NamespacedName: key.By(meshName, meshNamespace)}}
+	return []reconcile.Request{{NamespacedName: key.Of(meshName, meshNamespace)}}
 }
 
 // getCacertsName returns the name for the certificate and secret for a specific cluster
@@ -820,7 +820,7 @@ func (r *Reconciler) ensureCacertsDistributed(ctx context.Context, mesh *meshv1a
 func (r *Reconciler) ensureCacertsManifestWork(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) error {
 	secretName := getCacertsName(cluster.Name)
 	secret := &corev1.Secret{}
-	err := r.Get(ctx, key.By(secretName, mesh.Namespace), secret)
+	err := r.Get(ctx, key.Of(secretName, mesh.Namespace), secret)
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -1,0 +1,20 @@
+package key
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// By returns a NamespacedName from a name and optional namespace.
+func By(name string, namespace ...string) types.NamespacedName {
+	k := types.NamespacedName{Name: name}
+	if len(namespace) > 0 {
+		k.Namespace = namespace[0]
+	}
+	return k
+}
+
+// For returns the NamespacedName for an existing object.
+func For(obj client.Object) types.NamespacedName {
+	return client.ObjectKeyFromObject(obj)
+}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -5,8 +5,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// By returns a NamespacedName from a name and optional namespace.
-func By(name string, namespace ...string) types.NamespacedName {
+// Of returns a NamespacedName from a name and optional namespace.
+func Of(name string, namespace ...string) types.NamespacedName {
 	k := types.NamespacedName{Name: name}
 	if len(namespace) > 0 {
 		k.Namespace = namespace[0]

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+
+	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
 
@@ -253,7 +255,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				originalVersion := work.ResourceVersion
 
 				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.By(meshName, testNs), mesh)).To(Succeed())
 				mesh.Spec.ControlPlane.Namespace = "different-ns"
 				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
 
@@ -264,7 +266,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should update ManifestWork when operator config changes", func() {
 				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.By(meshName, testNs), mesh)).To(Succeed())
 				mesh.Spec.Operator.Channel = "tech-preview"
 				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
 
@@ -466,7 +468,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				cert := expectCertificate(testNs, clusterName, "mesh-issuer")
 
 				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.By(meshName, testNs), mesh)).To(Succeed())
 
 				Expect(cert.OwnerReferences).To(HaveLen(1))
 				ownerRef := cert.OwnerReferences[0]
@@ -486,10 +488,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 				Eventually(func() string {
 					c := &certmanagerv1.Certificate{}
-					if err := k8sClient.Get(ctx, types.NamespacedName{
-						Name:      cert.Name,
-						Namespace: cert.Namespace,
-					}, c); err != nil {
+					if err := k8sClient.Get(ctx, key.For(cert), c); err != nil {
 						return ""
 					}
 					return c.Spec.CommonName
@@ -519,20 +518,14 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectCacertsManifestWork(clusterName)
 
 				secret := &corev1.Secret{}
-				Expect(k8sClient.Get(ctx, types.NamespacedName{
-					Name:      fmt.Sprintf("cacerts-%s", clusterName),
-					Namespace: testNs,
-				}, secret)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.By(fmt.Sprintf("cacerts-%s", clusterName), testNs), secret)).To(Succeed())
 
 				secret.Data["tls.crt"] = []byte("updated-cert-data")
 				Expect(k8sClient.Update(ctx, secret)).To(Succeed())
 
 				Eventually(func() string {
 					work := &workv1.ManifestWork{}
-					if err := k8sClient.Get(ctx, types.NamespacedName{
-						Name:      meshcontroller.ManifestWorkNameCacerts,
-						Namespace: clusterName,
-					}, work); err != nil {
+					if err := k8sClient.Get(ctx, key.By(meshcontroller.ManifestWorkNameCacerts, clusterName), work); err != nil {
 						return ""
 					}
 					manifestSecret := &corev1.Secret{}
@@ -581,7 +574,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectCertificate(testNs, clusterName, "mesh-issuer")
 
 				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.By(meshName, testNs), mesh)).To(Succeed())
 				mesh.Spec.Security.Trust.CertManager.IssuerRef.Name = ""
 				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
 
@@ -642,7 +635,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 func expectFinalizer(name, namespace string) {
 	Eventually(func() []string {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.By(name, namespace), mesh); err != nil {
 			return nil
 		}
 		return mesh.Finalizers
@@ -651,7 +644,7 @@ func expectFinalizer(name, namespace string) {
 
 func updateClusterSetLabel(clusterName, newClusterSet string) {
 	cluster := &clusterv1.ManagedCluster{}
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster)).To(Succeed())
+	Expect(k8sClient.Get(ctx, key.By(clusterName), cluster)).To(Succeed())
 	cluster.Labels[meshcontroller.ClusterSetLabel] = newClusterSet
 	Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
 }
@@ -672,7 +665,7 @@ func expectNoManifestWorks() {
 // TODO(mkolesnik): Remove once WorkApplier uses the CR cache (sdk-go#226).
 func triggerReconcile(meshName, namespace string) {
 	mesh := &meshv1alpha1.MultiClusterMesh{}
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh)).To(Succeed())
+	Expect(k8sClient.Get(ctx, key.By(meshName, namespace), mesh)).To(Succeed())
 	if mesh.Annotations == nil {
 		mesh.Annotations = map[string]string{}
 	}
@@ -692,10 +685,7 @@ func expectAllManifestWorksDeleted() {
 func expectManifestWork(name, namespace string) *workv1.ManifestWork {
 	work := &workv1.ManifestWork{}
 	Eventually(func() error {
-		return k8sClient.Get(ctx, types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		}, work)
+		return k8sClient.Get(ctx, key.By(name, namespace), work)
 	}).Should(Succeed())
 	return work
 }
@@ -711,10 +701,7 @@ func expectCacertsManifestWork(clusterNamespace string) *workv1.ManifestWork {
 func expectNoCacertsManifestWork(clusterNamespace string) {
 	Consistently(func() bool {
 		work := &workv1.ManifestWork{}
-		err := k8sClient.Get(ctx, types.NamespacedName{
-			Name:      meshcontroller.ManifestWorkNameCacerts,
-			Namespace: clusterNamespace,
-		}, work)
+		err := k8sClient.Get(ctx, key.By(meshcontroller.ManifestWorkNameCacerts, clusterNamespace), work)
 		return errors.IsNotFound(err)
 	}).Should(BeTrue())
 }
@@ -722,10 +709,7 @@ func expectNoCacertsManifestWork(clusterNamespace string) {
 func expectCertificate(namespace, clusterName, issuerName string) *certmanagerv1.Certificate {
 	cert := &certmanagerv1.Certificate{}
 	Eventually(func() error {
-		return k8sClient.Get(ctx, types.NamespacedName{
-			Name:      fmt.Sprintf("cacerts-%s", clusterName),
-			Namespace: namespace,
-		}, cert)
+		return k8sClient.Get(ctx, key.By(fmt.Sprintf("cacerts-%s", clusterName), namespace), cert)
 	}).Should(Succeed())
 
 	Expect(cert.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
@@ -832,7 +816,7 @@ func expectSubscription(work *workv1.ManifestWork, index int, isOCP bool, expect
 func expectMeshNotReady(meshName, namespace string) {
 	Eventually(func() metav1.ConditionStatus {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.By(meshName, namespace), mesh); err != nil {
 			return ""
 		}
 		for _, c := range mesh.Status.Conditions {
@@ -847,7 +831,7 @@ func expectMeshNotReady(meshName, namespace string) {
 func expectClusterOperatorConditionReason(meshName, namespace, clusterName, reason string) {
 	Eventually(func() string {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.By(meshName, namespace), mesh); err != nil {
 			return ""
 		}
 		for _, cs := range mesh.Status.ClusterStatus {
@@ -866,7 +850,7 @@ func expectClusterOperatorConditionReason(meshName, namespace, clusterName, reas
 func expectNoClusterStatus(meshName, namespace, clusterName string) {
 	Eventually(func() bool {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.By(meshName, namespace), mesh); err != nil {
 			return false
 		}
 		for _, cs := range mesh.Status.ClusterStatus {
@@ -881,7 +865,7 @@ func expectNoClusterStatus(meshName, namespace, clusterName string) {
 func expectMeshConditionReason(meshName, namespace, conditionType, reason string) {
 	Eventually(func() string {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.By(meshName, namespace), mesh); err != nil {
 			return ""
 		}
 		for _, c := range mesh.Status.Conditions {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -255,7 +255,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				originalVersion := work.ResourceVersion
 
 				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, key.By(meshName, testNs), mesh)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
 				mesh.Spec.ControlPlane.Namespace = "different-ns"
 				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
 
@@ -266,7 +266,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should update ManifestWork when operator config changes", func() {
 				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, key.By(meshName, testNs), mesh)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
 				mesh.Spec.Operator.Channel = "tech-preview"
 				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
 
@@ -468,7 +468,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				cert := expectCertificate(testNs, clusterName, "mesh-issuer")
 
 				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, key.By(meshName, testNs), mesh)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
 
 				Expect(cert.OwnerReferences).To(HaveLen(1))
 				ownerRef := cert.OwnerReferences[0]
@@ -518,14 +518,14 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectCacertsManifestWork(clusterName)
 
 				secret := &corev1.Secret{}
-				Expect(k8sClient.Get(ctx, key.By(fmt.Sprintf("cacerts-%s", clusterName), testNs), secret)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.Of(fmt.Sprintf("cacerts-%s", clusterName), testNs), secret)).To(Succeed())
 
 				secret.Data["tls.crt"] = []byte("updated-cert-data")
 				Expect(k8sClient.Update(ctx, secret)).To(Succeed())
 
 				Eventually(func() string {
 					work := &workv1.ManifestWork{}
-					if err := k8sClient.Get(ctx, key.By(meshcontroller.ManifestWorkNameCacerts, clusterName), work); err != nil {
+					if err := k8sClient.Get(ctx, key.Of(meshcontroller.ManifestWorkNameCacerts, clusterName), work); err != nil {
 						return ""
 					}
 					manifestSecret := &corev1.Secret{}
@@ -574,7 +574,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectCertificate(testNs, clusterName, "mesh-issuer")
 
 				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, key.By(meshName, testNs), mesh)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
 				mesh.Spec.Security.Trust.CertManager.IssuerRef.Name = ""
 				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
 
@@ -635,7 +635,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 func expectFinalizer(name, namespace string) {
 	Eventually(func() []string {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, key.By(name, namespace), mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.Of(name, namespace), mesh); err != nil {
 			return nil
 		}
 		return mesh.Finalizers
@@ -644,7 +644,7 @@ func expectFinalizer(name, namespace string) {
 
 func updateClusterSetLabel(clusterName, newClusterSet string) {
 	cluster := &clusterv1.ManagedCluster{}
-	Expect(k8sClient.Get(ctx, key.By(clusterName), cluster)).To(Succeed())
+	Expect(k8sClient.Get(ctx, key.Of(clusterName), cluster)).To(Succeed())
 	cluster.Labels[meshcontroller.ClusterSetLabel] = newClusterSet
 	Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
 }
@@ -665,7 +665,7 @@ func expectNoManifestWorks() {
 // TODO(mkolesnik): Remove once WorkApplier uses the CR cache (sdk-go#226).
 func triggerReconcile(meshName, namespace string) {
 	mesh := &meshv1alpha1.MultiClusterMesh{}
-	Expect(k8sClient.Get(ctx, key.By(meshName, namespace), mesh)).To(Succeed())
+	Expect(k8sClient.Get(ctx, key.Of(meshName, namespace), mesh)).To(Succeed())
 	if mesh.Annotations == nil {
 		mesh.Annotations = map[string]string{}
 	}
@@ -685,7 +685,7 @@ func expectAllManifestWorksDeleted() {
 func expectManifestWork(name, namespace string) *workv1.ManifestWork {
 	work := &workv1.ManifestWork{}
 	Eventually(func() error {
-		return k8sClient.Get(ctx, key.By(name, namespace), work)
+		return k8sClient.Get(ctx, key.Of(name, namespace), work)
 	}).Should(Succeed())
 	return work
 }
@@ -701,7 +701,7 @@ func expectCacertsManifestWork(clusterNamespace string) *workv1.ManifestWork {
 func expectNoCacertsManifestWork(clusterNamespace string) {
 	Consistently(func() bool {
 		work := &workv1.ManifestWork{}
-		err := k8sClient.Get(ctx, key.By(meshcontroller.ManifestWorkNameCacerts, clusterNamespace), work)
+		err := k8sClient.Get(ctx, key.Of(meshcontroller.ManifestWorkNameCacerts, clusterNamespace), work)
 		return errors.IsNotFound(err)
 	}).Should(BeTrue())
 }
@@ -709,7 +709,7 @@ func expectNoCacertsManifestWork(clusterNamespace string) {
 func expectCertificate(namespace, clusterName, issuerName string) *certmanagerv1.Certificate {
 	cert := &certmanagerv1.Certificate{}
 	Eventually(func() error {
-		return k8sClient.Get(ctx, key.By(fmt.Sprintf("cacerts-%s", clusterName), namespace), cert)
+		return k8sClient.Get(ctx, key.Of(fmt.Sprintf("cacerts-%s", clusterName), namespace), cert)
 	}).Should(Succeed())
 
 	Expect(cert.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
@@ -816,7 +816,7 @@ func expectSubscription(work *workv1.ManifestWork, index int, isOCP bool, expect
 func expectMeshNotReady(meshName, namespace string) {
 	Eventually(func() metav1.ConditionStatus {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, key.By(meshName, namespace), mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.Of(meshName, namespace), mesh); err != nil {
 			return ""
 		}
 		for _, c := range mesh.Status.Conditions {
@@ -831,7 +831,7 @@ func expectMeshNotReady(meshName, namespace string) {
 func expectClusterOperatorConditionReason(meshName, namespace, clusterName, reason string) {
 	Eventually(func() string {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, key.By(meshName, namespace), mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.Of(meshName, namespace), mesh); err != nil {
 			return ""
 		}
 		for _, cs := range mesh.Status.ClusterStatus {
@@ -850,7 +850,7 @@ func expectClusterOperatorConditionReason(meshName, namespace, clusterName, reas
 func expectNoClusterStatus(meshName, namespace, clusterName string) {
 	Eventually(func() bool {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, key.By(meshName, namespace), mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.Of(meshName, namespace), mesh); err != nil {
 			return false
 		}
 		for _, cs := range mesh.Status.ClusterStatus {
@@ -865,7 +865,7 @@ func expectNoClusterStatus(meshName, namespace, clusterName string) {
 func expectMeshConditionReason(meshName, namespace, conditionType, reason string) {
 	Eventually(func() string {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, key.By(meshName, namespace), mesh); err != nil {
+		if err := k8sClient.Get(ctx, key.Of(meshName, namespace), mesh); err != nil {
 			return ""
 		}
 		for _, c := range mesh.Status.Conditions {

--- a/test/util/k8s.go
+++ b/test/util/k8s.go
@@ -8,11 +8,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
+	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
 )
 
 // UniqueName generates a unique name with the given prefix.
@@ -54,7 +54,7 @@ func CreateCacertsSecret(ctx context.Context, k8sClient client.Client, namespace
 
 // DeleteResource deletes a Kubernetes resource and waits for it to be fully removed.
 func DeleteResource(ctx context.Context, k8sClient client.Client, obj client.Object, name, namespace string) {
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)).To(Succeed())
+	Expect(k8sClient.Get(ctx, key.By(name, namespace), obj)).To(Succeed())
 	Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
 	ExpectResourceDeleted(ctx, k8sClient, obj, name, namespace)
 }
@@ -62,7 +62,7 @@ func DeleteResource(ctx context.Context, k8sClient client.Client, obj client.Obj
 // ExpectResourceDeleted waits for a resource to be fully removed (e.g. after a side-effect deletion by a controller).
 func ExpectResourceDeleted(ctx context.Context, k8sClient client.Client, obj client.Object, name, namespace string) {
 	Eventually(func() bool {
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)
+		err := k8sClient.Get(ctx, key.By(name, namespace), obj)
 		return errors.IsNotFound(err)
 	}).Should(BeTrue())
 }

--- a/test/util/k8s.go
+++ b/test/util/k8s.go
@@ -54,7 +54,7 @@ func CreateCacertsSecret(ctx context.Context, k8sClient client.Client, namespace
 
 // DeleteResource deletes a Kubernetes resource and waits for it to be fully removed.
 func DeleteResource(ctx context.Context, k8sClient client.Client, obj client.Object, name, namespace string) {
-	Expect(k8sClient.Get(ctx, key.By(name, namespace), obj)).To(Succeed())
+	Expect(k8sClient.Get(ctx, key.Of(name, namespace), obj)).To(Succeed())
 	Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
 	ExpectResourceDeleted(ctx, k8sClient, obj, name, namespace)
 }
@@ -62,7 +62,7 @@ func DeleteResource(ctx context.Context, k8sClient client.Client, obj client.Obj
 // ExpectResourceDeleted waits for a resource to be fully removed (e.g. after a side-effect deletion by a controller).
 func ExpectResourceDeleted(ctx context.Context, k8sClient client.Client, obj client.Object, name, namespace string) {
 	Eventually(func() bool {
-		err := k8sClient.Get(ctx, key.By(name, namespace), obj)
+		err := k8sClient.Get(ctx, key.Of(name, namespace), obj)
 		return errors.IsNotFound(err)
 	}).Should(BeTrue())
 }

--- a/test/util/ocm.go
+++ b/test/util/ocm.go
@@ -40,7 +40,7 @@ func CreateManagedCluster(ctx context.Context, k8sClient client.Client, name, cl
 // SetProductClaim sets the claim on an existing ManagedCluster to the given claim.
 func SetProductClaim(ctx context.Context, k8sClient client.Client, clusterName, productClaim string) {
 	cluster := &clusterv1.ManagedCluster{}
-	Expect(k8sClient.Get(ctx, key.By(clusterName), cluster)).To(Succeed())
+	Expect(k8sClient.Get(ctx, key.Of(clusterName), cluster)).To(Succeed())
 	cluster.Status.ClusterClaims = []clusterv1.ManagedClusterClaim{
 		{Name: "product.open-cluster-management.io", Value: productClaim},
 	}

--- a/test/util/ocm.go
+++ b/test/util/ocm.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	. "github.com/onsi/gomega"
+	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +40,7 @@ func CreateManagedCluster(ctx context.Context, k8sClient client.Client, name, cl
 // SetProductClaim sets the claim on an existing ManagedCluster to the given claim.
 func SetProductClaim(ctx context.Context, k8sClient client.Client, clusterName, productClaim string) {
 	cluster := &clusterv1.ManagedCluster{}
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster)).To(Succeed())
+	Expect(k8sClient.Get(ctx, key.By(clusterName), cluster)).To(Succeed())
 	cluster.Status.ClusterClaims = []clusterv1.ManagedClusterClaim{
 		{Name: "product.open-cluster-management.io", Value: productClaim},
 	}


### PR DESCRIPTION
Inline types.NamespacedName struct literals add verbosity,
especially in multi-line form. A small key package with By()
and For() makes client call sites more concise.
