### PR TITLE
Fix flaky E2E test by increasing spoke cleanup timeout

### DIFF
--- a/test/e2e/mesh_lifecycle_test.go
+++ b/test/e2e/mesh_lifecycle_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -144,7 +145,10 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 
 		Step("Verifying Subscriptions are removed from spoke clusters")
 		for _, spokeClient := range spokeClients {
-			util.ExpectResourceDeleted(ctx, spokeClient, &operatorsv1alpha1.Subscription{}, meshcontroller.OperatorNameSail, meshcontroller.DefaultOperatorNs)
+			// Spoke-side cleanup depends on the OCM work agent processing the
+			// ManifestWork deletion and OLM processing any Subscription finalizers,
+			// which can take longer than the default timeout in CI.
+			util.ExpectResourceDeleted(ctx, spokeClient, &operatorsv1alpha1.Subscription{}, meshcontroller.OperatorNameSail, meshcontroller.DefaultOperatorNs, 2*time.Minute)
 		}
 	})
 })

--- a/test/util/k8s.go
+++ b/test/util/k8s.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -69,9 +70,14 @@ func DeleteResource(ctx context.Context, k8sClient client.Client, obj client.Obj
 }
 
 // ExpectResourceDeleted waits for a resource to be fully removed (e.g. after a side-effect deletion by a controller).
-func ExpectResourceDeleted(ctx context.Context, k8sClient client.Client, obj client.Object, name, namespace string) {
-	Eventually(func() bool {
+// An optional timeout overrides the default Eventually timeout.
+func ExpectResourceDeleted(ctx context.Context, k8sClient client.Client, obj client.Object, name, namespace string, timeout ...time.Duration) {
+	e := Eventually(func() bool {
 		err := k8sClient.Get(ctx, key.Of(name, namespace), obj)
 		return errors.IsNotFound(err)
-	}).Should(BeTrue())
+	})
+	if len(timeout) > 0 {
+		e = e.WithTimeout(timeout[0])
+	}
+	e.Should(BeTrue())
 }


### PR DESCRIPTION
The "cleans up resources on mesh deletion" e2e test was timing out waiting for OLM Subscriptions to be removed from spoke clusters. Spoke-side cleanup depends on the OCM work agent noticing the ManifestWork deletion and OLM processing Subscription finalizers, which can exceed the default 30s timeout on resource-constrained CI runners. This PR bumps the timeout to 2 minutes for spoke resource checks.