### PR TITLE
Update Dockerfiles to follow submariner-addon pattern

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,8 +1,10 @@
-# using registry.ci.openshift.org instead of brew.registry.redhat.io to avoid authorization
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25 AS builder
+
 WORKDIR /go/src/github.com/stolostron/multicluster-mesh-addon
 COPY . .
-RUN make build
+# openshift-golang-builder sets GOFLAGS=-mod=vendor by default, but this repo doesn't use vendoring.
+# Override with -mod=mod to use Go modules from the module cache instead.
+RUN make GO_BUILD_FLAGS=-mod=mod build
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ test-e2e: ## Run e2e tests against dev-env clusters (requires make dev-env)
 
 .PHONY: build
 build: $(BIN_DIR) ## Build addon binary
-	CGO_ENABLED=0 go build -buildvcs=false -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/multicluster-mesh-addon .
+	CGO_ENABLED=0 go build $(GO_BUILD_FLAGS) -buildvcs=false -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/multicluster-mesh-addon .
 
 .PHONY: all
 all: build test


### PR DESCRIPTION
Changes:
- Dockerfile: Use UBI9 minimal base instead of scratch, add metadata labels, LICENSE file, and standard USER 1001
- Dockerfile.konflux: New file for Konflux builds using brew golang builder with -mod=mod override to bypass vendor mode requirement
- Makefile: Add GO_BUILD_FLAGS support to build target for Dockerfile.konflux

Both Dockerfiles now follow Red Hat container best practices matching submariner-addon's structure.