### PR TITLE
Add verify-gen to catch stale generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,14 +80,20 @@ gen-rbac: ## Generate RBAC manifests from controller annotations
 .PHONY: gen
 gen: gen-code gen-crds gen-rbac ## Generate code, CRDs, and RBAC
 
-# TODO: Add verify-gen target to check if generated files are up to date (CI/pre-commit)
+.PHONY: verify-gen
+verify-gen: gen ## Verify generated files are up to date
+	@if ! git diff --quiet HEAD -- config/ pkg/apis/**/zz_generated.*.go config/deploy/base/clusterrole.yaml; then \
+		echo "Generated files are out of date. Stage and commit the changes shown below."; \
+		git diff --stat HEAD; \
+		exit 1; \
+	fi
 
 .PHONY: vet
 vet: ## Run go vet
 	go vet ./...
 
 .PHONY: verify
-verify: verify-gofmt verify-modules vet ## Verify code passes all checks without modifying files
+verify: verify-gofmt verify-modules verify-gen vet ## Run all checks (may regenerate files)
 
 .PHONY: verify-gofmt
 verify-gofmt: ## Verify code is formatted correctly

--- a/config/crd/mesh.open-cluster-management.io_multiclustermeshes.yaml
+++ b/config/crd/mesh.open-cluster-management.io_multiclustermeshes.yaml
@@ -98,11 +98,14 @@ spec:
                     description: Discovery defines the endpoint discovery configuration
                     properties:
                       tokenValidity:
-                        default: 1m
+                        default: 360h
                         description: |-
                           TokenValidity defines how long discovery tokens are valid
-                          Supports hours (h), days (d), weeks (w), or months (m)
+                          Supports hours (h), minutes (m), seconds (s). If unset, defaults to 360h
                         type: string
+                        x-kubernetes-validations:
+                        - message: TokenValidity must be at least 10 minutes
+                          rule: duration(self) >= duration('10m')
                     type: object
                   trust:
                     description: Trust defines the mTLS trust configuration


### PR DESCRIPTION
Add a verify-gen target that runs make gen and checks for uncommitted diffs in generated files (CRDs, deepcopy, RBAC).
Added to the verify chain, so prow catches drift automatically.

Also regenerates the CRD which drifted when #127 changed TokenValidity from string to metav1.Duration.

Closes #84