### PR TITLE
Add ClusterManagementAddOn resource and E2E test

### DIFF
--- a/chart/templates/clustermanagementaddon.yaml
+++ b/chart/templates/clustermanagementaddon.yaml
@@ -1,0 +1,10 @@
+apiVersion: addon.open-cluster-management.io/v1beta1
+kind: ClusterManagementAddOn
+metadata:
+  name: multicluster-mesh-addon
+spec:
+  addOnMeta:
+    displayName: Multi-Cluster Mesh Add-on
+    description: "Hub-side controller for orchestrating multi-cluster Istio service mesh deployments"
+  installStrategy:
+    type: Manual

--- a/docs/design.md
+++ b/docs/design.md
@@ -31,6 +31,8 @@ The add-on follows OCM's hub-and-spoke model:
 - **Hub**: The Mesh Add-on controller watches `MultiClusterMesh` resources and creates [ManifestWorks][ManifestWork], orchestrates cert-manager and ManagedServiceAccount
 - **Spoke** (managed clusters): Receives ManifestWorks from the hub, runs the Sail/OSSM operator and Istio control plane
 
+A [ClusterManagementAddOn] resource is deployed to register this addon with OCM's addon manager, but the addon uses manual installation strategy and does not leverage the framework's lifecycle management features (auto-deployment, per-cluster enable/disable via `ManagedClusterAddOn`).
+
 ```mermaid
 flowchart TD
     subgraph Hub Cluster
@@ -243,7 +245,7 @@ ArgoCD with ApplicationSets is the recommended approach for managing Istio confi
 
 **Phase 2 (Future)**: "Full" approach - the add-on also manages Istio custom resources centrally, automating topology configuration and enforcing consistency.
 
-Potential additions include ACM addon lifecycle integration (i.e. via `ClusterManagementAddOn` / `ManagedClusterAddOn`) and observability stack management.
+Potential additions include observability stack management and full addon framework integration (leveraging `ManagedClusterAddOn` for per-cluster enable/disable).
 
 <!-- Reference links -->
 [OCM]: https://open-cluster-management.io/
@@ -254,6 +256,7 @@ Potential additions include ACM addon lifecycle integration (i.e. via `ClusterMa
 [ManagedClusterSet]: https://open-cluster-management.io/docs/concepts/cluster-inventory/managedclusterset/
 [ClusterClaim]: https://open-cluster-management.io/docs/concepts/cluster-inventory/clusterclaim/
 [ManagedClusterView]: https://github.com/stolostron/cluster-lifecycle-api
+[ClusterManagementAddOn]: https://open-cluster-management.io/docs/concepts/addon/#clustermanagementaddon
 [Plug-in CA]: https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/
 [Multi-Primary Multi-Network]: https://istio.io/latest/docs/setup/install/multicluster/multi-primary_multi-network/
 [#72]: https://github.com/stolostron/multicluster-mesh-addon/issues/72

--- a/test/e2e/mesh_lifecycle_test.go
+++ b/test/e2e/mesh_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -28,6 +29,17 @@ const (
 )
 
 var clusters = []string{"cluster1", "cluster2"}
+
+var _ = Describe("Addon registration", func() {
+	It("should have ClusterManagementAddOn registered", func(ctx SpecContext) {
+		cmao := &addonv1beta1.ClusterManagementAddOn{}
+		err := hubClient.Get(ctx, key.Of("multicluster-mesh-addon"), cmao)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cmao.Spec.AddOnMeta.DisplayName).To(Equal("Multi-Cluster Mesh Add-on"))
+		Expect(cmao.Spec.AddOnMeta.Description).To(Equal("Hub-side controller for orchestrating multi-cluster Istio service mesh deployments"))
+		Expect(cmao.Spec.InstallStrategy.Type).To(Equal(addonv1beta1.AddonInstallStrategyManual))
+	})
+})
 
 var _ = Describe("Controller health", func() {
 	It("should have the controller deployment available", func(ctx SpecContext) {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
@@ -47,6 +48,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 		workv1.Install,
 		operatorsv1.AddToScheme,
 		operatorsv1alpha1.AddToScheme,
+		addonv1beta1.Install,
 	)
 
 	hubKubeconfig := env("HUB_KUBECONFIG", ".kube/hub.config")


### PR DESCRIPTION
Adds ClusterManagementAddOn resource to register the addon with OCM's addon-manager. The resource is deployed via Helm and declares this as a hub-only addon with manual installation strategy.

- Set installStrategy.type=Manual (no auto-deployment to clusters)
- Add E2E test to verify ClusterManagementAddOn is created with correct metadata