### PR TITLE
Simplify dev-clean-meshes and replace ClusterIssuer with Issuer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,9 +284,6 @@ setup-mesh: ## Create cert-manager trust chain, mesh-system namespace, and Multi
 dev-clean-meshes: ## Delete all mesh resources, cert-manager trust chain, and mesh-system namespace
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete multiclustermeshes -A --all --ignore-not-found=true
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete manifestwork -A -l app.kubernetes.io/managed-by=multicluster-mesh-addon --ignore-not-found=true
-	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete issuer mesh-root-ca -n mesh-system --ignore-not-found=true
-	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete certificate mesh-root-ca -n mesh-system --ignore-not-found=true
-	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete clusterissuer mesh-selfsigned-issuer --ignore-not-found=true
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete namespace mesh-system --ignore-not-found=true
 
 .PHONY: dev-clean

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ See the [Kind known issues](https://kind.sigs.k8s.io/docs/user/known-issues/#pod
 kubectl create namespace mesh-system
 ```
 
-2. Create the cert-manager trust chain (ClusterIssuer, root CA Certificate, and CA-backed Issuer):
+2. Create the cert-manager trust chain (self-signed Issuer, root CA Certificate, and CA-backed Issuer):
 ```bash
 kubectl apply -f samples/cert-manager-issuer.yaml
 ```
@@ -178,7 +178,7 @@ For more configuration options, see the [samples](./samples/) directory:
 - **[complete.yaml](./samples/complete.yaml)** - All available fields with documentation
 - **[openshift.yaml](./samples/openshift.yaml)** - OpenShift-specific configuration
 - **[pinned-version.yaml](./samples/pinned-version.yaml)** - Version pinning with manual approval
-- **[cert-manager-issuer.yaml](./samples/cert-manager-issuer.yaml)** - cert-manager trust chain (ClusterIssuer + root CA + Issuer)
+- **[cert-manager-issuer.yaml](./samples/cert-manager-issuer.yaml)** - cert-manager trust chain (self-signed Issuer + root CA + CA-backed Issuer)
 
 #### What the Addon Does
 

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -269,12 +269,12 @@ setup_mesh() {
     kubectl --kubeconfig="${hub_kubeconfig}" rollout status deployment/cert-manager-cainjector \
         -n cert-manager --timeout=120s
 
-    log "Applying cert-manager trust chain (ClusterIssuer, root CA Certificate, Issuer)"
+    log "Applying cert-manager trust chain (self-signed Issuer, root CA Certificate, CA-backed Issuer)"
     kubectl --kubeconfig="${hub_kubeconfig}" apply -f "${SCRIPT_DIR}/samples/cert-manager-issuer.yaml"
 
-    log "Waiting for ClusterIssuer to be ready..."
-    kubectl --kubeconfig="${hub_kubeconfig}" wait clusterissuer/mesh-selfsigned-issuer \
-        --for=condition=Ready --timeout=60s
+    log "Waiting for bootstrap Issuer to be ready..."
+    kubectl --kubeconfig="${hub_kubeconfig}" wait issuer/mesh-selfsigned-issuer \
+        -n mesh-system --for=condition=Ready --timeout=60s
 
     log "Waiting for root CA Certificate to be issued..."
     kubectl --kubeconfig="${hub_kubeconfig}" wait certificate/mesh-root-ca \

--- a/samples/cert-manager-issuer.yaml
+++ b/samples/cert-manager-issuer.yaml
@@ -1,24 +1,25 @@
 # cert-manager trust chain for MultiClusterMesh
 #
 # Architecture:
-#   ClusterIssuer (self-signed) --> Certificate (root CA) --> Issuer (CA-backed)
+#   Issuer (self-signed) --> Certificate (root CA) --> Issuer (CA-backed)
 #
-# The self-signed ClusterIssuer bootstraps a root CA Certificate.
-# That Certificate's Secret backs a namespace-scoped Issuer, which the
+# The self-signed Issuer bootstraps a root CA Certificate.
+# That Certificate's Secret backs a CA-backed Issuer, which the
 # MultiClusterMesh controller uses to mint intermediate CAs for each cluster.
 # This ensures all clusters share a common trust root.
 
 ---
-# Step 1: Bootstrap issuer (self-signed, cluster-scoped)
+# Step 1: Bootstrap issuer (self-signed)
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: mesh-selfsigned-issuer
+  namespace: mesh-system
 spec:
   selfSigned: {}
 
 ---
-# Step 2: Root CA certificate (signed by the bootstrap ClusterIssuer)
+# Step 2: Root CA certificate (signed by the bootstrap Issuer)
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -35,7 +36,7 @@ spec:
     size: 256
   issuerRef:
     name: mesh-selfsigned-issuer
-    kind: ClusterIssuer
+    kind: Issuer
     group: cert-manager.io
 
 ---


### PR DESCRIPTION
Replace the cluster-scoped ClusterIssuer with a namespace-scoped self-signed Issuer.
The ClusterIssuer was unnecessary since the bootstrap issuer only signs a single Certificate in mesh-system.
This simplifies dev-clean-meshes to just deleting meshes, ManifestWorks, and the namespace.