### PR TITLE
Fix update-test-crds to ensure modules are downloaded before querying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,8 @@ test: ## Run unit tests
 .PHONY: update-test-crds
 update-test-crds: deps ## Update test CRDs from OCM API, managed-serviceaccount and cert-manager dependencies
 	@echo "Updating test CRDs from open-cluster-management.io/api..."
-	@OCM_API_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/api); \
+	@set -e; \
+	OCM_API_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/api); \
 	mkdir -p $(TEST_CRD_DIR)/ocm; \
 	echo "Copying CRDs from $$OCM_API_PATH..."; \
 	cp -v $$OCM_API_PATH/cluster/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
@@ -139,12 +140,14 @@ update-test-crds: deps ## Update test CRDs from OCM API, managed-serviceaccount 
 	cp -v $$OCM_API_PATH/work/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	echo "Test CRDs updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from open-cluster-management.io/managed-serviceaccount..."
-	@OCM_MSA_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/managed-serviceaccount); \
+	@set -e; \
+	OCM_MSA_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/managed-serviceaccount); \
 	echo "Copying CRDs from $$OCM_MSA_PATH..."; \
 	cp -v $$OCM_MSA_PATH/charts/managed-serviceaccount/crds/*.yaml $(TEST_CRD_DIR)/ocm/; \
 	echo "Test CRDs for MSA updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from cert-manager..."
-	@CERTMANAGER_PATH=$$(go list -m -f '{{.Dir}}' github.com/cert-manager/cert-manager); \
+	@set -e; \
+	CERTMANAGER_PATH=$$(go list -m -f '{{.Dir}}' github.com/cert-manager/cert-manager); \
 	mkdir -p $(TEST_CRD_DIR)/cert-manager; \
 	echo "Copying CRDs from $$CERTMANAGER_PATH..."; \
 	cp -v $$CERTMANAGER_PATH/deploy/crds/cert-manager.io_certificates.yaml $(TEST_CRD_DIR)/cert-manager/ 2>/dev/null || true; \

--- a/Makefile
+++ b/Makefile
@@ -129,14 +129,9 @@ test: ## Run unit tests
 	go test -short ./pkg/...
 
 .PHONY: update-test-crds
-update-test-crds: ## Update test CRDs from OCM API, managed-serviceaccount and cert-manager dependencies
+update-test-crds: deps ## Update test CRDs from OCM API, managed-serviceaccount and cert-manager dependencies
 	@echo "Updating test CRDs from open-cluster-management.io/api..."
-	@OCM_API_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' open-cluster-management.io/api 2>/dev/null); \
-	if [ -z "$$OCM_API_PATH" ]; then \
-		echo "Error: open-cluster-management.io/api not found in go.mod"; \
-		echo "Run: go mod download open-cluster-management.io/api"; \
-		exit 1; \
-	fi; \
+	@OCM_API_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/api); \
 	mkdir -p $(TEST_CRD_DIR)/ocm; \
 	echo "Copying CRDs from $$OCM_API_PATH..."; \
 	cp -v $$OCM_API_PATH/cluster/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
@@ -144,22 +139,12 @@ update-test-crds: ## Update test CRDs from OCM API, managed-serviceaccount and c
 	cp -v $$OCM_API_PATH/work/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	echo "Test CRDs updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from open-cluster-management.io/managed-serviceaccount..."
-	@OCM_MSA_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' open-cluster-management.io/managed-serviceaccount 2>/dev/null); \
-	if [ -z "$$OCM_MSA_PATH" ]; then \
-		echo "Error: open-cluster-management.io/managed-serviceaccount not found in go.mod"; \
-		echo "Run: go mod download open-cluster-management.io/managed-serviceaccount"; \
-		exit 1; \
-	fi; \
+	@OCM_MSA_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/managed-serviceaccount); \
 	echo "Copying CRDs from $$OCM_MSA_PATH..."; \
 	cp -v $$OCM_MSA_PATH/charts/managed-serviceaccount/crds/*.yaml $(TEST_CRD_DIR)/ocm/; \
 	echo "Test CRDs for MSA updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from cert-manager..."
-	@CERTMANAGER_PATH=$$(go list -mod=mod -m -f '{{.Dir}}' github.com/cert-manager/cert-manager 2>/dev/null); \
-	if [ -z "$$CERTMANAGER_PATH" ]; then \
-		echo "Error: github.com/cert-manager/cert-manager not found in go.mod"; \
-		echo "Run: go mod download github.com/cert-manager/cert-manager"; \
-		exit 1; \
-	fi; \
+	@CERTMANAGER_PATH=$$(go list -m -f '{{.Dir}}' github.com/cert-manager/cert-manager); \
 	mkdir -p $(TEST_CRD_DIR)/cert-manager; \
 	echo "Copying CRDs from $$CERTMANAGER_PATH..."; \
 	cp -v $$CERTMANAGER_PATH/deploy/crds/cert-manager.io_certificates.yaml $(TEST_CRD_DIR)/cert-manager/ 2>/dev/null || true; \


### PR DESCRIPTION
The update-test-crds target failed in CI when the Go module cache was empty because go list couldn't locate module directories. The error checking logic was misleading - it suggested modules weren't in go.mod when they actually weren't downloaded yet.

Changes:
- Add deps prerequisite to ensure go mod download runs first
- Remove -mod=mod flag (unnecessary after deps)
- Remove error suppression (2>/dev/null) for clearer failure messages
- Remove manual error checks - go list now fails clearly if needed