### PR TITLE
Update dev-env to not install the mesh components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ export DEV_KUBE_DIR K8S_VERSION OLM_VERSION CERT_MANAGER_VERSION
 export KIND CLUSTERADM
 
 .PHONY: dev-env
-dev-env: create-clusters install-olm install-cert-manager init-ocm join-clusters deploy-addon setup-mesh ## Provision full dev environment (Kind + OCM + addon + mesh)
+dev-env: create-clusters install-olm install-cert-manager init-ocm join-clusters deploy-addon ## Provision full dev environment (Kind + OCM + addon)
 
 .PHONY: create-clusters
 create-clusters: $(KIND) ## Create 3 Kind clusters (hub, cluster1, cluster2)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ kubectl create namespace multicluster-mesh-system
 
 #### Local Kind+OCM Dev Environment
 
-Provisions a complete multi-cluster topology (1 hub + 2 managed clusters) using Kind and OCM, then builds and deploys the addon controller with a ready-to-use mesh:
+Provisions a complete multi-cluster topology (1 hub + 2 managed clusters) using Kind and OCM, then builds and deploys the addon controller:
 
 ```bash
 make dev-env
@@ -154,8 +154,6 @@ See the [Kind known issues](https://kind.sigs.k8s.io/docs/user/known-issues/#pod
 ### Usage
 
 #### Quick Start
-
-> **Note:** If you used `make dev-env`, the mesh is already set up. The following manual steps are for deploying on existing clusters.
 
 1. Create a namespace for your mesh resources:
 ```bash


### PR DESCRIPTION
One of the previous PRs has updated `make dev-env` to automatically invoke `setup-mesh`, which installs mesh-related resources such as the cert-manager trust chain and the `MultiClusterMesh` CR.

However, `make test-e2e` expects a clean cluster state and performs its own setup. Automatically creating `MultiClusterMesh` resources as part of `dev-env` was interfering with the e2e tests.

This PR removes the automatic `setup-mesh` invocation from `make dev-env` command. Users who want a fully configured development env can run:

```
make dev-env
make setup-mesh
```

This keeps cluster provisioning separate from mesh configuration and ensures a clean starting point for e2e tests.