### PR TITLE
Add ManagedServiceAccount CRD and dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,6 @@ update-test-crds: ## Update test CRDs from OCM API and cert-manager dependencies
 		echo "Run: go mod download open-cluster-management.io/managed-serviceaccount"; \
 		exit 1; \
 	fi; \
-	mkdir -p $(TEST_CRD_DIR)/ocm; \
 	echo "Copying CRDs from $$OCM_MSA_PATH..."; \
 	cp -v $$OCM_MSA_PATH/charts/managed-serviceaccount/crds/*.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	echo "Test CRDs for MSA updated successfully in $(TEST_CRD_DIR)/ocm/"

--- a/Makefile
+++ b/Makefile
@@ -123,15 +123,15 @@ update-test-crds: ## Update test CRDs from OCM API and cert-manager dependencies
 	cp -v $$OCM_API_PATH/work/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	echo "Test CRDs updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from open-cluster-management.io/managed-serviceaccount..."
-	@OCP_MSA_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/managed-serviceaccount 2>/dev/null); \
-	if [ -z "$$OCP_MSA_PATH" ]; then \
+	@OCM_MSA_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' open-cluster-management.io/managed-serviceaccount 2>/dev/null); \
+	if [ -z "$$OCM_MSA_PATH" ]; then \
 		echo "Error: open-cluster-management.io/managed-serviceaccount not found in go.mod"; \
 		echo "Run: go mod download open-cluster-management.io/managed-serviceaccount"; \
 		exit 1; \
 	fi; \
 	mkdir -p $(TEST_CRD_DIR)/ocm; \
-	echo "Copying CRDs from $$OCP_MSA_PATH..."; \
-	cp -v $$OCP_MSA_PATH/charts/managed-serviceaccount/crds/*.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
+	echo "Copying CRDs from $$OCM_MSA_PATH..."; \
+	cp -v $$OCM_MSA_PATH/charts/managed-serviceaccount/crds/*.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	echo "Test CRDs for MSA updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from cert-manager..."
 	@CERTMANAGER_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' github.com/cert-manager/cert-manager 2>/dev/null); \

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test: ## Run unit tests
 	go test -short ./pkg/...
 
 .PHONY: update-test-crds
-update-test-crds: ## Update test CRDs from OCM API and cert-manager dependencies
+update-test-crds: ## Update test CRDs from OCM API, managed-serviceaccount and cert-manager dependencies
 	@echo "Updating test CRDs from open-cluster-management.io/api..."
 	@OCM_API_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' open-cluster-management.io/api 2>/dev/null); \
 	if [ -z "$$OCM_API_PATH" ]; then \
@@ -130,7 +130,7 @@ update-test-crds: ## Update test CRDs from OCM API and cert-manager dependencies
 		exit 1; \
 	fi; \
 	echo "Copying CRDs from $$OCM_MSA_PATH..."; \
-	cp -v $$OCM_MSA_PATH/charts/managed-serviceaccount/crds/*.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
+	cp -v $$OCM_MSA_PATH/charts/managed-serviceaccount/crds/*.yaml $(TEST_CRD_DIR)/ocm/; \
 	echo "Test CRDs for MSA updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from cert-manager..."
 	@CERTMANAGER_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' github.com/cert-manager/cert-manager 2>/dev/null); \

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,17 @@ update-test-crds: ## Update test CRDs from OCM API and cert-manager dependencies
 	cp -v $$OCM_API_PATH/cluster/v1beta2/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	cp -v $$OCM_API_PATH/work/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	echo "Test CRDs updated successfully in $(TEST_CRD_DIR)/ocm/"
+	@echo "Updating test CRDs from open-cluster-management.io/managed-serviceaccount..."
+	@OCP_MSA_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/managed-serviceaccount 2>/dev/null); \
+	if [ -z "$$OCP_MSA_PATH" ]; then \
+		echo "Error: open-cluster-management.io/managed-serviceaccount not found in go.mod"; \
+		echo "Run: go mod download open-cluster-management.io/managed-serviceaccount"; \
+		exit 1; \
+	fi; \
+	mkdir -p $(TEST_CRD_DIR)/ocm; \
+	echo "Copying CRDs from $$OCP_MSA_PATH..."; \
+	cp -v $$OCP_MSA_PATH/charts/managed-serviceaccount/crds/*.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
+	echo "Test CRDs for MSA updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from cert-manager..."
 	@CERTMANAGER_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' github.com/cert-manager/cert-manager 2>/dev/null); \
 	if [ -z "$$CERTMANAGER_PATH" ]; then \

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	open-cluster-management.io/api v1.3.0
+	open-cluster-management.io/managed-serviceaccount v0.10.0
 	open-cluster-management.io/sdk-go v1.3.0
 	sigs.k8s.io/controller-runtime v0.23.3
 )

--- a/go.sum
+++ b/go.sum
@@ -382,6 +382,8 @@ k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbe
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 open-cluster-management.io/api v1.3.0 h1:Q3miH38BE3N5+PesHQ0kcFi5nhX5350m7OJWapZcVqY=
 open-cluster-management.io/api v1.3.0/go.mod h1:t0DsBv4gjIo9ojd7GYfA2tcEMpNf0h5Ix68pFDXwNSk=
+open-cluster-management.io/managed-serviceaccount v0.10.0 h1:OBJ1EA8aaf0q8a7tBIHZT+5KdFECRKiDvoq/jqSHf1k=
+open-cluster-management.io/managed-serviceaccount v0.10.0/go.mod h1:VbPxD7JBoGHVdZIw+jHmNKuY5dVOOvKWIIREM/WO2jU=
 open-cluster-management.io/sdk-go v1.3.0 h1:03VnnN3c10FwWnsSl9+apevKadLUw1hrKIu91JHL364=
 open-cluster-management.io/sdk-go v1.3.0/go.mod h1:+zL1hpfT73F4kxq3k293H6qsgm8k4YiC1giSwn36fAo=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
 	"github.com/stolostron/multicluster-mesh-addon/pkg/version"
+	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 )
 
 var (
@@ -46,6 +47,7 @@ func init() {
 	utilruntime.Must(operatorsv1.AddToScheme(runtimeScheme))
 	utilruntime.Must(operatorsv1alpha1.AddToScheme(runtimeScheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(runtimeScheme))
+	utilruntime.Must(msav1beta1.AddToScheme(runtimeScheme))
 }
 
 func main() {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -25,6 +25,7 @@ import (
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
 	"github.com/stolostron/multicluster-mesh-addon/test/util"
+	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 )
 
 var (
@@ -69,6 +70,7 @@ var _ = BeforeSuite(func() {
 		operatorsv1.AddToScheme,
 		operatorsv1alpha1.AddToScheme,
 		certmanagerv1.AddToScheme,
+		msav1beta1.AddToScheme,
 	)
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})


### PR DESCRIPTION
This PR adds the ManagedServiceAccount dependencies and CRDs. This is the dependencies needed for the controller implementation.

This PR is the first part of the original last PR:
https://github.com/stolostron/multicluster-mesh-addon/pull/55