### PR TITLE
Fix stack trace in integration test logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.7
 
 require (
 	github.com/cert-manager/cert-manager v1.20.2
+	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/openshift/library-go v0.0.0-20260318142011-72bf34f474bc
@@ -40,7 +41,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.4 // indirect

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -76,6 +77,8 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	ctrl.SetLogger(logr.Discard())
 
 	ctx, cancel = context.WithCancel(context.Background())
 


### PR DESCRIPTION
This PR fixes the stack trace seen in [integration test logs](https://github.com/stolostron/multicluster-mesh-addon/pull/165#issuecomment-4789318531) and sets the controller-runtime logger to logr.Discard() to suppress internal operational messages (e.g. "Stopping and waiting for caches") that clutter test output. Our controller logs via klog directly, so no useful output is lost.