### PR TITLE
Report operator installation status via ManifestWork feedback

### DIFF
--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -145,6 +145,9 @@ const (
 	// ReasonManifestWorkCreated indicates the operator ManifestWork has been created
 	ReasonManifestWorkCreated = "ManifestWorkCreated"
 
+	// ReasonOperatorInstalled indicates the operator CSV has been successfully installed
+	ReasonOperatorInstalled = "Installed"
+
 	// ReasonMissingProductClaim indicates the cluster is missing its product claim
 	ReasonMissingProductClaim = "MissingProductClaim"
 

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -498,7 +498,7 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 			return fmt.Errorf("failed to get operator ManifestWork for cluster %s: %w", cluster.Name, err)
 		}
 
-		if installedCSV := getManifestWorkFeedback(operatorWork, FeedbackInstalledCSV); installedCSV != nil {
+		if installedCSV := getManifestWorkFeedback(operatorWork); installedCSV != nil {
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 				Type:               meshv1alpha1.ConditionOperatorInstalled,
 				Status:             metav1.ConditionTrue,
@@ -537,10 +537,10 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 	return nil
 }
 
-func getManifestWorkFeedback(work *workv1.ManifestWork, name string) *string {
+func getManifestWorkFeedback(work *workv1.ManifestWork) *string {
 	for _, manifest := range work.Status.ResourceStatus.Manifests {
 		for _, value := range manifest.StatusFeedbacks.Values {
-			if value.Name == name {
+			if value.Name == FeedbackInstalledCSV {
 				return value.Value.String
 			}
 		}

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -57,6 +57,8 @@ const (
 	OperatorManifestWorkName = "multicluster-mesh-operator"
 	ManifestWorkNameCacerts  = "multicluster-mesh-cacerts"
 
+	FeedbackInstalledCSV = "installedCSV"
+
 	CacertsSecretName = "cacerts"
 
 	FinalizerName = "mesh.open-cluster-management.io/finalizer"
@@ -491,11 +493,20 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 			continue
 		}
 
-		work := &workv1.ManifestWork{}
-		err := r.Get(ctx, key.Of(OperatorManifestWorkName, cluster.Name), work)
+		operatorWork := &workv1.ManifestWork{}
+		if err := r.Get(ctx, key.Of(OperatorManifestWorkName, cluster.Name), operatorWork); err != nil {
+			return fmt.Errorf("failed to get operator ManifestWork for cluster %s: %w", cluster.Name, err)
+		}
 
-		if err == nil {
-			// TODO: Set to actual status when operator installation is confirmed via ManifestWork status feedback
+		if installedCSV := getManifestWorkFeedback(operatorWork, FeedbackInstalledCSV); installedCSV != nil {
+			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+				Type:               meshv1alpha1.ConditionOperatorInstalled,
+				Status:             metav1.ConditionTrue,
+				Reason:             meshv1alpha1.ReasonOperatorInstalled,
+				ObservedGeneration: mesh.Generation,
+				Message:            fmt.Sprintf("Operator installed: %s", *installedCSV),
+			})
+		} else {
 			allReady = false
 			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 				Type:               meshv1alpha1.ConditionOperatorInstalled,
@@ -504,8 +515,6 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 				ObservedGeneration: mesh.Generation,
 				Message:            "Operator ManifestWork has been created, awaiting installation confirmation",
 			})
-		} else {
-			return fmt.Errorf("failed to get operator ManifestWork for cluster %s: %w", cluster.Name, err)
 		}
 
 		clusterStatuses = append(clusterStatuses, status)
@@ -525,6 +534,17 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 	}
 	meta.SetStatusCondition(&mesh.Status.Conditions, readyCondition)
 
+	return nil
+}
+
+func getManifestWorkFeedback(work *workv1.ManifestWork, name string) *string {
+	for _, manifest := range work.Status.ResourceStatus.Manifests {
+		for _, value := range manifest.StatusFeedbacks.Values {
+			if value.Name == name {
+				return value.Value.String
+			}
+		}
+	}
 	return nil
 }
 
@@ -693,6 +713,24 @@ func (r *Reconciler) buildOperatorManifestWork(mesh *meshv1alpha1.MultiClusterMe
 			Workload: workv1.ManifestsTemplate{
 				Manifests: manifests,
 			},
+			// Report the Subscription's installedCSV field back to the hub via ManifestWork feedback.
+			// OLM sets this field only after the operator's CSV reaches the Succeeded phase,
+			// so a non-empty value confirms the operator is installed.
+			ManifestConfigs: []workv1.ManifestConfigOption{{
+				ResourceIdentifier: workv1.ResourceIdentifier{
+					Group:     "operators.coreos.com",
+					Resource:  "subscriptions",
+					Name:      packageName,
+					Namespace: config.Namespace,
+				},
+				FeedbackRules: []workv1.FeedbackRule{{
+					Type: workv1.JSONPathsType,
+					JsonPaths: []workv1.JsonPath{{
+						Name: FeedbackInstalledCSV,
+						Path: ".status.installedCSV",
+					}},
+				}},
+			}},
 		},
 	}
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -13,6 +13,7 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -79,32 +80,63 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 	})
 
 	Context("Basic reconciliation", func() {
-		It("should create ManifestWorks for clusters in the specified ClusterSet", func() {
-			cluster1 := util.UniqueName("cluster")
-			cluster2 := util.UniqueName("cluster")
+		When("two clusters exist", func() {
+			var cluster2Name string
 
-			util.CreateK8sManagedCluster(ctx, k8sClient, cluster1, testClusterSet)
-			util.CreateOCPManagedCluster(ctx, k8sClient, cluster2, testClusterSet, meshcontroller.ProductOCP)
-			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+			BeforeEach(func() {
+				cluster2Name = util.UniqueName("cluster")
 
-			Eventually(func() int {
-				workList := &workv1.ManifestWorkList{}
-				if err := k8sClient.List(ctx, workList); err != nil {
-					return 0
+				util.CreateK8sManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateOCPManagedCluster(ctx, k8sClient, cluster2Name, testClusterSet, meshcontroller.ProductOCP)
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+			})
+
+			It("should create ManifestWorks for each cluster", func() {
+				work1 := expectOperatorManifestWork(clusterName)
+				work2 := expectOperatorManifestWork(cluster2Name)
+
+				Expect(work1.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
+				Expect(work2.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
+
+				expectMeshNotReady(meshName, testNs)
+				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonManifestWorkCreated)
+				expectClusterOperatorConditionReason(meshName, testNs, cluster2Name, meshv1alpha1.ReasonManifestWorkCreated)
+			})
+
+			It("should include feedback rules for the Operator Subscription status", func() {
+				for _, cluster := range []string{clusterName, cluster2Name} {
+					work := expectOperatorManifestWork(cluster)
+
+					Expect(work.Spec.ManifestConfigs).To(HaveLen(1))
+					Expect(work.Spec.ManifestConfigs[0].ResourceIdentifier.Resource).To(Equal("subscriptions"))
+					Expect(work.Spec.ManifestConfigs[0].FeedbackRules).To(HaveLen(1))
+					Expect(work.Spec.ManifestConfigs[0].FeedbackRules[0].Type).To(Equal(workv1.JSONPathsType))
+					Expect(work.Spec.ManifestConfigs[0].FeedbackRules[0].JsonPaths[0].Path).To(Equal(".status.installedCSV"))
 				}
-				return len(workList.Items)
-			}).Should(Equal(2))
+			})
 
-			work1 := expectOperatorManifestWork(cluster1)
-			work2 := expectOperatorManifestWork(cluster2)
+			It("should become ready after all clusters confirm operator installation", func() {
+				expectMeshNotReady(meshName, testNs)
 
-			Expect(work1.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
-			Expect(work2.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
+				By("setting feedback on one cluster, mesh should stay not-ready")
+				util.SetManifestWorkFeedback(ctx, k8sClient,
+					meshcontroller.OperatorManifestWorkName, clusterName,
+					meshcontroller.FeedbackInstalledCSV, "sailoperator.v1.0.0")
 
-			expectMeshNotReady(meshName, testNs)
-			expectClusterOperatorConditionReason(meshName, testNs, cluster1, meshv1alpha1.ReasonManifestWorkCreated)
-			expectClusterOperatorConditionReason(meshName, testNs, cluster2, meshv1alpha1.ReasonManifestWorkCreated)
-			expectConditionsObservedGeneration(meshName, testNs)
+				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonOperatorInstalled)
+				expectClusterOperatorConditionReason(meshName, testNs, cluster2Name, meshv1alpha1.ReasonManifestWorkCreated)
+				expectMeshNotReady(meshName, testNs)
+
+				By("setting feedback on all clusters, mesh should become ready")
+				util.SetManifestWorkFeedback(ctx, k8sClient,
+					meshcontroller.OperatorManifestWorkName, cluster2Name,
+					meshcontroller.FeedbackInstalledCSV, "servicemeshoperator3.v3.0.0")
+
+				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonOperatorInstalled)
+				expectClusterOperatorConditionReason(meshName, testNs, cluster2Name, meshv1alpha1.ReasonOperatorInstalled)
+				expectConditionsObservedGeneration(meshName, testNs)
+				expectMeshReady(meshName, testNs)
+			})
 		})
 
 		It("should use custom operator configuration on K8s when specified", func() {
@@ -846,35 +878,36 @@ func expectSubscription(work *workv1.ManifestWork, index int, isOCP bool, expect
 	Expect(sub.Spec.InstallPlanApproval).To(Equal(expectedInstallPlanApproval))
 }
 
+func getMeshCondition(meshName, namespace, conditionType string) *metav1.Condition {
+	mesh := &meshv1alpha1.MultiClusterMesh{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
+		return nil
+	}
+	return meta.FindStatusCondition(mesh.Status.Conditions, conditionType)
+}
+
 func expectMeshNotReady(meshName, namespace string) {
 	Eventually(func() metav1.ConditionStatus {
-		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, key.Of(meshName, namespace), mesh); err != nil {
-			return ""
-		}
-		for _, c := range mesh.Status.Conditions {
-			if c.Type == meshv1alpha1.ConditionReady {
-				return c.Status
-			}
+		if c := getMeshCondition(meshName, namespace, meshv1alpha1.ConditionReady); c != nil {
+			return c.Status
 		}
 		return ""
 	}).Should(Equal(metav1.ConditionFalse))
 }
 
-func expectClusterOperatorConditionReason(meshName, namespace, clusterName, reason string) {
-	Eventually(func() string {
-		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, key.Of(meshName, namespace), mesh); err != nil {
-			return ""
+func expectMeshReady(meshName, namespace string) {
+	Eventually(func() metav1.ConditionStatus {
+		if c := getMeshCondition(meshName, namespace, meshv1alpha1.ConditionReady); c != nil {
+			return c.Status
 		}
-		for _, cs := range mesh.Status.ClusterStatus {
-			if cs.ClusterName == clusterName {
-				for _, c := range cs.Conditions {
-					if c.Type == meshv1alpha1.ConditionOperatorInstalled {
-						return c.Reason
-					}
-				}
-			}
+		return ""
+	}).Should(Equal(metav1.ConditionTrue))
+}
+
+func expectMeshConditionReason(meshName, namespace, conditionType, reason string) {
+	Eventually(func() string {
+		if c := getMeshCondition(meshName, namespace, conditionType); c != nil {
+			return c.Reason
 		}
 		return ""
 	}).Should(Equal(reason))
@@ -895,15 +928,17 @@ func expectNoClusterStatus(meshName, namespace, clusterName string) {
 	}).Should(BeTrue())
 }
 
-func expectMeshConditionReason(meshName, namespace, conditionType, reason string) {
+func expectClusterOperatorConditionReason(meshName, namespace, clusterName, reason string) {
 	Eventually(func() string {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
 		if err := k8sClient.Get(ctx, key.Of(meshName, namespace), mesh); err != nil {
 			return ""
 		}
-		for _, c := range mesh.Status.Conditions {
-			if c.Type == conditionType {
-				return c.Reason
+		for _, cs := range mesh.Status.ClusterStatus {
+			if cs.ClusterName == clusterName {
+				if c := meta.FindStatusCondition(cs.Conditions, meshv1alpha1.ConditionOperatorInstalled); c != nil {
+					return c.Reason
+				}
 			}
 		}
 		return ""

--- a/test/util/ocm.go
+++ b/test/util/ocm.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -57,4 +58,31 @@ func CreateK8sManagedCluster(ctx context.Context, k8sClient client.Client, name,
 func CreateOCPManagedCluster(ctx context.Context, k8sClient client.Client, name, clusterSet, product string) {
 	CreateManagedCluster(ctx, k8sClient, name, clusterSet)
 	SetProductClaim(ctx, k8sClient, name, product)
+}
+
+// SetManifestWorkFeedback updates a ManifestWork's status to include a string feedback value,
+// simulating what the OCM work agent does on a real spoke cluster.
+func SetManifestWorkFeedback(ctx context.Context, k8sClient client.Client, workName, namespace, feedbackName, feedbackValue string) {
+	work := &workv1.ManifestWork{}
+	Expect(k8sClient.Get(ctx, key.Of(workName, namespace), work)).To(Succeed())
+	work.Status.ResourceStatus = workv1.ManifestResourceStatus{
+		Manifests: []workv1.ManifestCondition{{
+			Conditions: []metav1.Condition{{
+				Type:               workv1.ManifestApplied,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Applied",
+				LastTransitionTime: metav1.Now(),
+			}},
+			StatusFeedbacks: workv1.StatusFeedbackResult{
+				Values: []workv1.FeedbackValue{{
+					Name: feedbackName,
+					Value: workv1.FieldValue{
+						Type:   workv1.String,
+						String: &feedbackValue,
+					},
+				}},
+			},
+		}},
+	}
+	Expect(k8sClient.Status().Update(ctx, work)).To(Succeed())
 }


### PR DESCRIPTION
The mesh Ready condition could never become True because the controller never confirmed operator installation on spoke clusters.

Add a feedback rule to the operator ManifestWork that pulls back the Subscription's installedCSV field.
When the work agent reports a non-empty value, the controller sets OperatorInstalled=True for that cluster.
Once all clusters confirm, the mesh becomes Ready.

Closes #89