### PR TITLE
Limit mesh name to 63 characters via CEL validation

### DIFF
--- a/chart/crds/mesh.open-cluster-management.io_multiclustermeshes.yaml
+++ b/chart/crds/mesh.open-cluster-management.io_multiclustermeshes.yaml
@@ -287,6 +287,9 @@ spec:
                 x-kubernetes-list-type: map
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name must not exceed 63 characters
+          rule: size(self.metadata.name) <= 63
     served: true
     storage: true
     subresources:

--- a/docs/design.md
+++ b/docs/design.md
@@ -120,6 +120,7 @@ The MVP supports the [Multi-Primary Multi-Network] mesh topology. This aligns wi
 ## Custom Resource
 
 `MultiClusterMesh` is a namespaced resource. The namespace provides tenant isolation on the hub.
+The resource name (`metadata.name`) is limited to 63 characters because it is used in X.509 certificate subject fields and Kubernetes label values.
 
 ### Key Fields
 

--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -12,6 +12,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:subresource:status
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63",message="metadata.name must not exceed 63 characters"
 
 // MultiClusterMesh represents a multi-cluster service mesh configuration
 type MultiClusterMesh struct {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -437,6 +437,19 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			expectOperatorManifestWork(clusterName)
 		})
 
+		When("metadata.name exceeds 63 characters", func() {
+			It("should reject creation", func() {
+				longName := "a-mesh-name-that-is-way-too-long-and-exceeds-the-sixty-three-character-limit"
+				mesh := &meshv1alpha1.MultiClusterMesh{
+					ObjectMeta: metav1.ObjectMeta{Name: longName, Namespace: testNs},
+					Spec:       meshv1alpha1.MultiClusterMeshSpec{ClusterSet: testClusterSet},
+				}
+				err := k8sClient.Create(ctx, mesh)
+				Expect(err).To(HaveOccurred(), "expected validation error for long name")
+				Expect(errors.IsInvalid(err)).To(BeTrue())
+			})
+		})
+
 		When("spec.clusterSet is empty", func() {
 			It("should reject creation", func() {
 				mesh := &meshv1alpha1.MultiClusterMesh{


### PR DESCRIPTION
The mesh name is used in X.509 certificate subject fields (Organization, OU) and Kubernetes label values, all of which have a 63-64 character limit.
Names exceeding 63 chars would fail at label creation time with a confusing error.
Validate early with a clear message instead.