### PR TITLE
Add Konflux Tekton pipeline configurations for ACM 5.1

### DIFF
--- a/.tekton/multicluster-mesh-addon-acm-51-pull-request.yaml
+++ b/.tekton/multicluster-mesh-addon-acm-51-pull-request.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-mesh-addon?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: release-acm-51
+    appstudio.openshift.io/component: multicluster-mesh-addon-acm-51
+    pipelines.appstudio.openshift.io/type: build
+  name: multicluster-mesh-addon-acm-51-on-pull-request
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/multicluster-mesh-addon-acm-51:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: build-platforms
+      value:
+        - linux/x86_64
+    - name: dockerfile
+      value: Dockerfile.konflux
+    - name: path-context
+      value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "."}]'
+    - name: build-source-image
+      value: "true"
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicluster-mesh-addon-acm-51
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/stolostron/konflux-build-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common.yaml
+status: {}

--- a/.tekton/multicluster-mesh-addon-acm-51-push.yaml
+++ b/.tekton/multicluster-mesh-addon-acm-51-push.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/multicluster-mesh-addon?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: release-acm-51
+    appstudio.openshift.io/component: multicluster-mesh-addon-acm-51
+    pipelines.appstudio.openshift.io/type: build
+  name: multicluster-mesh-addon-acm-51-on-push
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/multicluster-mesh-addon-acm-51:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/ppc64le
+        - linux/s390x
+        - linux/arm64
+    - name: dockerfile
+      value: Dockerfile.konflux
+    - name: path-context
+      value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "."}]'
+    - name: build-source-image
+      value: "true"
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-multicluster-mesh-addon-acm-51
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/stolostron/konflux-build-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common.yaml
+status: {}


### PR DESCRIPTION
Add Pipelines-as-Code configurations for automated builds:
- Pull request pipeline: x86_64 only, 5-day image expiry
- Push pipeline: multi-arch (x86_64, ppc64le, s390x, arm64)

Both use Dockerfile.konflux and the stolostron-common-build-pipeline which includes hermetic builds, dependency prefetching, SAST scanning, and source image generation.