### PR TITLE
Add setup-mesh target to automate mesh and trust chain setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ export DEV_KUBE_DIR K8S_VERSION OLM_VERSION CERT_MANAGER_VERSION
 export KIND CLUSTERADM
 
 .PHONY: dev-env
-dev-env: create-clusters install-olm install-cert-manager init-ocm join-clusters deploy-addon ## Provision full dev environment (Kind + OCM + addon)
+dev-env: create-clusters install-olm install-cert-manager init-ocm join-clusters deploy-addon setup-mesh ## Provision full dev environment (Kind + OCM + addon + mesh)
 
 .PHONY: create-clusters
 create-clusters: $(KIND) ## Create 3 Kind clusters (hub, cluster1, cluster2)
@@ -276,10 +276,18 @@ deploy-addon: $(KIND) gen images $(KUSTOMIZE) ## Build and deploy addon to the h
 		-n multicluster-mesh-system --timeout=180s
 	@echo "==> Addon controller deployed successfully. Use KUBECONFIG=$(HUB_KUBECONFIG) to interact with the hub."
 
+.PHONY: setup-mesh
+setup-mesh: ## Create cert-manager trust chain, mesh-system namespace, and MultiClusterMesh CR
+	$(DEV_ENV_SCRIPT) setup-mesh
+
 .PHONY: dev-clean-meshes
-dev-clean-meshes: ## Delete all addon resources from the dev-env whether user created, or "leaked" resources left by an aborted/failed test
+dev-clean-meshes: ## Delete all mesh resources, cert-manager trust chain, and mesh-system namespace
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete multiclustermeshes -A --all --ignore-not-found=true
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete manifestwork -A -l app.kubernetes.io/managed-by=multicluster-mesh-addon --ignore-not-found=true
+	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete issuer mesh-root-ca -n mesh-system --ignore-not-found=true
+	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete certificate mesh-root-ca -n mesh-system --ignore-not-found=true
+	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete clusterissuer mesh-selfsigned-issuer --ignore-not-found=true
+	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete namespace mesh-system --ignore-not-found=true
 
 .PHONY: dev-clean
 dev-clean: ## Destroy dev clusters and remove .kube/ folder

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ kubectl create namespace multicluster-mesh-system
 
 #### Local Kind+OCM Dev Environment
 
-Provisions a complete multi-cluster topology (1 hub + 2 managed clusters) using Kind and OCM, then builds and deploys the addon controller:
+Provisions a complete multi-cluster topology (1 hub + 2 managed clusters) using Kind and OCM, then builds and deploys the addon controller with a ready-to-use mesh:
 
 ```bash
 make dev-env
@@ -114,14 +114,17 @@ make dev-env
 
 Individual targets are also available:
 
-| Target                 | Description                                            |
-|------------------------|--------------------------------------------------------|
-| `make create-clusters` | Create three Kind clusters (hub, cluster1, cluster2)   |
-| `make install-olm`     | Install OLM on managed clusters                        |
-| `make init-ocm`        | Initialize hub as OCM control plane                    |
-| `make join-clusters`   | Register managed clusters and create ManagedClusterSet |
-| `make deploy-addon`    | Build and deploy addon to the hub Kind cluster         |
-| `make dev-clean`       | Destroy clusters and remove `.kube/`                   |
+| Target                      | Description                                            |
+|-----------------------------|--------------------------------------------------------|
+| `make create-clusters`      | Create three Kind clusters (hub, cluster1, cluster2)   |
+| `make install-olm`          | Install OLM on managed clusters                        |
+| `make install-cert-manager` | Install cert-manager on the hub cluster                |
+| `make init-ocm`             | Initialize hub as OCM control plane                    |
+| `make join-clusters`        | Register managed clusters and create ManagedClusterSet |
+| `make deploy-addon`         | Build and deploy addon to the hub Kind cluster         |
+| `make setup-mesh`           | Create cert-manager trust chain and MultiClusterMesh CR|
+| `make dev-clean`            | Destroy clusters and remove `.kube/`                   |
+| `make dev-clean-meshes`     | Delete mesh resources only (re-run `setup-mesh` to recreate) |
 
 **Configuration (override via environment or command-line):**
 
@@ -152,12 +155,14 @@ See the [Kind known issues](https://kind.sigs.k8s.io/docs/user/known-issues/#pod
 
 #### Quick Start
 
+> **Note:** If you used `make dev-env`, the mesh is already set up. The following manual steps are for deploying on existing clusters.
+
 1. Create a namespace for your mesh resources:
 ```bash
 kubectl create namespace mesh-system
 ```
 
-2. Create a cert-manager Issuer to act as the Root CA:
+2. Create the cert-manager trust chain (ClusterIssuer, root CA Certificate, and CA-backed Issuer):
 ```bash
 kubectl apply -f samples/cert-manager-issuer.yaml
 ```
@@ -167,7 +172,7 @@ kubectl apply -f samples/cert-manager-issuer.yaml
 kubectl apply -f samples/basic.yaml
 ```
 
-> **Note:** All samples use `clusterSet: default` as the ManagedClusterSet reference. Update this field to match your actual ManagedClusterSet name as needed.
+> **Note:** The `basic.yaml` sample uses `clusterSet: mesh-cluster-set`. Update this field to match your actual ManagedClusterSet name as needed.
 
 For more configuration options, see the [samples](./samples/) directory:
 
@@ -175,7 +180,7 @@ For more configuration options, see the [samples](./samples/) directory:
 - **[complete.yaml](./samples/complete.yaml)** - All available fields with documentation
 - **[openshift.yaml](./samples/openshift.yaml)** - OpenShift-specific configuration
 - **[pinned-version.yaml](./samples/pinned-version.yaml)** - Version pinning with manual approval
-- **[cert-manager-issuer.yaml](./samples/cert-manager-issuer.yaml)** - Example cert-manager Issuer setup
+- **[cert-manager-issuer.yaml](./samples/cert-manager-issuer.yaml)** - cert-manager trust chain (ClusterIssuer + root CA + Issuer)
 
 #### What the Addon Does
 

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -3,7 +3,7 @@
 # This file is invoked by Makefile targets with an action argument.
 #
 # Usage: hack/dev-env.sh <action>
-# Actions: create-clusters, install-olm, install-cert-manager, init-ocm, join-clusters, clean
+# Actions: create-clusters, install-olm, install-cert-manager, init-ocm, join-clusters, setup-mesh, clean
 
 set -euo pipefail
 
@@ -250,6 +250,47 @@ join_clusters() {
     kubectl --kubeconfig="${hub_kubeconfig}" get managedclustersets
 }
 
+setup_mesh() {
+    local hub_kubeconfig
+    hub_kubeconfig="$(kubeconfig_for "${HUB}")"
+
+    if [[ ! -f "${hub_kubeconfig}" ]]; then
+        err "Hub kubeconfig not found at ${hub_kubeconfig}. Run 'make deploy-addon' first."
+    fi
+
+    if kubectl --kubeconfig="${hub_kubeconfig}" get namespace mesh-system &>/dev/null; then
+        log "Namespace mesh-system already exists, skipping"
+    else
+        log "Creating namespace mesh-system"
+        kubectl --kubeconfig="${hub_kubeconfig}" create namespace mesh-system
+    fi
+
+    log "Waiting for cert-manager-cainjector to be ready..."
+    kubectl --kubeconfig="${hub_kubeconfig}" rollout status deployment/cert-manager-cainjector \
+        -n cert-manager --timeout=120s
+
+    log "Applying cert-manager trust chain (ClusterIssuer, root CA Certificate, Issuer)"
+    kubectl --kubeconfig="${hub_kubeconfig}" apply -f "${SCRIPT_DIR}/samples/cert-manager-issuer.yaml"
+
+    log "Waiting for ClusterIssuer to be ready..."
+    kubectl --kubeconfig="${hub_kubeconfig}" wait clusterissuer/mesh-selfsigned-issuer \
+        --for=condition=Ready --timeout=60s
+
+    log "Waiting for root CA Certificate to be issued..."
+    kubectl --kubeconfig="${hub_kubeconfig}" wait certificate/mesh-root-ca \
+        -n mesh-system --for=condition=Ready --timeout=120s
+
+    log "Waiting for CA-backed Issuer to be ready..."
+    kubectl --kubeconfig="${hub_kubeconfig}" wait issuer/mesh-root-ca \
+        -n mesh-system --for=condition=Ready --timeout=60s
+
+    log "Creating MultiClusterMesh CR"
+    kubectl --kubeconfig="${hub_kubeconfig}" apply -f "${SCRIPT_DIR}/samples/basic.yaml"
+
+    log "Mesh setup complete. The controller will now reconcile the mesh."
+    log "Monitor progress: kubectl --kubeconfig=${hub_kubeconfig} get multiclustermesh -n mesh-system"
+}
+
 clean() {
     log "Deleting Kind clusters..."
     for cluster in "${HUB}" "${CLUSTER1}" "${CLUSTER2}"; do
@@ -272,7 +313,8 @@ case "${ACTION}" in
     install-cert-manager)  install_cert_manager ;;
     init-ocm)              init_ocm ;;
     join-clusters)         join_clusters ;;
+    setup-mesh)            setup_mesh ;;
     clean)                 clean ;;
     *)
-        err "Unknown action: '${ACTION}'. Valid: create-clusters, install-olm, install-cert-manager, init-ocm, join-clusters, clean" ;;
+        err "Unknown action: '${ACTION}'. Valid: create-clusters, install-olm, install-cert-manager, init-ocm, join-clusters, setup-mesh, clean" ;;
 esac

--- a/samples/basic.yaml
+++ b/samples/basic.yaml
@@ -6,8 +6,7 @@ metadata:
 spec:
   # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
   # NOTE: Update this to match your ManagedClusterSet name
-  clusterSet: default
-
+  clusterSet: mesh-cluster-set
   # Minimal security configuration using cert-manager for trust
   security:
     trust:

--- a/samples/cert-manager-issuer.yaml
+++ b/samples/cert-manager-issuer.yaml
@@ -1,10 +1,51 @@
-# Example cert-manager Issuer to use with MultiClusterMesh
-# This must be created in the same namespace as the MultiClusterMesh resource
+# cert-manager trust chain for MultiClusterMesh
+#
+# Architecture:
+#   ClusterIssuer (self-signed) --> Certificate (root CA) --> Issuer (CA-backed)
+#
+# The self-signed ClusterIssuer bootstraps a root CA Certificate.
+# That Certificate's Secret backs a namespace-scoped Issuer, which the
+# MultiClusterMesh controller uses to mint intermediate CAs for each cluster.
+# This ensures all clusters share a common trust root.
 
+---
+# Step 1: Bootstrap issuer (self-signed, cluster-scoped)
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: mesh-selfsigned-issuer
+spec:
+  selfSigned: {}
+
+---
+# Step 2: Root CA certificate (signed by the bootstrap ClusterIssuer)
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mesh-root-ca
+  namespace: mesh-system
+spec:
+  isCA: true
+  commonName: Mesh Root CA
+  secretName: mesh-root-ca-secret
+  duration: 87600h   # 10 years
+  renewBefore: 720h  # 30 days
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: mesh-selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+
+---
+# Step 3: CA-backed Issuer (references the root CA secret)
+# This is the Issuer referenced by MultiClusterMesh spec.security.trust.certManager.issuerRef.name
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: mesh-root-ca
   namespace: mesh-system
 spec:
-  selfSigned: {}
+  ca:
+    secretName: mesh-root-ca-secret

--- a/samples/kind-dev.yaml
+++ b/samples/kind-dev.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: mesh.open-cluster-management.io/v1alpha1
-kind: MultiClusterMesh
-metadata:
-  name: my-mesh
-  namespace: multicluster-mesh-system
-spec:
-  clusterSet: mesh-cluster-set


### PR DESCRIPTION
Currently, after running 'make dev-env', users had to manually create
the mesh-system namespace, set up the cert-manager trust chain, and
apply the MultiClusterMesh CR. This PR adds a 'make setup-mesh' target
that automates all of it and chains it into the dev-env pipeline.