### PR TITLE
Tell CodeRabbit to check existing patterns before flagging

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,5 +15,6 @@ reviews:
         - Group similar issues into a single comment instead of posting multiple notes.
         - Skip repetition — if a pattern repeats, mention it once at a summary level only.
         - Do not post comments on code style, formatting, or non-critical improvements.
+        - Before flagging a deviation from best practices, check if the PR follows an existing pattern in the codebase. If the same approach is used elsewhere in the repo, it's intentional, not a bug.
 chat:
   auto_reply: false


### PR DESCRIPTION
Reduces noise from CodeRabbit comments that flag deviations from best practices when the PR is following the repo's existing convention (e.g. Eventually without per-assertion timeout when the suite sets defaults, or `|| true` on cp matching the existing Makefile pattern).