### PR TITLE
Fix update-test-crds failure when vendor directory is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@ bin/
 config/crd
 test/integration/crds/
 
+# Go vendor directory
+vendor/
+
 # Dev environment (make dev-env)
 .kube/

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ test: ## Run unit tests
 .PHONY: update-test-crds
 update-test-crds: ## Update test CRDs from OCM API and cert-manager dependencies
 	@echo "Updating test CRDs from open-cluster-management.io/api..."
-	@OCM_API_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/api 2>/dev/null); \
+	@OCM_API_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' open-cluster-management.io/api 2>/dev/null); \
 	if [ -z "$$OCM_API_PATH" ]; then \
 		echo "Error: open-cluster-management.io/api not found in go.mod"; \
 		echo "Run: go mod download open-cluster-management.io/api"; \
@@ -123,7 +123,7 @@ update-test-crds: ## Update test CRDs from OCM API and cert-manager dependencies
 	cp -v $$OCM_API_PATH/work/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	echo "Test CRDs updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from cert-manager..."
-	@CERTMANAGER_PATH=$$(go list -m -f '{{.Dir}}' github.com/cert-manager/cert-manager 2>/dev/null); \
+	@CERTMANAGER_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' github.com/cert-manager/cert-manager 2>/dev/null); \
 	if [ -z "$$CERTMANAGER_PATH" ]; then \
 		echo "Error: github.com/cert-manager/cert-manager not found in go.mod"; \
 		echo "Run: go mod download github.com/cert-manager/cert-manager"; \


### PR DESCRIPTION
When a `vendor` directory exists, Go defaults to `-mod=vendor` which causes `go list -m -f '{{.Dir}}'` to return empty output since vendored modules don't have a cache directory path. This made the Makefile's update-test-crds target fail with "not found in go.mod".

This PR modifies the command to use `-mod=mod` to always resolve module paths from the module cache. This works correctly with or without a vendor directory.