### PR TITLE
Enforce immutability and non-empty validation for spec.clusterSet

### DIFF
--- a/chart/crds/mesh.open-cluster-management.io_multiclustermeshes.yaml
+++ b/chart/crds/mesh.open-cluster-management.io_multiclustermeshes.yaml
@@ -43,7 +43,11 @@ spec:
               clusterSet:
                 description: ClusterSet references the ACM ManagedClusterSet that
                   defines cluster membership
+                minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: spec.clusterSet is immutable
+                  rule: self == oldSelf
               controlPlane:
                 description: ControlPlane defines the target configuration for the
                   mesh control plane

--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -36,6 +36,8 @@ func (m *MultiClusterMesh) GetControlPlaneNamespace() string {
 type MultiClusterMeshSpec struct {
 	// ClusterSet references the ACM ManagedClusterSet that defines cluster membership
 	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.clusterSet is immutable"
 	ClusterSet string `json:"clusterSet"`
 
 	// ControlPlane defines the target configuration for the mesh control plane

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -408,6 +408,29 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			expectOperatorManifestWork(clusterName)
 		})
 
+		When("spec.clusterSet is empty", func() {
+			It("should reject creation", func() {
+				mesh := &meshv1alpha1.MultiClusterMesh{
+					ObjectMeta: metav1.ObjectMeta{Name: meshName + "-empty", Namespace: testNs},
+					Spec:       meshv1alpha1.MultiClusterMeshSpec{ClusterSet: ""},
+				}
+				err := k8sClient.Create(ctx, mesh)
+				Expect(err).To(HaveOccurred(), "expected validation error for empty clusterSet")
+				Expect(errors.IsInvalid(err)).To(BeTrue())
+			})
+		})
+
+		When("spec.clusterSet is changed on update", func() {
+			It("should reject the update", func() {
+				mesh := &meshv1alpha1.MultiClusterMesh{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+				mesh.Spec.ClusterSet = "different-set"
+				err := k8sClient.Update(ctx, mesh)
+				Expect(err).To(HaveOccurred(), "expected validation error when updating the clusterSet")
+				Expect(errors.IsInvalid(err)).To(BeTrue())
+			})
+		})
+
 		It("should allow two meshes with different control plane namespaces", func() {
 			util.CreateMultiClusterMesh(ctx, k8sClient, otherMesh, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
 				ControlPlane: meshv1alpha1.ControlPlaneConfig{Namespace: "istio-system-2"},


### PR DESCRIPTION
A Mesh CR should not be allowed to switch ClusterSets after creation, since doing so can orphan ManifestWorks, certificates, and discovery tokens associated with the original ClusterSet.

This PR adds CEL validation rules that:
* Reject empty values using `MinLength=1`
* Prevent updates using `self == oldSelf`

Fixes: https://github.com/stolostron/multicluster-mesh-addon/issues/97