### PR TITLE
certificate: Set X.509 subject fields and SAN on Istio CA certificates

### DIFF
--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -19,6 +19,11 @@ type MultiClusterMesh struct {
 	Status MultiClusterMeshStatus `json:"status,omitempty"`
 }
 
+// GetTrustDomain returns the trust domain for this mesh, derived from the mesh name.
+func (m *MultiClusterMesh) GetTrustDomain() string {
+	return m.Name
+}
+
 // GetControlPlaneNamespace returns the control plane namespace, defaulting to "istio-system".
 func (m *MultiClusterMesh) GetControlPlaneNamespace() string {
 	if m.Spec.ControlPlane.Namespace == "" {

--- a/pkg/hub/mesh/certificate.go
+++ b/pkg/hub/mesh/certificate.go
@@ -5,18 +5,28 @@ import (
 	"fmt"
 )
 
-const maxOULength = 64
+const (
+	maxOULength    = 64
+	maxLabelLength = 63
+)
 
-// formatOU formats a cluster name for use as the X.509 Organizational Unit (OU) field.
-// If the name fits within the 64-character limit, it is returned as-is.
-// Otherwise, it is truncated to 55 characters and suffixed with a dash and the
-// first 8 hex characters of the SHA-256 hash of the full name (55 + 1 + 8 = 64).
 func formatOU(clusterName string) string {
-	if len(clusterName) <= maxOULength {
-		return clusterName
-	}
+	return truncateWithHash(clusterName, maxOULength)
+}
 
-	return fmt.Sprintf("%.55s-%.4x", clusterName, sha256.Sum256([]byte(clusterName)))
+func formatLabelValue(clusterName string) string {
+	return truncateWithHash(clusterName, maxLabelLength)
+}
+
+// truncateWithHash returns s as-is if it fits within maxLen.
+// Otherwise, it truncates to (maxLen - 9) characters and appends a dash
+// followed by the first 8 hex characters of the SHA-256 hash of the full string.
+func truncateWithHash(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	hash := fmt.Sprintf("%.4x", sha256.Sum256([]byte(s)))
+	return s[:maxLen-9] + "-" + hash
 }
 
 func certURI(clusterName, trustDomain string) string {

--- a/pkg/hub/mesh/certificate.go
+++ b/pkg/hub/mesh/certificate.go
@@ -3,7 +3,6 @@ package mesh
 import (
 	"crypto/sha256"
 	"fmt"
-	"strings"
 )
 
 const maxOULength = 63
@@ -21,8 +20,6 @@ func formatOU(clusterName string) string {
 	return clusterName[:54] + "-" + hash[:8]
 }
 
-// certDNSName generates the SAN DNS name for an Istio CA certificate.
-// Trailing dashes are stripped from the cluster name to produce a valid DNS name.
-func certDNSName(clusterName, trustDomain string) string {
-	return strings.TrimRight(clusterName, "-") + ".istio-ca." + trustDomain
+func certURI(clusterName, trustDomain string) string {
+	return "spiffe://" + trustDomain + "/cluster/" + clusterName + "/ca/istio-ca"
 }

--- a/pkg/hub/mesh/certificate.go
+++ b/pkg/hub/mesh/certificate.go
@@ -1,0 +1,28 @@
+package mesh
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+const maxOULength = 63
+
+// formatOU formats a cluster name for use as the X.509 Organizational Unit (OU) field.
+// If the name fits within the 63-character limit, it is returned as-is.
+// Otherwise, it is truncated to 54 characters and suffixed with a dash and the
+// first 8 hex characters of the SHA-256 hash of the full name (54 + 1 + 8 = 63).
+func formatOU(clusterName string) string {
+	if len(clusterName) <= maxOULength {
+		return clusterName
+	}
+
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(clusterName)))
+	return clusterName[:54] + "-" + hash[:8]
+}
+
+// certDNSName generates the SAN DNS name for an Istio CA certificate.
+// Trailing dashes are stripped from the cluster name to produce a valid DNS name.
+func certDNSName(clusterName, trustDomain string) string {
+	return strings.TrimRight(clusterName, "-") + ".istio-ca." + trustDomain
+}

--- a/pkg/hub/mesh/certificate.go
+++ b/pkg/hub/mesh/certificate.go
@@ -16,8 +16,7 @@ func formatOU(clusterName string) string {
 		return clusterName
 	}
 
-	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(clusterName)))
-	return clusterName[:55] + "-" + hash[:8]
+	return fmt.Sprintf("%.55s-%.4x", clusterName, sha256.Sum256([]byte(clusterName)))
 }
 
 func certURI(clusterName, trustDomain string) string {

--- a/pkg/hub/mesh/certificate.go
+++ b/pkg/hub/mesh/certificate.go
@@ -5,19 +5,19 @@ import (
 	"fmt"
 )
 
-const maxOULength = 63
+const maxOULength = 64
 
 // formatOU formats a cluster name for use as the X.509 Organizational Unit (OU) field.
-// If the name fits within the 63-character limit, it is returned as-is.
-// Otherwise, it is truncated to 54 characters and suffixed with a dash and the
-// first 8 hex characters of the SHA-256 hash of the full name (54 + 1 + 8 = 63).
+// If the name fits within the 64-character limit, it is returned as-is.
+// Otherwise, it is truncated to 55 characters and suffixed with a dash and the
+// first 8 hex characters of the SHA-256 hash of the full name (55 + 1 + 8 = 64).
 func formatOU(clusterName string) string {
 	if len(clusterName) <= maxOULength {
 		return clusterName
 	}
 
 	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(clusterName)))
-	return clusterName[:54] + "-" + hash[:8]
+	return clusterName[:55] + "-" + hash[:8]
 }
 
 func certURI(clusterName, trustDomain string) string {

--- a/pkg/hub/mesh/certificate_test.go
+++ b/pkg/hub/mesh/certificate_test.go
@@ -1,0 +1,91 @@
+package mesh
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestFormatOU(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		expected    string
+	}{
+		{
+			name:        "name up to 63 characters is used as-is",
+			clusterName: strings.Repeat("a", 63),
+			expected:    strings.Repeat("a", 63),
+		},
+		{
+			name:        "64 characters triggers truncation",
+			clusterName: strings.Repeat("a", 64),
+			expected:    strings.Repeat("a", 54) + "-" + hashPrefix(strings.Repeat("a", 64)),
+		},
+		{
+			name:        "long production name",
+			clusterName: "production-environment-kubernetes-cluster-us-east-2-deployment-pipeline-id-992384",
+			expected:    "production-environment-kubernetes-cluster-us-east-2-de-9cdc3049",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatOU(tc.clusterName)
+			if got != tc.expected {
+				t.Errorf("formatOU(%q) = %q, want %q", tc.clusterName, got, tc.expected)
+			}
+			if len(got) > maxOULength {
+				t.Errorf("formatOU(%q) produced %d characters, exceeds limit of %d", tc.clusterName, len(got), maxOULength)
+			}
+		})
+	}
+}
+
+func TestCertDNSName(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		trustDomain string
+		expected    string
+	}{
+		{
+			name:        "short cluster name",
+			clusterName: "dev-cluster",
+			trustDomain: "mesh.local",
+			expected:    "dev-cluster.istio-ca.mesh.local",
+		},
+		{
+			name:        "long cluster name preserves full name",
+			clusterName: "production-environment-kubernetes-cluster-us-east-2-deployment-pipeline-id-992384",
+			trustDomain: "company.internal",
+			expected:    "production-environment-kubernetes-cluster-us-east-2-deployment-pipeline-id-992384.istio-ca.company.internal",
+		},
+		{
+			name:        "trailing dash is stripped",
+			clusterName: "production-cluster-",
+			trustDomain: "company.internal",
+			expected:    "production-cluster.istio-ca.company.internal",
+		},
+		{
+			name:        "multiple trailing dashes are stripped",
+			clusterName: "production-cluster---",
+			trustDomain: "company.internal",
+			expected:    "production-cluster.istio-ca.company.internal",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := certDNSName(tc.clusterName, tc.trustDomain)
+			if got != tc.expected {
+				t.Errorf("certDNSName(%q, %q) = %q, want %q", tc.clusterName, tc.trustDomain, got, tc.expected)
+			}
+		})
+	}
+}
+
+func hashPrefix(s string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(s)))[:8]
+}

--- a/pkg/hub/mesh/certificate_test.go
+++ b/pkg/hub/mesh/certificate_test.go
@@ -43,6 +43,37 @@ func TestFormatOU(t *testing.T) {
 	}
 }
 
+func TestFormatLabelValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		expected    string
+	}{
+		{
+			name:        "name up to 63 characters is used as-is",
+			clusterName: strings.Repeat("a", 63),
+			expected:    strings.Repeat("a", 63),
+		},
+		{
+			name:        "long CI-generated name",
+			clusterName: "ci-managed-cluster-with-a-very-long-generated-name-that-exceeds-64-chars",
+			expected:    "ci-managed-cluster-with-a-very-long-generated-name-tha-1d71f97d",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatLabelValue(tc.clusterName)
+			if got != tc.expected {
+				t.Errorf("formatLabelValue(%q) = %q, want %q", tc.clusterName, got, tc.expected)
+			}
+			if len(got) > maxLabelLength {
+				t.Errorf("formatLabelValue(%q) produced %d characters, exceeds limit of %d", tc.clusterName, len(got), maxLabelLength)
+			}
+		})
+	}
+}
+
 func TestCertURI(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/hub/mesh/certificate_test.go
+++ b/pkg/hub/mesh/certificate_test.go
@@ -43,7 +43,7 @@ func TestFormatOU(t *testing.T) {
 	}
 }
 
-func TestCertDNSName(t *testing.T) {
+func TestCertURI(t *testing.T) {
 	tests := []struct {
 		name        string
 		clusterName string
@@ -54,33 +54,21 @@ func TestCertDNSName(t *testing.T) {
 			name:        "short cluster name",
 			clusterName: "dev-cluster",
 			trustDomain: "mesh.local",
-			expected:    "dev-cluster.istio-ca.mesh.local",
+			expected:    "spiffe://mesh.local/cluster/dev-cluster/ca/istio-ca",
 		},
 		{
 			name:        "long cluster name preserves full name",
 			clusterName: "production-environment-kubernetes-cluster-us-east-2-deployment-pipeline-id-992384",
 			trustDomain: "company.internal",
-			expected:    "production-environment-kubernetes-cluster-us-east-2-deployment-pipeline-id-992384.istio-ca.company.internal",
-		},
-		{
-			name:        "trailing dash is stripped",
-			clusterName: "production-cluster-",
-			trustDomain: "company.internal",
-			expected:    "production-cluster.istio-ca.company.internal",
-		},
-		{
-			name:        "multiple trailing dashes are stripped",
-			clusterName: "production-cluster---",
-			trustDomain: "company.internal",
-			expected:    "production-cluster.istio-ca.company.internal",
+			expected:    "spiffe://company.internal/cluster/production-environment-kubernetes-cluster-us-east-2-deployment-pipeline-id-992384/ca/istio-ca",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := certDNSName(tc.clusterName, tc.trustDomain)
+			got := certURI(tc.clusterName, tc.trustDomain)
 			if got != tc.expected {
-				t.Errorf("certDNSName(%q, %q) = %q, want %q", tc.clusterName, tc.trustDomain, got, tc.expected)
+				t.Errorf("certURI(%q, %q) = %q, want %q", tc.clusterName, tc.trustDomain, got, tc.expected)
 			}
 		})
 	}

--- a/pkg/hub/mesh/certificate_test.go
+++ b/pkg/hub/mesh/certificate_test.go
@@ -14,19 +14,19 @@ func TestFormatOU(t *testing.T) {
 		expected    string
 	}{
 		{
-			name:        "name up to 63 characters is used as-is",
-			clusterName: strings.Repeat("a", 63),
-			expected:    strings.Repeat("a", 63),
+			name:        "name up to 64 characters is used as-is",
+			clusterName: strings.Repeat("a", 64),
+			expected:    strings.Repeat("a", 64),
 		},
 		{
-			name:        "64 characters triggers truncation",
-			clusterName: strings.Repeat("a", 64),
-			expected:    strings.Repeat("a", 54) + "-" + hashPrefix(strings.Repeat("a", 64)),
+			name:        "65 characters triggers truncation",
+			clusterName: strings.Repeat("a", 65),
+			expected:    strings.Repeat("a", 55) + "-" + hashPrefix(strings.Repeat("a", 65)),
 		},
 		{
 			name:        "long production name",
 			clusterName: "production-environment-kubernetes-cluster-us-east-2-deployment-pipeline-id-992384",
-			expected:    "production-environment-kubernetes-cluster-us-east-2-de-9cdc3049",
+			expected:    "production-environment-kubernetes-cluster-us-east-2-dep-9cdc3049",
 		},
 	}
 

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -792,7 +792,7 @@ func (r *Reconciler) ensureCertificateForCluster(ctx context.Context, mesh *mesh
 			WithSubject(certmanagerapply.X509Subject().
 				WithOrganizations(mesh.Name).
 				WithOrganizationalUnits(formatOU(cluster.Name))).
-			WithDNSNames(certDNSName(cluster.Name, mesh.Name)).
+			WithURIs(certURI(cluster.Name, mesh.Name)).
 			WithIsCA(true).
 			WithUsages(
 				certmanagerv1.UsageDigitalSignature,

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -790,9 +790,9 @@ func (r *Reconciler) ensureCertificateForCluster(ctx context.Context, mesh *mesh
 			WithRenewBefore(metav1.Duration{Duration: 15 * Day}).
 			WithCommonName("Istio CA").
 			WithSubject(certmanagerapply.X509Subject().
-				WithOrganizations(mesh.Name).
+				WithOrganizations(mesh.GetTrustDomain()).
 				WithOrganizationalUnits(formatOU(cluster.Name))).
-			WithURIs(certURI(cluster.Name, mesh.Name)).
+			WithURIs(certURI(cluster.Name, mesh.GetTrustDomain())).
 			WithIsCA(true).
 			WithUsages(
 				certmanagerv1.UsageDigitalSignature,

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -424,7 +424,10 @@ func (r *Reconciler) cleanupManifestWorks(ctx context.Context, clusterSet string
 // are removed (e.g. when the issuer is cleared). Otherwise, only Certificates for clusters no longer in the
 // ClusterSet are removed.
 func (r *Reconciler) cleanupCertificates(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster, forceCleanupAll bool) error {
-	clusterNames := clusterNameSet(clusters)
+	labelValues := make(map[string]bool, len(clusters))
+	for _, c := range clusters {
+		labelValues[formatLabelValue(c.Name)] = true
+	}
 
 	certList := &certmanagerv1.CertificateList{}
 	if err := r.List(ctx, certList,
@@ -436,7 +439,7 @@ func (r *Reconciler) cleanupCertificates(ctx context.Context, mesh *meshv1alpha1
 
 	for _, cert := range certList.Items {
 		clusterName := cert.Labels[ClusterNameLabel]
-		if !forceCleanupAll && clusterNames[clusterName] {
+		if !forceCleanupAll && labelValues[clusterName] {
 			continue
 		}
 
@@ -882,6 +885,6 @@ func meshOwnedLabels(mesh *meshv1alpha1.MultiClusterMesh, clusterName string) ma
 		ClusterSetLabel:    mesh.Spec.ClusterSet,
 		MeshNameLabel:      mesh.Name,
 		MeshNamespaceLabel: mesh.Namespace,
-		ClusterNameLabel:   clusterName,
+		ClusterNameLabel:   formatLabelValue(clusterName),
 	}
 }

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -788,7 +788,11 @@ func (r *Reconciler) ensureCertificateForCluster(ctx context.Context, mesh *mesh
 				WithLabels(meshOwnedLabels(mesh, cluster.Name))).
 			WithDuration(metav1.Duration{Duration: 60 * Day}).
 			WithRenewBefore(metav1.Duration{Duration: 15 * Day}).
-			WithCommonName("Intermediate Istio CA").
+			WithCommonName("Istio CA").
+			WithSubject(certmanagerapply.X509Subject().
+				WithOrganizations(mesh.Name).
+				WithOrganizationalUnits(formatOU(cluster.Name))).
+			WithDNSNames(certDNSName(cluster.Name, mesh.Name)).
 			WithIsCA(true).
 			WithUsages(
 				certmanagerv1.UsageDigitalSignature,

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -513,18 +513,24 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				Expect(*ownerRef.BlockOwnerDeletion).To(BeTrue())
 			})
 
-			It("should set Subject with Organization and OrganizationalUnit", func() {
-				cert := expectCertificate(testNs, clusterName, "mesh-issuer")
+			It("should set Subject and URI SAN with truncated OU and full cluster name", func() {
+				longCluster := "ci-managed-cluster-with-a-very-long-generated-name-that-exceeds-64-chars"
+				Expect(k8sClient.Create(ctx, &clusterv1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: longCluster,
+						Labels: map[string]string{
+							meshcontroller.ClusterSetLabel: testClusterSet,
+						},
+					},
+				})).To(Succeed())
+
+				cert := expectCertificate(testNs, longCluster, "mesh-issuer")
 
 				Expect(cert.Spec.Subject).NotTo(BeNil())
 				Expect(cert.Spec.Subject.Organizations).To(ConsistOf(meshName))
-				Expect(cert.Spec.Subject.OrganizationalUnits).To(ConsistOf(clusterName))
-			})
+				Expect(cert.Spec.Subject.OrganizationalUnits).To(ConsistOf("ci-managed-cluster-with-a-very-long-generated-name-that-1d71f97d"))
 
-			It("should set URI SAN with trust domain and cluster name", func() {
-				cert := expectCertificate(testNs, clusterName, "mesh-issuer")
-
-				expectedSAN := "spiffe://" + meshName + "/cluster/" + clusterName + "/ca/istio-ca"
+				expectedSAN := "spiffe://" + meshName + "/cluster/" + longCluster + "/ca/istio-ca"
 				Expect(cert.Spec.URIs).To(ConsistOf(expectedSAN))
 			})
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -513,6 +513,21 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				Expect(*ownerRef.BlockOwnerDeletion).To(BeTrue())
 			})
 
+			It("should set Subject with Organization and OrganizationalUnit", func() {
+				cert := expectCertificate(testNs, clusterName, "mesh-issuer")
+
+				Expect(cert.Spec.Subject).NotTo(BeNil())
+				Expect(cert.Spec.Subject.Organizations).To(ConsistOf(meshName))
+				Expect(cert.Spec.Subject.OrganizationalUnits).To(ConsistOf(clusterName))
+			})
+
+			It("should set DNS SAN with cluster name and trust domain", func() {
+				cert := expectCertificate(testNs, clusterName, "mesh-issuer")
+
+				expectedSAN := clusterName + ".istio-ca." + meshName
+				Expect(cert.Spec.DNSNames).To(ConsistOf(expectedSAN))
+			})
+
 			It("should restore Certificate spec when externally modified", func() {
 				cert := expectCertificate(testNs, clusterName, "mesh-issuer")
 
@@ -525,7 +540,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 						return ""
 					}
 					return c.Spec.CommonName
-				}).Should(Equal("Intermediate Istio CA"))
+				}).Should(Equal("Istio CA"))
 			})
 
 			It("should recreate Certificate when it is externally deleted", func() {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -521,11 +521,11 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				Expect(cert.Spec.Subject.OrganizationalUnits).To(ConsistOf(clusterName))
 			})
 
-			It("should set DNS SAN with cluster name and trust domain", func() {
+			It("should set URI SAN with trust domain and cluster name", func() {
 				cert := expectCertificate(testNs, clusterName, "mesh-issuer")
 
-				expectedSAN := clusterName + ".istio-ca." + meshName
-				Expect(cert.Spec.DNSNames).To(ConsistOf(expectedSAN))
+				expectedSAN := "spiffe://" + meshName + "/cluster/" + clusterName + "/ca/istio-ca"
+				Expect(cert.Spec.URIs).To(ConsistOf(expectedSAN))
 			})
 
 			It("should restore Certificate spec when externally modified", func() {


### PR DESCRIPTION
Configure the cert-manager Certificate with Organization (trust domain),
Organizational Unit (cluster name with deterministic truncation for names exceeding 63 chars),
and a URI SAN for full cluster traceability.

Fixes #65 