### PR TITLE
Prevent missing ObservedGeneration on status conditions

### DIFF
--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -1,7 +1,10 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -30,6 +33,40 @@ func (m *MultiClusterMesh) GetControlPlaneNamespace() string {
 		return "istio-system"
 	}
 	return m.Spec.ControlPlane.Namespace
+}
+
+// SetReadyCondition sets the mesh-level Ready condition.
+func (m *MultiClusterMesh) SetReadyCondition(status metav1.ConditionStatus, reason string, messageFmt string, args ...any) {
+	meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
+		Type:               ConditionReady,
+		Status:             status,
+		Reason:             reason,
+		ObservedGeneration: m.Generation,
+		Message:            fmt.Sprintf(messageFmt, args...),
+	})
+}
+
+// SetClusterCondition sets a per-cluster condition, creating the cluster status entry if needed.
+func (m *MultiClusterMesh) SetClusterCondition(clusterName string, conditionType string, status metav1.ConditionStatus, reason string, messageFmt string, args ...any) {
+	cs := m.getOrCreateClusterStatus(clusterName)
+	meta.SetStatusCondition(&cs.Conditions, metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		Reason:             reason,
+		ObservedGeneration: m.Generation,
+		Message:            fmt.Sprintf(messageFmt, args...),
+	})
+}
+
+func (m *MultiClusterMesh) getOrCreateClusterStatus(clusterName string) *ClusterMeshStatus {
+	// Index-based iteration to return a pointer into the slice, not a copy.
+	for i := range m.Status.ClusterStatus {
+		if m.Status.ClusterStatus[i].ClusterName == clusterName {
+			return &m.Status.ClusterStatus[i]
+		}
+	}
+	m.Status.ClusterStatus = append(m.Status.ClusterStatus, ClusterMeshStatus{ClusterName: clusterName})
+	return &m.Status.ClusterStatus[len(m.Status.ClusterStatus)-1]
 }
 
 // MultiClusterMeshSpec defines the desired state of a multi-cluster mesh

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -189,12 +189,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 
 	oldStatus := mesh.Status.DeepCopy()
 
-	var invalidCondition *metav1.Condition
-	if invalidCondition, reconcileErr = r.validate(ctx, mesh); reconcileErr != nil {
-		r.setErrorStatus(mesh, reconcileErr)
-	} else if invalidCondition != nil {
-		meta.SetStatusCondition(&mesh.Status.Conditions, *invalidCondition)
-	} else {
+	var conflict bool
+	if conflict, reconcileErr = r.validate(ctx, mesh); reconcileErr != nil {
+		mesh.SetReadyCondition(metav1.ConditionFalse, meshv1alpha1.ReasonReconcileError, "%v", reconcileErr)
+	} else if !conflict {
 		clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
 		if err != nil {
 			reconcileErr = fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
@@ -209,7 +207,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 
 		if reconcileErr != nil {
 			klog.Errorf("Encountered an error while reconciling MultiClusterMesh %s/%s: %v", mesh.Namespace, mesh.Name, reconcileErr)
-			r.setErrorStatus(mesh, reconcileErr)
+			mesh.SetReadyCondition(metav1.ConditionFalse, meshv1alpha1.ReasonReconcileError, "%v", reconcileErr)
 		}
 	}
 
@@ -230,37 +228,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 }
 
 // validate checks for conflicts that prevent reconciliation.
-// Returns a condition to set on the mesh if validation fails, or nil if ok.
-func (r *Reconciler) validate(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) (conflict *metav1.Condition, err error) {
+// Sets a condition on the mesh and returns true if a conflict is found.
+func (r *Reconciler) validate(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) (conflict bool, err error) {
 	if err = r.forEachMeshInClusterSet(ctx, mesh.Spec.ClusterSet, func(other *meshv1alpha1.MultiClusterMesh) {
-		if other.UID == mesh.UID || conflict != nil {
+		if other.UID == mesh.UID || conflict {
 			return
 		}
 		if isOlderMesh(mesh, other) {
 			return
 		}
 		if mesh.GetControlPlaneNamespace() == other.GetControlPlaneNamespace() {
-			conflict = &metav1.Condition{
-				Type:   meshv1alpha1.ConditionReady,
-				Status: metav1.ConditionFalse,
-				Reason: meshv1alpha1.ReasonNamespaceConflict,
-				Message: fmt.Sprintf("controlPlane.namespace %q conflicts with older mesh %s/%s targeting the same ClusterSet %s",
-					mesh.GetControlPlaneNamespace(), other.Namespace, other.Name, mesh.Spec.ClusterSet),
-			}
+			mesh.SetReadyCondition(metav1.ConditionFalse, meshv1alpha1.ReasonNamespaceConflict,
+				"controlPlane.namespace %q conflicts with older mesh %s/%s targeting the same ClusterSet %s",
+				mesh.GetControlPlaneNamespace(), other.Namespace, other.Name, mesh.Spec.ClusterSet)
+			conflict = true
 			return
 		}
 		if r.operatorConfigConflicts(mesh.Spec.Operator, other.Spec.Operator) {
-			conflict = &metav1.Condition{
-				Type:               meshv1alpha1.ConditionReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             meshv1alpha1.ReasonOperatorConfigConflict,
-				ObservedGeneration: mesh.Generation,
-				Message: fmt.Sprintf("operator config conflicts with older mesh %s/%s targeting the same ClusterSet %s",
-					other.Namespace, other.Name, mesh.Spec.ClusterSet),
-			}
+			mesh.SetReadyCondition(metav1.ConditionFalse, meshv1alpha1.ReasonOperatorConfigConflict,
+				"operator config conflicts with older mesh %s/%s targeting the same ClusterSet %s",
+				other.Namespace, other.Name, mesh.Spec.ClusterSet)
+			conflict = true
 		}
 	}); err != nil {
-		return nil, fmt.Errorf("failed to validate: %w", err)
+		return false, fmt.Errorf("failed to validate: %w", err)
 	}
 
 	return conflict, nil
@@ -482,24 +473,14 @@ func (r *Reconciler) triggerReconcileForNotReadyMeshes(ctx context.Context, mesh
 }
 
 func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
-	var clusterStatuses []meshv1alpha1.ClusterMeshStatus
+	mesh.Status.ClusterStatus = make([]meshv1alpha1.ClusterMeshStatus, 0, len(clusters))
 	allReady := len(clusters) > 0
 
 	for _, cluster := range clusters {
-		status := meshv1alpha1.ClusterMeshStatus{
-			ClusterName: cluster.Name,
-		}
-
 		if getProductClaim(&cluster) == "" {
 			allReady = false
-			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
-				Type:               meshv1alpha1.ConditionOperatorInstalled,
-				Status:             metav1.ConditionFalse,
-				Reason:             meshv1alpha1.ReasonMissingProductClaim,
-				ObservedGeneration: mesh.Generation,
-				Message:            "Cluster is missing product claim, cannot determine platform",
-			})
-			clusterStatuses = append(clusterStatuses, status)
+			mesh.SetClusterCondition(cluster.Name, meshv1alpha1.ConditionOperatorInstalled, metav1.ConditionFalse,
+				meshv1alpha1.ReasonMissingProductClaim, "Cluster is missing product claim, cannot determine platform")
 			continue
 		}
 
@@ -509,40 +490,22 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 		}
 
 		if installedCSV := getManifestWorkFeedback(operatorWork); installedCSV != nil {
-			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
-				Type:               meshv1alpha1.ConditionOperatorInstalled,
-				Status:             metav1.ConditionTrue,
-				Reason:             meshv1alpha1.ReasonOperatorInstalled,
-				ObservedGeneration: mesh.Generation,
-				Message:            fmt.Sprintf("Operator installed: %s", *installedCSV),
-			})
+			mesh.SetClusterCondition(cluster.Name, meshv1alpha1.ConditionOperatorInstalled, metav1.ConditionTrue,
+				meshv1alpha1.ReasonOperatorInstalled, "Operator installed: %s", *installedCSV)
 		} else {
 			allReady = false
-			meta.SetStatusCondition(&status.Conditions, metav1.Condition{
-				Type:               meshv1alpha1.ConditionOperatorInstalled,
-				Status:             metav1.ConditionFalse,
-				Reason:             meshv1alpha1.ReasonManifestWorkCreated,
-				ObservedGeneration: mesh.Generation,
-				Message:            "Operator ManifestWork has been created, awaiting installation confirmation",
-			})
+			mesh.SetClusterCondition(cluster.Name, meshv1alpha1.ConditionOperatorInstalled, metav1.ConditionFalse,
+				meshv1alpha1.ReasonManifestWorkCreated, "Operator ManifestWork has been created, awaiting installation confirmation")
 		}
-
-		clusterStatuses = append(clusterStatuses, status)
 	}
 
-	mesh.Status.ClusterStatus = clusterStatuses
-
-	readyCondition := metav1.Condition{Type: meshv1alpha1.ConditionReady, ObservedGeneration: mesh.Generation}
 	if allReady {
-		readyCondition.Status = metav1.ConditionTrue
-		readyCondition.Reason = meshv1alpha1.ReasonAllClustersReady
-		readyCondition.Message = "All clusters are ready"
+		mesh.SetReadyCondition(metav1.ConditionTrue,
+			meshv1alpha1.ReasonAllClustersReady, "All clusters are ready")
 	} else {
-		readyCondition.Status = metav1.ConditionFalse
-		readyCondition.Reason = meshv1alpha1.ReasonClustersNotReady
-		readyCondition.Message = "Not all clusters are ready, check individual cluster statuses for details"
+		mesh.SetReadyCondition(metav1.ConditionFalse,
+			meshv1alpha1.ReasonClustersNotReady, "Not all clusters are ready, check individual cluster statuses for details")
 	}
-	meta.SetStatusCondition(&mesh.Status.Conditions, readyCondition)
 
 	return nil
 }
@@ -556,16 +519,6 @@ func getManifestWorkFeedback(work *workv1.ManifestWork) *string {
 		}
 	}
 	return nil
-}
-
-func (r *Reconciler) setErrorStatus(mesh *meshv1alpha1.MultiClusterMesh, reconcileErr error) {
-	meta.SetStatusCondition(&mesh.Status.Conditions, metav1.Condition{
-		Type:               meshv1alpha1.ConditionReady,
-		Status:             metav1.ConditionFalse,
-		Reason:             meshv1alpha1.ReasonReconcileError,
-		ObservedGeneration: mesh.Generation,
-		Message:            reconcileErr.Error(),
-	})
 }
 
 // getMeshEnabledClusters returns all clusters in the given ClusterSet if any non-deleting mesh targets it, or an empty set otherwise.

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -134,7 +134,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonOperatorInstalled)
 				expectClusterOperatorConditionReason(meshName, testNs, cluster2Name, meshv1alpha1.ReasonOperatorInstalled)
-				expectConditionsObservedGeneration(meshName, testNs)
 				expectMeshReady(meshName, testNs)
 			})
 		})
@@ -260,7 +259,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectMeshNotReady(meshName, testNs)
 				expectNoManifestWorks()
 				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonMissingProductClaim)
-				expectConditionsObservedGeneration(meshName, testNs)
 			})
 
 			It("should process it when a claim is set", func() {
@@ -308,7 +306,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 					Expect(unmarshalManifest(work.Spec.Workload.Manifests[2], sub)).To(Succeed())
 					return sub.Spec.Channel
 				}).Should(Equal("tech-preview"))
-				expectConditionsObservedGeneration(meshName, testNs)
 			})
 
 			It("should restore ManifestWork spec when externally modified", func() {
@@ -482,7 +479,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should block the newer mesh", func() {
 				expectMeshConditionReason(otherMesh, testNs, meshv1alpha1.ConditionReady, meshv1alpha1.ReasonOperatorConfigConflict)
-				expectConditionsObservedGeneration(otherMesh, testNs)
 			})
 
 			It("should unblock the newer mesh when the older mesh is deleted", func() {
@@ -942,39 +938,46 @@ func expectSubscription(work *workv1.ManifestWork, index int, isOCP bool, expect
 	Expect(sub.Spec.InstallPlanApproval).To(Equal(expectedInstallPlanApproval))
 }
 
-func getMeshCondition(meshName, namespace, conditionType string) *metav1.Condition {
-	mesh := &meshv1alpha1.MultiClusterMesh{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh); err != nil {
-		return nil
-	}
-	return meta.FindStatusCondition(mesh.Status.Conditions, conditionType)
+func findCondition(g Gomega, conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	c := meta.FindStatusCondition(conditions, conditionType)
+	g.Expect(c).NotTo(BeNil(), "condition %s not found", conditionType)
+	return c
 }
 
 func expectMeshNotReady(meshName, namespace string) {
-	Eventually(func() metav1.ConditionStatus {
-		if c := getMeshCondition(meshName, namespace, meshv1alpha1.ConditionReady); c != nil {
-			return c.Status
-		}
-		return ""
-	}).Should(Equal(metav1.ConditionFalse))
+	Eventually(func(g Gomega) {
+		mesh := &meshv1alpha1.MultiClusterMesh{}
+		g.Expect(k8sClient.Get(ctx, key.Of(meshName, namespace), mesh)).To(Succeed())
+		c := findCondition(g, mesh.Status.Conditions, meshv1alpha1.ConditionReady)
+		g.Expect(c.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(c.ObservedGeneration).To(Equal(mesh.Generation))
+	}).Should(Succeed())
 }
 
 func expectMeshReady(meshName, namespace string) {
-	Eventually(func() metav1.ConditionStatus {
-		if c := getMeshCondition(meshName, namespace, meshv1alpha1.ConditionReady); c != nil {
-			return c.Status
-		}
-		return ""
-	}).Should(Equal(metav1.ConditionTrue))
+	Eventually(func(g Gomega) {
+		mesh := &meshv1alpha1.MultiClusterMesh{}
+		g.Expect(k8sClient.Get(ctx, key.Of(meshName, namespace), mesh)).To(Succeed())
+		c := findCondition(g, mesh.Status.Conditions, meshv1alpha1.ConditionReady)
+		g.Expect(c.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(c.ObservedGeneration).To(Equal(mesh.Generation))
+	}).Should(Succeed())
 }
 
-func expectMeshConditionReason(meshName, namespace, conditionType, reason string) {
-	Eventually(func() string {
-		if c := getMeshCondition(meshName, namespace, conditionType); c != nil {
-			return c.Reason
+func expectClusterOperatorConditionReason(meshName, namespace, clusterName, reason string) {
+	Eventually(func(g Gomega) {
+		mesh := &meshv1alpha1.MultiClusterMesh{}
+		g.Expect(k8sClient.Get(ctx, key.Of(meshName, namespace), mesh)).To(Succeed())
+		for _, cs := range mesh.Status.ClusterStatus {
+			if cs.ClusterName == clusterName {
+				c := findCondition(g, cs.Conditions, meshv1alpha1.ConditionOperatorInstalled)
+				g.Expect(c.Reason).To(Equal(reason))
+				g.Expect(c.ObservedGeneration).To(Equal(mesh.Generation))
+				return
+			}
 		}
-		return ""
-	}).Should(Equal(reason))
+		g.Expect(false).To(BeTrue(), "cluster %s not found in status", clusterName)
+	}).Should(Succeed())
 }
 
 func expectNoClusterStatus(meshName, namespace, clusterName string) {
@@ -992,39 +995,12 @@ func expectNoClusterStatus(meshName, namespace, clusterName string) {
 	}).Should(BeTrue())
 }
 
-func expectClusterOperatorConditionReason(meshName, namespace, clusterName, reason string) {
-	Eventually(func() string {
-		mesh := &meshv1alpha1.MultiClusterMesh{}
-		if err := k8sClient.Get(ctx, key.Of(meshName, namespace), mesh); err != nil {
-			return ""
-		}
-		for _, cs := range mesh.Status.ClusterStatus {
-			if cs.ClusterName == clusterName {
-				if c := meta.FindStatusCondition(cs.Conditions, meshv1alpha1.ConditionOperatorInstalled); c != nil {
-					return c.Reason
-				}
-			}
-		}
-		return ""
-	}).Should(Equal(reason))
-}
-
-func expectConditionsObservedGeneration(meshName, namespace string) {
+func expectMeshConditionReason(meshName, namespace, conditionType, reason string) {
 	Eventually(func(g Gomega) {
 		mesh := &meshv1alpha1.MultiClusterMesh{}
-		g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: namespace}, mesh)).To(Succeed())
-		g.Expect(mesh.Status.Conditions).NotTo(BeEmpty())
-
-		for _, c := range mesh.Status.Conditions {
-			g.Expect(c.ObservedGeneration).To(Equal(mesh.Generation),
-				"mesh-level condition %s should have ObservedGeneration=%d", c.Type, mesh.Generation)
-		}
-
-		for _, cs := range mesh.Status.ClusterStatus {
-			for _, c := range cs.Conditions {
-				g.Expect(c.ObservedGeneration).To(Equal(mesh.Generation),
-					"cluster %s condition %s should have ObservedGeneration=%d", cs.ClusterName, c.Type, mesh.Generation)
-			}
-		}
+		g.Expect(k8sClient.Get(ctx, key.Of(meshName, namespace), mesh)).To(Succeed())
+		c := findCondition(g, mesh.Status.Conditions, conditionType)
+		g.Expect(c.Reason).To(Equal(reason))
+		g.Expect(c.ObservedGeneration).To(Equal(mesh.Generation))
 	}).Should(Succeed())
 }


### PR DESCRIPTION
ObservedGeneration was missing on the NamespaceConflict condition because each call site had to remember to set it manually.

Move condition setting into SetReadyCondition and SetClusterCondition on the mesh type so ObservedGeneration is always set from mesh.Generation.
Test helpers now check it on every assertion, so a missing value fails the test immediately.