### PR TITLE
Skip E2E tests when only documentation files change

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "frontend/docs/**"
 
 jobs:
   e2e:


### PR DESCRIPTION
Add paths-ignore to pr-e2e workflow to skip CI runs when PRs only modify markdown files or docs directories, reducing unnecessary resource usage.