### PR TITLE
Remove hardcoded namespace from the manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,12 @@ kubectl create namespace mesh-system
 
 2. Create the cert-manager trust chain (self-signed Issuer, root CA Certificate, and CA-backed Issuer):
 ```bash
-kubectl apply -f samples/cert-manager-issuer.yaml
+kubectl apply -n mesh-system -f samples/cert-manager-issuer.yaml
 ```
 
 3. Deploy a basic MultiClusterMesh:
 ```bash
-kubectl apply -f samples/basic.yaml
+kubectl apply -n mesh-system -f samples/basic.yaml
 ```
 
 > **Note:** The `basic.yaml` sample uses `clusterSet: mesh-cluster-set`. Update this field to match your actual ManagedClusterSet name as needed.

--- a/frontend/DEV-INSTALL.md
+++ b/frontend/DEV-INSTALL.md
@@ -135,7 +135,7 @@ To test certificate and trust distribution, create a cert-manager Issuer and con
 cd <multicluster-mesh-addon-repo>
 
 # Create a cert-manager trust chain (ClusterIssuer -> root CA Certificate -> CA-backed Issuer)
-oc apply -f samples/cert-manager-issuer.yaml
+oc apply -n mesh-system -f samples/cert-manager-issuer.yaml
 
 # Configure the mesh to use it
 oc patch multiclustermesh my-mesh -n mesh-system --type=merge \

--- a/frontend/hack/setup-demo.sh
+++ b/frontend/hack/setup-demo.sh
@@ -199,7 +199,7 @@ EOF
     || die "Failed to create mesh-system namespace"
 
   echo "=== Creating cert-manager trust chain ==="
-  oc apply -f "${REPO_ROOT}/samples/cert-manager-issuer.yaml" \
+  oc apply -n mesh-system -f "${REPO_ROOT}/samples/cert-manager-issuer.yaml" \
     || die "Failed to create cert-manager trust chain"
 
   echo "=== Creating my-mesh MCM (with trust) ==="
@@ -331,7 +331,7 @@ uninstall() {
   oc delete multiclustermesh my-mesh staging-mesh -n mesh-system --ignore-not-found 2>/dev/null || true
 
   echo "=== Removing cert-manager trust chain ==="
-  oc delete -f "${REPO_ROOT}/samples/cert-manager-issuer.yaml" --ignore-not-found 2>/dev/null || true
+  oc delete -n mesh-system -f "${REPO_ROOT}/samples/cert-manager-issuer.yaml" --ignore-not-found 2>/dev/null || true
 
   echo "=== Removing mesh-system namespace ==="
   oc delete namespace mesh-system --ignore-not-found 2>/dev/null || true

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -307,7 +307,7 @@ setup_mesh() {
         -n cert-manager --timeout=120s
 
     log "Applying cert-manager trust chain (self-signed Issuer, root CA Certificate, CA-backed Issuer)"
-    on "${HUB}" kubectl apply -f "${SCRIPT_DIR}/samples/cert-manager-issuer.yaml"
+    on "${HUB}" kubectl apply -n mesh-system -f "${SCRIPT_DIR}/samples/cert-manager-issuer.yaml"
 
     log "Waiting for bootstrap Issuer to be ready..."
     on "${HUB}" retry kubectl wait issuer/mesh-selfsigned-issuer \
@@ -322,7 +322,7 @@ setup_mesh() {
         -n mesh-system --for=condition=Ready --timeout=60s
 
     log "Creating MultiClusterMesh CR"
-    on "${HUB}" kubectl apply -f "${SCRIPT_DIR}/samples/basic.yaml"
+    on "${HUB}" kubectl apply -n mesh-system -f "${SCRIPT_DIR}/samples/basic.yaml"
 
     log "Mesh setup complete. The controller will now reconcile the mesh."
     log "Monitor progress: $(on "${HUB}" echo kubectl get multiclustermesh -n mesh-system)"

--- a/samples/basic.yaml
+++ b/samples/basic.yaml
@@ -2,7 +2,6 @@ apiVersion: mesh.open-cluster-management.io/v1alpha1
 kind: MultiClusterMesh
 metadata:
   name: basic-mesh
-  namespace: mesh-system
 spec:
   # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
   # NOTE: Update this to match your ManagedClusterSet name

--- a/samples/cert-manager-issuer.yaml
+++ b/samples/cert-manager-issuer.yaml
@@ -14,7 +14,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: mesh-selfsigned-issuer
-  namespace: mesh-system
 spec:
   selfSigned: {}
 
@@ -24,7 +23,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: mesh-root-ca
-  namespace: mesh-system
 spec:
   isCA: true
   commonName: Mesh Root CA
@@ -46,7 +44,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: mesh-root-ca
-  namespace: mesh-system
 spec:
   ca:
     secretName: mesh-root-ca-secret

--- a/samples/complete.yaml
+++ b/samples/complete.yaml
@@ -2,7 +2,6 @@ apiVersion: mesh.open-cluster-management.io/v1alpha1
 kind: MultiClusterMesh
 metadata:
   name: complete-mesh
-  namespace: mesh-system
 spec:
   # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
   # NOTE: Update this to match your ManagedClusterSet name

--- a/samples/openshift.yaml
+++ b/samples/openshift.yaml
@@ -2,7 +2,6 @@ apiVersion: mesh.open-cluster-management.io/v1alpha1
 kind: MultiClusterMesh
 metadata:
   name: openshift-mesh
-  namespace: mesh-system
 spec:
   # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
   # NOTE: Update this to match your ManagedClusterSet name

--- a/samples/pinned-version.yaml
+++ b/samples/pinned-version.yaml
@@ -2,7 +2,6 @@ apiVersion: mesh.open-cluster-management.io/v1alpha1
 kind: MultiClusterMesh
 metadata:
   name: pinned-version-mesh
-  namespace: mesh-system
 spec:
   # Reference to the ManagedClusterSet that defines which clusters participate in the mesh
   # NOTE: Update this to match your ManagedClusterSet name


### PR DESCRIPTION
This PR removes the namespace from the manifests in the samples folder and updates the calling context to explicitly specify the namespace as part of the command.

Related to: https://github.com/stolostron/multicluster-mesh-addon/pull/160