### PR TITLE
Retry mesh updates on conflict in integration tests

### DIFF
--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -256,10 +256,9 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			It("should not update operator ManifestWork when operator config hasn't changed", func() {
 				originalVersion := work.ResourceVersion
 
-				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
-				mesh.Spec.ControlPlane.Namespace = "different-ns"
-				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
+				updateMesh(meshName, testNs, func(mesh *meshv1alpha1.MultiClusterMesh) {
+					mesh.Spec.ControlPlane.Namespace = "different-ns"
+				})
 
 				Consistently(func() string {
 					return expectOperatorManifestWork(clusterName).ResourceVersion
@@ -267,10 +266,9 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should update ManifestWork when operator config changes", func() {
-				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
-				mesh.Spec.Operator.Channel = "tech-preview"
-				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
+				updateMesh(meshName, testNs, func(mesh *meshv1alpha1.MultiClusterMesh) {
+					mesh.Spec.Operator.Channel = "tech-preview"
+				})
 
 				Eventually(func() string {
 					work := expectOperatorManifestWork(clusterName)
@@ -606,10 +604,9 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, util.CertManagerSpec("mesh-issuer"))
 				expectCertificate(testNs, clusterName, "mesh-issuer")
 
-				mesh := &meshv1alpha1.MultiClusterMesh{}
-				Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
-				mesh.Spec.Security.Trust.CertManager.IssuerRef.Name = ""
-				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
+				updateMesh(meshName, testNs, func(mesh *meshv1alpha1.MultiClusterMesh) {
+					mesh.Spec.Security.Trust.CertManager.IssuerRef.Name = ""
+				})
 
 				util.ExpectResourceDeleted(ctx, k8sClient, &certmanagerv1.Certificate{},
 					fmt.Sprintf("cacerts-%s", clusterName), testNs)
@@ -697,13 +694,25 @@ func expectNoManifestWorks() {
 // causing safeToSkipApply to read stale generation and skip the patch.
 // TODO(mkolesnik): Remove once WorkApplier uses the CR cache (sdk-go#226).
 func triggerReconcile(meshName, namespace string) {
+	updateMesh(meshName, namespace, func(mesh *meshv1alpha1.MultiClusterMesh) {
+		if mesh.Annotations == nil {
+			mesh.Annotations = map[string]string{}
+		}
+		mesh.Annotations["test.reconcile-trigger"] = mesh.ResourceVersion
+	})
+}
+
+// updateMesh makes sure to retry the read-modify-write cycle in case of a conflict.
+func updateMesh(meshName, namespace string, mutate func(*meshv1alpha1.MultiClusterMesh)) *meshv1alpha1.MultiClusterMesh {
 	mesh := &meshv1alpha1.MultiClusterMesh{}
-	Expect(k8sClient.Get(ctx, key.Of(meshName, namespace), mesh)).To(Succeed())
-	if mesh.Annotations == nil {
-		mesh.Annotations = map[string]string{}
-	}
-	mesh.Annotations["test.reconcile-trigger"] = mesh.ResourceVersion
-	Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
+	Eventually(func() error {
+		if err := k8sClient.Get(ctx, key.Of(meshName, namespace), mesh); err != nil {
+			return err
+		}
+		mutate(mesh)
+		return k8sClient.Update(ctx, mesh)
+	}).Should(Succeed())
+	return mesh
 }
 
 // expectAllManifestWorksDeleted makes sure ManifestWorks are deleted and none remain


### PR DESCRIPTION
The controller can reconcile between a test's Get and Update, bumping resourceVersion and causing a 409 Conflict.
This was observed as a flaky failure in CI on the "should restore ManifestWork spec when externally modified" test.

Adds an `updateMesh` helper that retries the read-modify-write cycle via `Eventually`, and converts all 4 mesh update sites to use it.