### PR TITLE
[frontend] Enhance frontend performance for large fleet-scale meshes, clusters, and control planes

### DIFF
--- a/frontend/src/components/ControlPlaneDetailPage.tsx
+++ b/frontend/src/components/ControlPlaneDetailPage.tsx
@@ -63,6 +63,9 @@ const ControlPlaneDetailContent: FC<{ cluster: string; name: string; type: CpTyp
 
     fleetK8sGet<Istio>({ model: istioModel, name, cluster })
       .then((r) => {
+        // Cache write is intentionally outside the cancelled guard: valid data
+        // should warm the shared cache even if the user navigated away, so other
+        // pages benefit from the fetch without re-requesting.
         setInEnrichmentCache(cluster, name, r)
         if (!cancelled) { setIstio(r); setLoaded(true) }
       })

--- a/frontend/src/components/ControlPlaneDetailPage.tsx
+++ b/frontend/src/components/ControlPlaneDetailPage.tsx
@@ -6,6 +6,7 @@ import {
   Timestamp,
 } from '@openshift-console/dynamic-plugin-sdk'
 import {
+  Alert,
   Breadcrumb,
   BreadcrumbItem,
   Card,
@@ -28,6 +29,7 @@ import {
 } from '@patternfly/react-core'
 import type { Istio } from '../types/istio'
 import { istioModel } from '../types/istio'
+import { getFromEnrichmentCache } from '../hooks/useEnrichedControlPlanes'
 import { useMultiClusterMeshes } from '../hooks/useMultiClusterMeshes'
 import { buildMcmIndex, lookupMcm } from '../utils/correlateMCM'
 import { clusterDetailLink } from '../utils/linkUtils'
@@ -42,17 +44,32 @@ const ControlPlaneDetailContent: FC<{ cluster: string; name: string; type: CpTyp
   const [istio, setIstio] = useState<Istio | null>(null)
   const [loaded, setLoaded] = useState(false)
   const [error, setError] = useState<unknown>(null)
+  const [refreshError, setRefreshError] = useState<unknown>(null)
   const [mcms] = useMultiClusterMeshes()
   const mcmIndex = useMemo(() => buildMcmIndex(mcms ?? []), [mcms])
 
   useEffect(() => {
     let cancelled = false
-    setLoaded(false)
+    const cached = getFromEnrichmentCache(cluster, name)
+    if (cached) {
+      setIstio(cached)
+      setLoaded(true)
+    } else {
+      setIstio(null)
+      setLoaded(false)
+    }
     setError(null)
-    setIstio(null)
+    setRefreshError(null)
+
     fleetK8sGet<Istio>({ model: istioModel, name, cluster })
       .then((r) => { if (!cancelled) { setIstio(r); setLoaded(true) } })
-      .catch((e) => { if (!cancelled) { console.error('Failed to load control plane:', e); setError(e); setLoaded(true) } })
+      .catch((e) => {
+        if (!cancelled) {
+          console.error('Failed to load control plane:', e)
+          if (!cached) { setError(e); setLoaded(true) }
+          else setRefreshError(e)
+        }
+      })
     return () => { cancelled = true }
   }, [cluster, name])
 
@@ -117,6 +134,11 @@ const ControlPlaneDetailContent: FC<{ cluster: string; name: string; type: CpTyp
 
       <PageSection>
         <Grid hasGutter>
+          {!!refreshError && (
+            <GridItem span={12}>
+              <Alert variant="warning" isInline title={t('Data may be stale — background refresh failed.')} />
+            </GridItem>
+          )}
           <GridItem span={5}>
             <Card isCompact>
               <CardBody>

--- a/frontend/src/components/ControlPlaneDetailPage.tsx
+++ b/frontend/src/components/ControlPlaneDetailPage.tsx
@@ -29,7 +29,7 @@ import {
 } from '@patternfly/react-core'
 import type { Istio } from '../types/istio'
 import { istioModel } from '../types/istio'
-import { getFromEnrichmentCache } from '../hooks/useEnrichedControlPlanes'
+import { getFromEnrichmentCache, setInEnrichmentCache } from '../hooks/useEnrichedControlPlanes'
 import { useMultiClusterMeshes } from '../hooks/useMultiClusterMeshes'
 import { buildMcmIndex, lookupMcm } from '../utils/correlateMCM'
 import { clusterDetailLink } from '../utils/linkUtils'
@@ -62,7 +62,10 @@ const ControlPlaneDetailContent: FC<{ cluster: string; name: string; type: CpTyp
     setRefreshError(null)
 
     fleetK8sGet<Istio>({ model: istioModel, name, cluster })
-      .then((r) => { if (!cancelled) { setIstio(r); setLoaded(true) } })
+      .then((r) => {
+        setInEnrichmentCache(cluster, name, r)
+        if (!cancelled) { setIstio(r); setLoaded(true) }
+      })
       .catch((e) => {
         if (!cancelled) {
           console.error('Failed to load control plane:', e)

--- a/frontend/src/components/ControlPlanesCard.tsx
+++ b/frontend/src/components/ControlPlanesCard.tsx
@@ -16,6 +16,12 @@ import { cpTypeSegment } from '../utils/cpTypeSegment'
 import { clusterDetailLink } from '../utils/linkUtils'
 import { useMeshTranslation } from '../utils/i18nUtils'
 
+const cpRowKey = (cp: EnrichedControlPlane) => `${cp.clusterName}/${cp.metadata.name}`
+const cpSearchMatch = (cp: EnrichedControlPlane, query: string) => {
+  const q = query.toLowerCase()
+  return cp.clusterName.toLowerCase().includes(q) || cp.metadata.name.toLowerCase().includes(q)
+}
+
 const CATEGORY_LABELS: CategoryLabel[] = [
   { key: 'all', label: 'All ({{count}})' },
   { key: 'ready', label: 'Ready ({{count}})' },
@@ -69,11 +75,8 @@ const ControlPlanesCard: FC<{ planes: EnrichedControlPlane[] }> = ({ planes }) =
           columns={columns}
           emptyMessage="No control planes match the current filter."
           items={planes}
-          rowKey={(cp) => `${cp.clusterName}/${cp.metadata.name}`}
-          searchMatch={(cp, query) => {
-            const q = query.toLowerCase()
-            return cp.clusterName.toLowerCase().includes(q) || cp.metadata.name.toLowerCase().includes(q)
-          }}
+          rowKey={cpRowKey}
+          searchMatch={cpSearchMatch}
           searchPlaceholder="Filter by cluster name"
         />
       </CardBody>

--- a/frontend/src/components/ControlPlanesCard.tsx
+++ b/frontend/src/components/ControlPlanesCard.tsx
@@ -61,7 +61,7 @@ const ControlPlanesCard: FC<{ planes: EnrichedControlPlane[] }> = ({ planes }) =
         : <Label color="grey">{t('Unknown')}</Label>,
       width: '20%',
     },
-  ], [t])
+  ], []) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (planes.length === 0) return null
 

--- a/frontend/src/components/ControlPlanesPage.tsx
+++ b/frontend/src/components/ControlPlanesPage.tsx
@@ -30,6 +30,14 @@ import { fuzzyCaseInsensitive } from '../utils/filterUtils'
 import type { RowSearchFilter } from '../utils/filterUtils'
 import { useMeshTranslation } from '../utils/i18nUtils'
 
+const compareCpMeshID = (a: EnrichedControlPlane, b: EnrichedControlPlane) =>
+  (a.meshID ?? '').localeCompare(b.meshID ?? '')
+const compareCpStatusRank = (a: EnrichedControlPlane, b: EnrichedControlPlane) =>
+  getStatusRank(a.status?.conditions) - getStatusRank(b.status?.conditions)
+const cpTypeRank = (cp: EnrichedControlPlane) => cp.managedBy ? 0 : cp.meshID ? 1 : 2
+const compareCpType = (a: EnrichedControlPlane, b: EnrichedControlPlane) =>
+  cpTypeRank(a) - cpTypeRank(b)
+
 function buildColumns(t: (key: string) => string): TableColumn<EnrichedControlPlane>[] {
   return [
     {
@@ -37,9 +45,7 @@ function buildColumns(t: (key: string) => string): TableColumn<EnrichedControlPl
       id: 'meshID',
       sort: (data: EnrichedControlPlane[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) =>
-          dir * (a.meshID ?? '').localeCompare(b.meshID ?? ''),
-        )
+        return [...data].sort((a, b) => dir * compareCpMeshID(a, b))
       },
     },
     {
@@ -47,8 +53,7 @@ function buildColumns(t: (key: string) => string): TableColumn<EnrichedControlPl
       id: 'type',
       sort: (data: EnrichedControlPlane[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        const typeRank = (cp: EnrichedControlPlane) => cp.managedBy ? 0 : cp.meshID ? 1 : 2
-        return [...data].sort((a, b) => dir * (typeRank(a) - typeRank(b)))
+        return [...data].sort((a, b) => dir * compareCpType(a, b))
       },
     },
     { title: t('Name'), id: 'name', sort: 'metadata.name' },
@@ -61,9 +66,7 @@ function buildColumns(t: (key: string) => string): TableColumn<EnrichedControlPl
       id: 'status',
       sort: (data: EnrichedControlPlane[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort(
-          (a, b) => dir * (getStatusRank(a.status?.conditions) - getStatusRank(b.status?.conditions)),
-        )
+        return [...data].sort((a, b) => dir * compareCpStatusRank(a, b))
       },
     },
   ]

--- a/frontend/src/components/ControlPlanesPage.tsx
+++ b/frontend/src/components/ControlPlanesPage.tsx
@@ -184,8 +184,8 @@ const ControlPlanesPage: FC = () => {
   const [mcms] = useMultiClusterMeshes()
   const [enrichedPlanes, , , enrichmentError] = useEnrichedControlPlanes(searchResults, mcms ?? [])
 
-  const columns = useMemo(() => buildColumns(t), [t])
-  const searchFilters = useMemo(() => buildSearchFilters(t), [t])
+  const columns = useMemo(() => buildColumns(t), []) // eslint-disable-line react-hooks/exhaustive-deps
+  const searchFilters = useMemo(() => buildSearchFilters(t), []) // eslint-disable-line react-hooks/exhaustive-deps
   const [staticData, filteredData, onFilterChange] = useListPageFilter(enrichedPlanes, searchFilters as any)
   const [activeColumns, userSettingsLoaded] = useActiveColumns({
     columns,

--- a/frontend/src/components/ControlPlanesPage.tsx
+++ b/frontend/src/components/ControlPlanesPage.tsx
@@ -29,6 +29,7 @@ import { clusterDetailLink } from '../utils/linkUtils'
 import { fuzzyCaseInsensitive } from '../utils/filterUtils'
 import type { RowSearchFilter } from '../utils/filterUtils'
 import { useMeshTranslation } from '../utils/i18nUtils'
+import { sortWithComparator } from '../utils/tableCallbacks'
 
 const compareCpMeshID = (a: EnrichedControlPlane, b: EnrichedControlPlane) =>
   (a.meshID ?? '').localeCompare(b.meshID ?? '')
@@ -40,35 +41,14 @@ const compareCpType = (a: EnrichedControlPlane, b: EnrichedControlPlane) =>
 
 function buildColumns(t: (key: string) => string): TableColumn<EnrichedControlPlane>[] {
   return [
-    {
-      title: t('Mesh ID'),
-      id: 'meshID',
-      sort: (data: EnrichedControlPlane[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareCpMeshID(a, b))
-      },
-    },
-    {
-      title: t('Type'),
-      id: 'type',
-      sort: (data: EnrichedControlPlane[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareCpType(a, b))
-      },
-    },
+    { title: t('Mesh ID'), id: 'meshID', sort: (data: EnrichedControlPlane[], dir: string) => sortWithComparator(data, dir, compareCpMeshID) },
+    { title: t('Type'), id: 'type', sort: (data: EnrichedControlPlane[], dir: string) => sortWithComparator(data, dir, compareCpType) },
     { title: t('Name'), id: 'name', sort: 'metadata.name' },
     { title: t('Cluster'), id: 'cluster', sort: 'clusterName' },
     { title: t('Namespace'), id: 'namespace', sort: 'controlPlaneNamespace' },
     { title: t('Version'), id: 'version', sort: 'version' },
     { title: t('Created'), id: 'created', sort: 'metadata.creationTimestamp' },
-    {
-      title: t('Status'),
-      id: 'status',
-      sort: (data: EnrichedControlPlane[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareCpStatusRank(a, b))
-      },
-    },
+    { title: t('Status'), id: 'status', sort: (data: EnrichedControlPlane[], dir: string) => sortWithComparator(data, dir, compareCpStatusRank) },
   ]
 }
 

--- a/frontend/src/components/DiscoveredMeshDetailPage.tsx
+++ b/frontend/src/components/DiscoveredMeshDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import type { FC } from 'react'
 import { useParams, Link } from 'react-router-dom-v5-compat'
 import {
@@ -48,6 +48,10 @@ import { useMeshTranslation } from '../utils/i18nUtils'
 
 const CONDITION_COL_WIDTHS = ['12%', '12%', '14%', '10%', '12%', '25%', '15%']
 
+const discoveredClusterRowKey = (name: string) => name
+const discoveredClusterSearchMatch = (name: string, query: string) =>
+  name.toLowerCase().includes(query.toLowerCase())
+
 const DISCOVERED_CLUSTER_CATEGORIES: CategoryLabel[] = [
   { key: 'all', label: 'All ({{count}})' },
   { key: 'available', label: 'Available ({{count}})' },
@@ -89,6 +93,11 @@ const DiscoveredMeshDetailContent: FC<{ meshID: string }> = ({ meshID }) => {
     }
     return map
   }, [uniqueClusterNames, managedClusterMap])
+
+  const discoveredClusterCategorize = useCallback(
+    (name: string) => clusterAvailabilityMap.get(name) ?? 'unreachable',
+    [clusterAvailabilityMap],
+  )
 
   const clusterColumns = useMemo<VirtualFilterColumn<string>[]>(() => [
     {
@@ -253,13 +262,13 @@ const DiscoveredMeshDetailContent: FC<{ meshID: string }> = ({ meshID }) => {
               <CardTitle><strong>{t('Clusters ({{count}})', { count: uniqueClusterNames.length })}</strong></CardTitle>
               <CardBody>
                 <VirtualFilterTable
-                  categorize={(name) => clusterAvailabilityMap.get(name) ?? 'unreachable'}
+                  categorize={discoveredClusterCategorize}
                   categoryLabels={DISCOVERED_CLUSTER_CATEGORIES}
                   columns={clusterColumns}
                   emptyMessage="No clusters match the current filter."
                   items={uniqueClusterNames}
-                  rowKey={(name) => name}
-                  searchMatch={(name, query) => name.toLowerCase().includes(query.toLowerCase())}
+                  rowKey={discoveredClusterRowKey}
+                  searchMatch={discoveredClusterSearchMatch}
                   searchPlaceholder="Filter by cluster name"
                 />
               </CardBody>

--- a/frontend/src/components/MeshDetailPage.tsx
+++ b/frontend/src/components/MeshDetailPage.tsx
@@ -33,8 +33,7 @@ import type { MultiClusterMesh, ClusterMeshStatus } from '../types/multiClusterM
 import type { K8sCondition } from '../types/common'
 import { multiClusterMeshGroupVersionKind } from '../types/multiClusterMesh'
 import { useMultiClusterMeshes } from '../hooks/useMultiClusterMeshes'
-import { useDiscoveredControlPlanes } from '../hooks/useDiscoveredControlPlanes'
-import { useEnrichedControlPlanes } from '../hooks/useEnrichedControlPlanes'
+import { useMeshControlPlanes } from '../hooks/useMeshControlPlanes'
 import { useManagedClusterMap } from '../hooks/useManagedClusterMap'
 import type { ManagedCluster } from '../types/managedCluster'
 import { getClusterAvailability, availabilityColor, availabilityLabelKey } from '../types/managedCluster'
@@ -46,6 +45,7 @@ import { TrustStatusCard } from './TrustStatusCard'
 import { VirtualFilterTable } from './VirtualFilterTable'
 import type { CategoryLabel, VirtualFilterColumn } from './VirtualFilterTable'
 import { useMeshTranslation } from '../utils/i18nUtils'
+import { clusterMeshStatusRowKey, clusterMeshStatusSearchMatch } from '../utils/tableCallbacks'
 
 function conditionMessage(condition: K8sCondition): string {
   if (condition.message) return condition.message
@@ -154,8 +154,8 @@ export const ClusterStatusSection: FC<{
           columns={columns}
           emptyMessage="No clusters match the current filter."
           items={clusterStatuses}
-          rowKey={(cs) => cs.clusterName}
-          searchMatch={(cs, query) => cs.clusterName.toLowerCase().includes(query.toLowerCase())}
+          rowKey={clusterMeshStatusRowKey}
+          searchMatch={clusterMeshStatusSearchMatch}
           searchPlaceholder="Filter by cluster name"
         />
       </CardBody>
@@ -172,8 +172,11 @@ const MeshDetailContent: FC<{ ns: string; name: string }> = ({ ns, name }) => {
   })
   const [mcms] = useMultiClusterMeshes()
   const [managedClusterMap, managedClustersLoaded] = useManagedClusterMap()
-  const { results: searchResults } = useDiscoveredControlPlanes()
-  const [enrichedPlanes, , , enrichmentError] = useEnrichedControlPlanes(searchResults, mcms ?? [])
+  const clusterNames = useMemo(
+    () => (mesh?.status?.clusterStatus ?? []).map((cs) => cs.clusterName),
+    [mesh],
+  )
+  const [enrichedPlanes, , enrichmentError] = useMeshControlPlanes(clusterNames, mcms ?? [])
   const managedPlanes = useMemo(
     () => enrichedPlanes.filter((cp) => cp.managedBy?.name === name && cp.managedBy?.namespace === ns),
     [enrichedPlanes, name, ns],

--- a/frontend/src/components/OverviewPage.tsx
+++ b/frontend/src/components/OverviewPage.tsx
@@ -57,9 +57,44 @@ interface RecentIssue {
 }
 
 const MAX_ISSUES = 5
+const TOP_K_THRESHOLD = 100
+
+function insertTopK(buffer: RecentIssue[], issue: RecentIssue, k: number): void {
+  if (buffer.length < k) {
+    buffer.push(issue)
+    return
+  }
+  let oldestIdx = 0
+  let oldestTime = buffer[0].lastTransitionTime ?? ''
+  for (let i = 1; i < buffer.length; i++) {
+    const t = buffer[i].lastTransitionTime ?? ''
+    if (t < oldestTime) { oldestTime = t; oldestIdx = i }
+  }
+  if ((issue.lastTransitionTime ?? '') > oldestTime) buffer[oldestIdx] = issue
+}
+
+const sortByNewest = (a: RecentIssue, b: RecentIssue) => {
+  if (!a.lastTransitionTime) return 1
+  if (!b.lastTransitionTime) return -1
+  return b.lastTransitionTime.localeCompare(a.lastTransitionTime)
+}
 
 function collectRecentIssues(meshes: MultiClusterMesh[], controlPlanes: EnrichedControlPlane[]): RecentIssue[] {
   const issues: RecentIssue[] = []
+  let useTopK = false
+
+  const addIssue = (issue: RecentIssue) => {
+    if (useTopK) {
+      insertTopK(issues, issue, MAX_ISSUES)
+    } else {
+      issues.push(issue)
+      if (issues.length >= TOP_K_THRESHOLD) {
+        useTopK = true
+        issues.sort(sortByNewest)
+        issues.length = MAX_ISSUES
+      }
+    }
+  }
 
   for (const mesh of meshes) {
     const meshName = mesh.metadata?.name ?? ''
@@ -69,14 +104,14 @@ function collectRecentIssues(meshes: MultiClusterMesh[], controlPlanes: Enriched
     for (const c of mesh.status?.conditions ?? []) {
       if (c.status === 'True') continue
       const { label, color } = deriveStatus([c], c.type)
-      issues.push({ kind: 'mesh', source: meshName, link: meshLink, label, color, lastTransitionTime: c.lastTransitionTime })
+      addIssue({ kind: 'mesh', source: meshName, link: meshLink, label, color, lastTransitionTime: c.lastTransitionTime })
     }
 
     for (const cs of mesh.status?.clusterStatus ?? []) {
       for (const c of cs.conditions ?? []) {
         if (c.status === 'True') continue
         const { label, color } = deriveStatus([c], c.type)
-        issues.push({
+        addIssue({
           kind: 'mesh',
           source: `${meshName} / ${cs.clusterName}`,
           link: meshLink,
@@ -92,7 +127,7 @@ function collectRecentIssues(meshes: MultiClusterMesh[], controlPlanes: Enriched
     for (const c of cp.status?.conditions ?? []) {
       if (c.status === 'True') continue
       const { label, color } = deriveStatus([c], c.type)
-      issues.push({
+      addIssue({
         kind: 'controlPlane',
         source: `${cp.clusterName} / ${cp.metadata.name}`,
         link: `/fleet-mesh/control-planes/${cpTypeSegment(cp)}/${encodeURIComponent(cp.clusterName)}/${encodeURIComponent(cp.metadata.name)}`,
@@ -103,12 +138,7 @@ function collectRecentIssues(meshes: MultiClusterMesh[], controlPlanes: Enriched
     }
   }
 
-  issues.sort((a, b) => {
-    if (!a.lastTransitionTime) return 1
-    if (!b.lastTransitionTime) return -1
-    return b.lastTransitionTime.localeCompare(a.lastTransitionTime)
-  })
-
+  issues.sort(sortByNewest)
   return issues.slice(0, MAX_ISSUES)
 }
 

--- a/frontend/src/components/OverviewPage.tsx
+++ b/frontend/src/components/OverviewPage.tsx
@@ -29,10 +29,14 @@ import type { StatusCounts } from './StatusDonutChart'
 import { cpTypeSegment } from '../utils/cpTypeSegment'
 import { useMeshTranslation } from '../utils/i18nUtils'
 
-function countByStatus(items: { conditions?: K8sCondition[] }[], conditionType?: string): StatusCounts {
+function countByStatus<T>(
+  items: T[],
+  getConditions: (item: T) => K8sCondition[] | undefined,
+  conditionType?: string,
+): StatusCounts {
   const counts = { degraded: 0, notReady: 0, ready: 0, unknown: 0 }
   for (const item of items) {
-    const { color } = deriveStatus(item.conditions, conditionType)
+    const { color } = deriveStatus(getConditions(item), conditionType)
     if (color === 'green') counts.ready++
     else if (color === 'orange') counts.degraded++
     else if (color === 'grey') counts.unknown++
@@ -127,8 +131,8 @@ const OverviewPage: FC = () => {
   const meshCount = enrichmentLoaded ? items.length : mcms.length
   const meshStatusCounts = useMemo(
     () => enrichmentLoaded
-      ? countByStatus(items)
-      : countByStatus(mcms.map((m) => ({ conditions: m.status?.conditions }))),
+      ? countByStatus(items, (i) => i.conditions)
+      : countByStatus(mcms, (m) => m.status?.conditions),
     [items, mcms, enrichmentLoaded],
   )
 
@@ -137,7 +141,7 @@ const OverviewPage: FC = () => {
   const cpCount = enrichedPlanes.length
 
   const cpStatusCounts = useMemo(
-    () => countByStatus(enrichedPlanes.map((cp) => ({ conditions: cp.status?.conditions }))),
+    () => countByStatus(enrichedPlanes, (cp) => cp.status?.conditions),
     [enrichedPlanes],
   )
 

--- a/frontend/src/components/ServiceMeshPage.tsx
+++ b/frontend/src/components/ServiceMeshPage.tsx
@@ -189,8 +189,8 @@ const ServiceMeshPage: FC = () => {
     isFleetAvailable,
   } = useFleetMeshItems()
   const { t } = useMeshTranslation()
-  const columns = useMemo(() => buildColumns(t), [t])
-  const searchFilters = useMemo(() => buildSearchFilters(t), [t])
+  const columns = useMemo(() => buildColumns(t), []) // eslint-disable-line react-hooks/exhaustive-deps
+  const searchFilters = useMemo(() => buildSearchFilters(t), []) // eslint-disable-line react-hooks/exhaustive-deps
   const [staticData, filteredData, onFilterChange] = useListPageFilter(items, searchFilters as any)
   const [activeColumns, userSettingsLoaded] = useActiveColumns({
     columns,

--- a/frontend/src/components/ServiceMeshPage.tsx
+++ b/frontend/src/components/ServiceMeshPage.tsx
@@ -26,6 +26,7 @@ import { clusterSetDetailLink } from '../utils/linkUtils'
 import { fuzzyCaseInsensitive } from '../utils/filterUtils'
 import type { RowSearchFilter } from '../utils/filterUtils'
 import { useMeshTranslation } from '../utils/i18nUtils'
+import { sortWithComparator } from '../utils/tableCallbacks'
 
 const compareMeshClusterCount = (a: FleetMeshItem, b: FleetMeshItem) => a.clusterCount - b.clusterCount
 const compareMeshClusterSet = (a: FleetMeshItem, b: FleetMeshItem) => (a.clusterSet ?? '').localeCompare(b.clusterSet ?? '')
@@ -37,62 +38,13 @@ const compareMeshType = (a: FleetMeshItem, b: FleetMeshItem) => a.kind.localeCom
 
 function buildColumns(t: (key: string) => string): TableColumn<FleetMeshItem>[] {
   return [
-    {
-      title: t('Mesh ID'),
-      id: 'meshID',
-      sort: (data: FleetMeshItem[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareMeshID(a, b))
-      },
-    },
-    {
-      title: t('Type'),
-      id: 'type',
-      sort: (data: FleetMeshItem[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareMeshType(a, b))
-      },
-    },
-    {
-      title: t('Name'),
-      id: 'name',
-      sort: (data: FleetMeshItem[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareMeshName(a, b))
-      },
-    },
-    {
-      title: t('Cluster Set'),
-      id: 'clusterSet',
-      sort: (data: FleetMeshItem[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareMeshClusterSet(a, b))
-      },
-    },
-    {
-      title: t('Clusters'),
-      id: 'clusters',
-      sort: (data: FleetMeshItem[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareMeshClusterCount(a, b))
-      },
-    },
-    {
-      title: t('Trust'),
-      id: 'trust',
-      sort: (data: FleetMeshItem[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareMeshTrust(a, b))
-      },
-    },
-    {
-      title: t('Status'),
-      id: 'status',
-      sort: (data: FleetMeshItem[], sortDirection: string) => {
-        const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * compareMeshStatusRank(a, b))
-      },
-    },
+    { title: t('Mesh ID'), id: 'meshID', sort: (data: FleetMeshItem[], dir: string) => sortWithComparator(data, dir, compareMeshID) },
+    { title: t('Type'), id: 'type', sort: (data: FleetMeshItem[], dir: string) => sortWithComparator(data, dir, compareMeshType) },
+    { title: t('Name'), id: 'name', sort: (data: FleetMeshItem[], dir: string) => sortWithComparator(data, dir, compareMeshName) },
+    { title: t('Cluster Set'), id: 'clusterSet', sort: (data: FleetMeshItem[], dir: string) => sortWithComparator(data, dir, compareMeshClusterSet) },
+    { title: t('Clusters'), id: 'clusters', sort: (data: FleetMeshItem[], dir: string) => sortWithComparator(data, dir, compareMeshClusterCount) },
+    { title: t('Trust'), id: 'trust', sort: (data: FleetMeshItem[], dir: string) => sortWithComparator(data, dir, compareMeshTrust) },
+    { title: t('Status'), id: 'status', sort: (data: FleetMeshItem[], dir: string) => sortWithComparator(data, dir, compareMeshStatusRank) },
   ]
 }
 

--- a/frontend/src/components/ServiceMeshPage.tsx
+++ b/frontend/src/components/ServiceMeshPage.tsx
@@ -27,6 +27,14 @@ import { fuzzyCaseInsensitive } from '../utils/filterUtils'
 import type { RowSearchFilter } from '../utils/filterUtils'
 import { useMeshTranslation } from '../utils/i18nUtils'
 
+const compareMeshClusterCount = (a: FleetMeshItem, b: FleetMeshItem) => a.clusterCount - b.clusterCount
+const compareMeshClusterSet = (a: FleetMeshItem, b: FleetMeshItem) => (a.clusterSet ?? '').localeCompare(b.clusterSet ?? '')
+const compareMeshID = (a: FleetMeshItem, b: FleetMeshItem) => (a.meshID ?? '').localeCompare(b.meshID ?? '')
+const compareMeshName = (a: FleetMeshItem, b: FleetMeshItem) => a.metadata.name.localeCompare(b.metadata.name)
+const compareMeshStatusRank = (a: FleetMeshItem, b: FleetMeshItem) => a.statusRank - b.statusRank
+const compareMeshTrust = (a: FleetMeshItem, b: FleetMeshItem) => (a.trustIssuer ?? '').localeCompare(b.trustIssuer ?? '')
+const compareMeshType = (a: FleetMeshItem, b: FleetMeshItem) => a.kind.localeCompare(b.kind)
+
 function buildColumns(t: (key: string) => string): TableColumn<FleetMeshItem>[] {
   return [
     {
@@ -34,7 +42,7 @@ function buildColumns(t: (key: string) => string): TableColumn<FleetMeshItem>[] 
       id: 'meshID',
       sort: (data: FleetMeshItem[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * (a.meshID ?? '').localeCompare(b.meshID ?? ''))
+        return [...data].sort((a, b) => dir * compareMeshID(a, b))
       },
     },
     {
@@ -42,7 +50,7 @@ function buildColumns(t: (key: string) => string): TableColumn<FleetMeshItem>[] 
       id: 'type',
       sort: (data: FleetMeshItem[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * a.kind.localeCompare(b.kind))
+        return [...data].sort((a, b) => dir * compareMeshType(a, b))
       },
     },
     {
@@ -50,7 +58,7 @@ function buildColumns(t: (key: string) => string): TableColumn<FleetMeshItem>[] 
       id: 'name',
       sort: (data: FleetMeshItem[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * a.metadata.name.localeCompare(b.metadata.name))
+        return [...data].sort((a, b) => dir * compareMeshName(a, b))
       },
     },
     {
@@ -58,7 +66,7 @@ function buildColumns(t: (key: string) => string): TableColumn<FleetMeshItem>[] 
       id: 'clusterSet',
       sort: (data: FleetMeshItem[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * (a.clusterSet ?? '').localeCompare(b.clusterSet ?? ''))
+        return [...data].sort((a, b) => dir * compareMeshClusterSet(a, b))
       },
     },
     {
@@ -66,7 +74,7 @@ function buildColumns(t: (key: string) => string): TableColumn<FleetMeshItem>[] 
       id: 'clusters',
       sort: (data: FleetMeshItem[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * (a.clusterCount - b.clusterCount))
+        return [...data].sort((a, b) => dir * compareMeshClusterCount(a, b))
       },
     },
     {
@@ -74,7 +82,7 @@ function buildColumns(t: (key: string) => string): TableColumn<FleetMeshItem>[] 
       id: 'trust',
       sort: (data: FleetMeshItem[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * (a.trustIssuer ?? '').localeCompare(b.trustIssuer ?? ''))
+        return [...data].sort((a, b) => dir * compareMeshTrust(a, b))
       },
     },
     {
@@ -82,7 +90,7 @@ function buildColumns(t: (key: string) => string): TableColumn<FleetMeshItem>[] 
       id: 'status',
       sort: (data: FleetMeshItem[], sortDirection: string) => {
         const dir = sortDirection === 'asc' ? 1 : -1
-        return [...data].sort((a, b) => dir * (a.statusRank - b.statusRank))
+        return [...data].sort((a, b) => dir * compareMeshStatusRank(a, b))
       },
     },
   ]

--- a/frontend/src/components/StatusDonutChart.tsx
+++ b/frontend/src/components/StatusDonutChart.tsx
@@ -30,14 +30,14 @@ export const StatusDonutChart = memo<StatusDonutChartProps>(({ counts, subtitle 
     { x: t('Degraded'), y: counts.degraded },
     { x: t('Not Ready'), y: counts.notReady },
     { x: t('Unknown'), y: counts.unknown },
-  ], [counts.ready, counts.degraded, counts.notReady, counts.unknown, t])
+  ], [counts.ready, counts.degraded, counts.notReady, counts.unknown]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const legendData = useMemo(() => [
     { name: t('{{count}} Ready', { count: counts.ready }) },
     { name: t('{{count}} Degraded', { count: counts.degraded }) },
     { name: t('{{count}} Not Ready', { count: counts.notReady }) },
     { name: t('{{count}} Unknown', { count: counts.unknown }) },
-  ], [counts.ready, counts.degraded, counts.notReady, counts.unknown, t])
+  ], [counts.ready, counts.degraded, counts.notReady, counts.unknown]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div style={{ width: '100%' }}>
@@ -57,3 +57,4 @@ export const StatusDonutChart = memo<StatusDonutChartProps>(({ counts, subtitle 
     </div>
   )
 })
+StatusDonutChart.displayName = 'StatusDonutChart'

--- a/frontend/src/components/StatusDonutChart.tsx
+++ b/frontend/src/components/StatusDonutChart.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react'
+import { memo, useMemo } from 'react'
 import { ChartDonut } from '@patternfly/react-charts/victory'
 import { useMeshTranslation } from '../utils/i18nUtils'
 
@@ -21,23 +21,23 @@ const colorScale = [
   'var(--pf-v6-chart-color-black-300, #d2d2d2)',
 ]
 
-export const StatusDonutChart: FC<StatusDonutChartProps> = ({ counts, subtitle }) => {
+export const StatusDonutChart = memo<StatusDonutChartProps>(({ counts, subtitle }) => {
   const { t } = useMeshTranslation()
   const total = counts.ready + counts.degraded + counts.notReady + counts.unknown
 
-  const data = [
+  const data = useMemo(() => [
     { x: t('Ready'), y: counts.ready },
     { x: t('Degraded'), y: counts.degraded },
     { x: t('Not Ready'), y: counts.notReady },
     { x: t('Unknown'), y: counts.unknown },
-  ]
+  ], [counts.ready, counts.degraded, counts.notReady, counts.unknown, t])
 
-  const legendData = [
+  const legendData = useMemo(() => [
     { name: t('{{count}} Ready', { count: counts.ready }) },
     { name: t('{{count}} Degraded', { count: counts.degraded }) },
     { name: t('{{count}} Not Ready', { count: counts.notReady }) },
     { name: t('{{count}} Unknown', { count: counts.unknown }) },
-  ]
+  ], [counts.ready, counts.degraded, counts.notReady, counts.unknown, t])
 
   return (
     <div style={{ width: '100%' }}>
@@ -56,4 +56,4 @@ export const StatusDonutChart: FC<StatusDonutChartProps> = ({ counts, subtitle }
       />
     </div>
   )
-}
+})

--- a/frontend/src/components/TrustStatusCard.tsx
+++ b/frontend/src/components/TrustStatusCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import type { FC, ReactNode } from 'react'
 import { Link } from 'react-router-dom-v5-compat'
 import { Trans } from 'react-i18next'
@@ -26,6 +26,7 @@ import { clusterDetailLink } from '../utils/linkUtils'
 import { VirtualFilterTable } from './VirtualFilterTable'
 import type { CategoryLabel, VirtualFilterColumn } from './VirtualFilterTable'
 import { useMeshTranslation } from '../utils/i18nUtils'
+import { clusterMeshStatusRowKey, clusterMeshStatusSearchMatch } from '../utils/tableCallbacks'
 
 const TRUST_CATEGORY_LABELS: CategoryLabel[] = [
   { key: 'all', label: 'All ({{count}})' },
@@ -246,6 +247,11 @@ export const TrustStatusCard: FC<TrustStatusCardProps> = ({
     )
   }
 
+  const trustCategorize = useCallback(
+    (cs: ClusterMeshStatus) => categorizeTrust(certsByCluster.get(cs.clusterName), mwByCluster.get(cs.clusterName)),
+    [certsByCluster, mwByCluster],
+  )
+
   const noCertsAtAll = certsByCluster.size === 0 && mwByCluster.size === 0
   if (noCertsAtAll) {
     return (
@@ -267,13 +273,13 @@ export const TrustStatusCard: FC<TrustStatusCardProps> = ({
       <CardTitle><strong>{t('Trust Status ({{count}})', { count: clusterStatuses.length })}</strong></CardTitle>
       <CardBody>
         <VirtualFilterTable
-          categorize={(cs) => categorizeTrust(certsByCluster.get(cs.clusterName), mwByCluster.get(cs.clusterName))}
+          categorize={trustCategorize}
           categoryLabels={TRUST_CATEGORY_LABELS}
           columns={columns}
           emptyMessage="No clusters match the current filter."
           items={clusterStatuses}
-          rowKey={(cs) => cs.clusterName}
-          searchMatch={(cs, query) => cs.clusterName.toLowerCase().includes(query.toLowerCase())}
+          rowKey={clusterMeshStatusRowKey}
+          searchMatch={clusterMeshStatusSearchMatch}
           searchPlaceholder="Filter by cluster name"
         />
       </CardBody>

--- a/frontend/src/components/TrustStatusCard.tsx
+++ b/frontend/src/components/TrustStatusCard.tsx
@@ -151,6 +151,11 @@ export const TrustStatusCard: FC<TrustStatusCardProps> = ({
     return map
   }, [manifestWorks])
 
+  const trustCategorize = useCallback(
+    (cs: ClusterMeshStatus) => categorizeTrust(certsByCluster.get(cs.clusterName), mwByCluster.get(cs.clusterName)),
+    [certsByCluster, mwByCluster],
+  )
+
   const columns = useMemo<VirtualFilterColumn<ClusterMeshStatus>[]>(() => [
     {
       key: 'cluster',
@@ -246,11 +251,6 @@ export const TrustStatusCard: FC<TrustStatusCardProps> = ({
       </Card>
     )
   }
-
-  const trustCategorize = useCallback(
-    (cs: ClusterMeshStatus) => categorizeTrust(certsByCluster.get(cs.clusterName), mwByCluster.get(cs.clusterName)),
-    [certsByCluster, mwByCluster],
-  )
 
   const noCertsAtAll = certsByCluster.size === 0 && mwByCluster.size === 0
   if (noCertsAtAll) {

--- a/frontend/src/components/VirtualFilterTable.tsx
+++ b/frontend/src/components/VirtualFilterTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import {
   Flex,
@@ -46,7 +46,13 @@ export function VirtualFilterTable<T>({
   const { t } = useMeshTranslation()
   const allKey = categoryLabels[0].key
   const [filter, setFilter] = useState(allKey)
-  const [search, setSearch] = useState('')
+  const [searchInput, setSearchInput] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchInput), 200)
+    return () => clearTimeout(timer)
+  }, [searchInput])
 
   const categoryMap = useMemo(() => {
     const map = new Map<string, string>()
@@ -68,10 +74,10 @@ export function VirtualFilterTable<T>({
   const filtered = useMemo(() => {
     return items.filter((item) => {
       if (filter !== allKey && categoryMap.get(rowKey(item)) !== filter) return false
-      if (search && !searchMatch(item, search)) return false
+      if (debouncedSearch && !searchMatch(item, debouncedSearch)) return false
       return true
     })
-  }, [items, categoryMap, filter, search, allKey, rowKey, searchMatch])
+  }, [items, categoryMap, filter, debouncedSearch, allKey, rowKey, searchMatch])
 
   const { visibleItems, topSpacer, bottomSpacer, containerRef } = useVirtualRows(filtered)
 
@@ -93,9 +99,9 @@ export function VirtualFilterTable<T>({
         <FlexItem grow={{ default: 'grow' }}>
           <SearchInput
             placeholder={t(searchPlaceholder)}
-            value={search}
-            onChange={(_event, value) => setSearch(value)}
-            onClear={() => setSearch('')}
+            value={searchInput}
+            onChange={(_event, value) => setSearchInput(value)}
+            onClear={() => { setSearchInput(''); setDebouncedSearch('') }}
           />
         </FlexItem>
       </Flex>

--- a/frontend/src/components/__tests__/ControlPlaneDetailPage.test.tsx
+++ b/frontend/src/components/__tests__/ControlPlaneDetailPage.test.tsx
@@ -3,6 +3,7 @@ import ControlPlaneDetailPage from '../ControlPlaneDetailPage'
 import { useParams } from 'react-router-dom-v5-compat'
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk'
 import { fleetK8sGet } from '@stolostron/multicluster-sdk'
+import { setInEnrichmentCache, __resetEnrichmentCache } from '../../hooks/useEnrichedControlPlanes'
 import type { Istio } from '../../types/istio'
 
 const makeIstio = (overrides: Partial<Istio> = {}): Istio => ({
@@ -26,7 +27,7 @@ const makeIstio = (overrides: Partial<Istio> = {}): Istio => ({
   ...overrides,
 })
 
-afterEach(() => rstest.clearAllMocks())
+afterEach(() => { rstest.clearAllMocks(); __resetEnrichmentCache() })
 
 beforeEach(() => {
   rstest.mocked(useK8sWatchResource).mockReturnValue([[], true, null])
@@ -190,6 +191,71 @@ describe('ControlPlaneDetailPage', () => {
       resolvePromise!(makeIstio())
       await new Promise((r) => setTimeout(r, 0))
       expect(screen.queryByText('default')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('stale-while-revalidate', () => {
+    beforeEach(() => {
+      rstest.mocked(useParams).mockReturnValue({ type: 'discovered', cluster: 'cluster-a', name: 'default' })
+    })
+
+    it('renders cached data immediately without waiting for network', () => {
+      setInEnrichmentCache('cluster-a', 'default', makeIstio())
+      rstest.mocked(fleetK8sGet).mockReturnValue(new Promise(() => {}))
+      render(<ControlPlaneDetailPage />)
+      expect(screen.getByRole('heading', { name: 'default' })).toBeInTheDocument()
+      expect(screen.getByText('v1.24.0')).toBeInTheDocument()
+      expect(screen.queryByLabelText('Loading control plane')).not.toBeInTheDocument()
+    })
+
+    it('shows spinner when cache has no entry for the requested CP', () => {
+      rstest.mocked(fleetK8sGet).mockReturnValue(new Promise(() => {}))
+      render(<ControlPlaneDetailPage />)
+      expect(screen.getByLabelText('Loading control plane')).toBeInTheDocument()
+    })
+
+    it('shows refresh error banner when cached data is shown but background refresh fails', async () => {
+      setInEnrichmentCache('cluster-a', 'default', makeIstio())
+      rstest.mocked(fleetK8sGet).mockRejectedValue(new Error('network timeout'))
+      render(<ControlPlaneDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('Data may be stale — background refresh failed.')).toBeInTheDocument()
+      })
+      expect(screen.getByRole('heading', { name: 'default' })).toBeInTheDocument()
+    })
+
+    it('does not show refresh error banner when cache miss and refresh fails', async () => {
+      rstest.mocked(fleetK8sGet).mockRejectedValue(new Error('network timeout'))
+      render(<ControlPlaneDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('Error loading control plane')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('Data may be stale — background refresh failed.')).not.toBeInTheDocument()
+    })
+
+    it('updates data when background refresh succeeds after cache hit', async () => {
+      const oldIstio = makeIstio({ spec: { namespace: 'istio-system', version: 'v1.23.0' } })
+      setInEnrichmentCache('cluster-a', 'default', oldIstio)
+      rstest.mocked(fleetK8sGet).mockResolvedValue(makeIstio())
+      render(<ControlPlaneDetailPage />)
+      expect(screen.getByText('v1.23.0')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText('v1.24.0')).toBeInTheDocument()
+      })
+    })
+
+    it('clears stale data on route change when new CP has no cache entry', async () => {
+      setInEnrichmentCache('cluster-a', 'default', makeIstio())
+      rstest.mocked(fleetK8sGet).mockReturnValue(new Promise(() => {}))
+      const { rerender } = render(<ControlPlaneDetailPage />)
+      expect(screen.getByRole('heading', { name: 'default' })).toBeInTheDocument()
+
+      rstest.mocked(useParams).mockReturnValue({ type: 'discovered', cluster: 'cluster-b', name: 'other' })
+      rstest.mocked(fleetK8sGet).mockReturnValue(new Promise(() => {}))
+      rerender(<ControlPlaneDetailPage />)
+
+      expect(screen.queryByText('v1.24.0')).not.toBeInTheDocument()
+      expect(screen.getByLabelText('Loading control plane')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/__tests__/ControlPlanesCard.test.tsx
+++ b/frontend/src/components/__tests__/ControlPlanesCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ControlPlanesCard } from '../ControlPlanesCard'
 import { makeEnrichedCP } from '../../__fixtures__/testFactories'
@@ -71,25 +71,29 @@ describe('ControlPlanesCard', () => {
     expect(screen.queryByText('cluster-b')).not.toBeInTheDocument()
   })
 
-  it('filters by search term matching cluster or name', async () => {
-    const user = userEvent.setup()
+  it('filters by search term matching cluster or name', () => {
+    rstest.useFakeTimers()
     const planes = [
       makeCp('cluster-a', 'default'),
       makeCp('cluster-b', 'default'),
     ]
     render(<ControlPlanesCard planes={planes} />)
 
-    await user.type(screen.getByPlaceholderText('Filter by cluster name'), 'cluster-a')
+    fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'cluster-a' } })
+    act(() => { rstest.advanceTimersByTime(200) })
     expect(screen.getByText('cluster-a')).toBeInTheDocument()
     expect(screen.queryByText('cluster-b')).not.toBeInTheDocument()
+    rstest.useRealTimers()
   })
 
-  it('shows empty state when filter matches nothing', async () => {
-    const user = userEvent.setup()
+  it('shows empty state when filter matches nothing', () => {
+    rstest.useFakeTimers()
     render(<ControlPlanesCard planes={[makeCp('cluster-a', 'default')]} />)
 
-    await user.type(screen.getByPlaceholderText('Filter by cluster name'), 'zzznomatch')
+    fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'zzznomatch' } })
+    act(() => { rstest.advanceTimersByTime(200) })
     expect(screen.getByText('No control planes match the current filter.')).toBeInTheDocument()
+    rstest.useRealTimers()
   })
 
   it('shows Unknown label when CP has no conditions', () => {

--- a/frontend/src/components/__tests__/ControlPlanesCard.test.tsx
+++ b/frontend/src/components/__tests__/ControlPlanesCard.test.tsx
@@ -71,29 +71,30 @@ describe('ControlPlanesCard', () => {
     expect(screen.queryByText('cluster-b')).not.toBeInTheDocument()
   })
 
-  it('filters by search term matching cluster or name', () => {
-    rstest.useFakeTimers()
-    const planes = [
-      makeCp('cluster-a', 'default'),
-      makeCp('cluster-b', 'default'),
-    ]
-    render(<ControlPlanesCard planes={planes} />)
+  describe('search with debounce', () => {
+    beforeEach(() => { rstest.useFakeTimers() })
+    afterEach(() => { rstest.useRealTimers() })
 
-    fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'cluster-a' } })
-    act(() => { rstest.advanceTimersByTime(200) })
-    expect(screen.getByText('cluster-a')).toBeInTheDocument()
-    expect(screen.queryByText('cluster-b')).not.toBeInTheDocument()
-    rstest.useRealTimers()
-  })
+    it('filters by search term matching cluster or name', () => {
+      const planes = [
+        makeCp('cluster-a', 'default'),
+        makeCp('cluster-b', 'default'),
+      ]
+      render(<ControlPlanesCard planes={planes} />)
 
-  it('shows empty state when filter matches nothing', () => {
-    rstest.useFakeTimers()
-    render(<ControlPlanesCard planes={[makeCp('cluster-a', 'default')]} />)
+      fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'cluster-a' } })
+      act(() => { rstest.advanceTimersByTime(200) })
+      expect(screen.getByText('cluster-a')).toBeInTheDocument()
+      expect(screen.queryByText('cluster-b')).not.toBeInTheDocument()
+    })
 
-    fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'zzznomatch' } })
-    act(() => { rstest.advanceTimersByTime(200) })
-    expect(screen.getByText('No control planes match the current filter.')).toBeInTheDocument()
-    rstest.useRealTimers()
+    it('shows empty state when filter matches nothing', () => {
+      render(<ControlPlanesCard planes={[makeCp('cluster-a', 'default')]} />)
+
+      fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'zzznomatch' } })
+      act(() => { rstest.advanceTimersByTime(200) })
+      expect(screen.getByText('No control planes match the current filter.')).toBeInTheDocument()
+    })
   })
 
   it('shows Unknown label when CP has no conditions', () => {

--- a/frontend/src/components/__tests__/DiscoveredMeshDetailPage.test.tsx
+++ b/frontend/src/components/__tests__/DiscoveredMeshDetailPage.test.tsx
@@ -375,15 +375,18 @@ describe('DiscoveredMeshDetailPage', () => {
       expect(clusterLinks).toHaveLength(2)
     })
 
-    it('shows empty state when filter matches nothing', () => {
-      rstest.useFakeTimers()
-      mockDefaults({ enrichedPlanes: [cp1] })
-      render(<DiscoveredMeshDetailPage />)
-      const searchInputs = screen.getAllByPlaceholderText('Filter by cluster name')
-      fireEvent.change(searchInputs[0], { target: { value: 'zzznomatch' } })
-      act(() => { rstest.advanceTimersByTime(200) })
-      expect(screen.getAllByText('No clusters match the current filter.')).toHaveLength(1)
-      rstest.useRealTimers()
+    describe('search with debounce', () => {
+      beforeEach(() => { rstest.useFakeTimers() })
+      afterEach(() => { rstest.useRealTimers() })
+
+      it('shows empty state when filter matches nothing', () => {
+        mockDefaults({ enrichedPlanes: [cp1] })
+        render(<DiscoveredMeshDetailPage />)
+        const searchInputs = screen.getAllByPlaceholderText('Filter by cluster name')
+        fireEvent.change(searchInputs[0], { target: { value: 'zzznomatch' } })
+        act(() => { rstest.advanceTimersByTime(200) })
+        expect(screen.getAllByText('No clusters match the current filter.')).toHaveLength(1)
+      })
     })
   })
 })

--- a/frontend/src/components/__tests__/DiscoveredMeshDetailPage.test.tsx
+++ b/frontend/src/components/__tests__/DiscoveredMeshDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DiscoveredMeshDetailPage from '../DiscoveredMeshDetailPage'
 import { useParams } from 'react-router-dom-v5-compat'
@@ -375,13 +375,15 @@ describe('DiscoveredMeshDetailPage', () => {
       expect(clusterLinks).toHaveLength(2)
     })
 
-    it('shows empty state when filter matches nothing', async () => {
-      const user = userEvent.setup()
+    it('shows empty state when filter matches nothing', () => {
+      rstest.useFakeTimers()
       mockDefaults({ enrichedPlanes: [cp1] })
       render(<DiscoveredMeshDetailPage />)
       const searchInputs = screen.getAllByPlaceholderText('Filter by cluster name')
-      await user.type(searchInputs[0], 'zzznomatch')
+      fireEvent.change(searchInputs[0], { target: { value: 'zzznomatch' } })
+      act(() => { rstest.advanceTimersByTime(200) })
       expect(screen.getAllByText('No clusters match the current filter.')).toHaveLength(1)
+      rstest.useRealTimers()
     })
   })
 })

--- a/frontend/src/components/__tests__/MeshDetailPage.test.tsx
+++ b/frontend/src/components/__tests__/MeshDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MeshDetailPage, { ClusterStatusSection } from '../MeshDetailPage'
 import { useParams } from 'react-router-dom-v5-compat'
@@ -306,19 +306,23 @@ describe('ClusterStatusSection', () => {
       makeCluster('beta-cluster', 'False'),
     ]
 
-    it('shows only matching clusters when searching', async () => {
-      const user = userEvent.setup()
+    it('shows only matching clusters when searching', () => {
+      rstest.useFakeTimers()
       render(<ClusterStatusSection clusterStatuses={clusters} />)
-      await user.type(screen.getByPlaceholderText('Filter by cluster name'), 'alpha')
+      fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'alpha' } })
+      act(() => { rstest.advanceTimersByTime(200) })
       expect(screen.getByText('alpha-cluster')).toBeInTheDocument()
       expect(screen.queryByText('beta-cluster')).not.toBeInTheDocument()
+      rstest.useRealTimers()
     })
 
-    it('shows no-match row when search has no results', async () => {
-      const user = userEvent.setup()
+    it('shows no-match row when search has no results', () => {
+      rstest.useFakeTimers()
       render(<ClusterStatusSection clusterStatuses={clusters} />)
-      await user.type(screen.getByPlaceholderText('Filter by cluster name'), 'zzznomatch')
+      fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'zzznomatch' } })
+      act(() => { rstest.advanceTimersByTime(200) })
       expect(screen.getByText('No clusters match the current filter.')).toBeInTheDocument()
+      rstest.useRealTimers()
     })
   })
 

--- a/frontend/src/components/__tests__/MeshDetailPage.test.tsx
+++ b/frontend/src/components/__tests__/MeshDetailPage.test.tsx
@@ -306,23 +306,22 @@ describe('ClusterStatusSection', () => {
       makeCluster('beta-cluster', 'False'),
     ]
 
+    beforeEach(() => { rstest.useFakeTimers() })
+    afterEach(() => { rstest.useRealTimers() })
+
     it('shows only matching clusters when searching', () => {
-      rstest.useFakeTimers()
       render(<ClusterStatusSection clusterStatuses={clusters} />)
       fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'alpha' } })
       act(() => { rstest.advanceTimersByTime(200) })
       expect(screen.getByText('alpha-cluster')).toBeInTheDocument()
       expect(screen.queryByText('beta-cluster')).not.toBeInTheDocument()
-      rstest.useRealTimers()
     })
 
     it('shows no-match row when search has no results', () => {
-      rstest.useFakeTimers()
       render(<ClusterStatusSection clusterStatuses={clusters} />)
       fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'zzznomatch' } })
       act(() => { rstest.advanceTimersByTime(200) })
       expect(screen.getByText('No clusters match the current filter.')).toBeInTheDocument()
-      rstest.useRealTimers()
     })
   })
 

--- a/frontend/src/components/__tests__/TrustStatusCard.test.tsx
+++ b/frontend/src/components/__tests__/TrustStatusCard.test.tsx
@@ -280,25 +280,25 @@ describe('TrustStatusCard — search', () => {
   const certs = [makeCert('alpha-cluster', 'True'), makeCert('beta-cluster', 'True')]
   const mws = [makeMW('alpha-cluster', true, true), makeMW('beta-cluster', true, true)]
 
-  beforeEach(() => setupWatches(certs, mws))
+  beforeEach(() => {
+    setupWatches(certs, mws)
+    rstest.useFakeTimers()
+  })
+  afterEach(() => { rstest.useRealTimers() })
 
   it('narrows results to the matching cluster', () => {
-    rstest.useFakeTimers()
     render(<TrustStatusCard {...defaultProps} clusterStatuses={clusters} />)
     fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'alpha' } })
     act(() => { rstest.advanceTimersByTime(200) })
     expect(screen.getByText('alpha-cluster')).toBeInTheDocument()
     expect(screen.queryByText('beta-cluster')).not.toBeInTheDocument()
-    rstest.useRealTimers()
   })
 
   it('shows no-match row when search has no results', () => {
-    rstest.useFakeTimers()
     render(<TrustStatusCard {...defaultProps} clusterStatuses={clusters} />)
     fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'zzznomatch' } })
     act(() => { rstest.advanceTimersByTime(200) })
     expect(screen.getByText('No clusters match the current filter.')).toBeInTheDocument()
-    rstest.useRealTimers()
   })
 })
 

--- a/frontend/src/components/__tests__/TrustStatusCard.test.tsx
+++ b/frontend/src/components/__tests__/TrustStatusCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TrustStatusCard } from '../TrustStatusCard'
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk'
@@ -282,19 +282,23 @@ describe('TrustStatusCard — search', () => {
 
   beforeEach(() => setupWatches(certs, mws))
 
-  it('narrows results to the matching cluster', async () => {
-    const user = userEvent.setup()
+  it('narrows results to the matching cluster', () => {
+    rstest.useFakeTimers()
     render(<TrustStatusCard {...defaultProps} clusterStatuses={clusters} />)
-    await user.type(screen.getByPlaceholderText('Filter by cluster name'), 'alpha')
+    fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'alpha' } })
+    act(() => { rstest.advanceTimersByTime(200) })
     expect(screen.getByText('alpha-cluster')).toBeInTheDocument()
     expect(screen.queryByText('beta-cluster')).not.toBeInTheDocument()
+    rstest.useRealTimers()
   })
 
-  it('shows no-match row when search has no results', async () => {
-    const user = userEvent.setup()
+  it('shows no-match row when search has no results', () => {
+    rstest.useFakeTimers()
     render(<TrustStatusCard {...defaultProps} clusterStatuses={clusters} />)
-    await user.type(screen.getByPlaceholderText('Filter by cluster name'), 'zzznomatch')
+    fireEvent.change(screen.getByPlaceholderText('Filter by cluster name'), { target: { value: 'zzznomatch' } })
+    act(() => { rstest.advanceTimersByTime(200) })
     expect(screen.getByText('No clusters match the current filter.')).toBeInTheDocument()
+    rstest.useRealTimers()
   })
 })
 

--- a/frontend/src/components/__tests__/VirtualFilterTable.test.tsx
+++ b/frontend/src/components/__tests__/VirtualFilterTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { VirtualFilterTable } from '../VirtualFilterTable'
 import type { CategoryLabel, VirtualFilterColumn } from '../VirtualFilterTable'
 
@@ -68,23 +68,33 @@ describe('VirtualFilterTable', () => {
   })
 
   it('search filters items by the searchMatch predicate', () => {
+    rstest.useFakeTimers()
     renderTable()
 
     const searchInput = screen.getByPlaceholderText('Search...')
     fireEvent.change(searchInput, { target: { value: 'alpha' } })
 
+    act(() => { rstest.advanceTimersByTime(200) })
+
     expect(screen.getByText('Alpha')).toBeInTheDocument()
     expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
     expect(screen.queryByText('Charlie')).not.toBeInTheDocument()
+
+    rstest.useRealTimers()
   })
 
   it('shows empty message when filter matches nothing', () => {
+    rstest.useFakeTimers()
     renderTable()
 
     const searchInput = screen.getByPlaceholderText('Search...')
     fireEvent.change(searchInput, { target: { value: 'zzz-no-match' } })
 
+    act(() => { rstest.advanceTimersByTime(200) })
+
     expect(screen.getByText('No items found')).toBeInTheDocument()
+
+    rstest.useRealTimers()
   })
 
   it('shows all items when "All" toggle is selected', () => {
@@ -97,6 +107,35 @@ describe('VirtualFilterTable', () => {
     expect(screen.getByText('Alpha')).toBeInTheDocument()
     expect(screen.getByText('Bravo')).toBeInTheDocument()
     expect(screen.getByText('Charlie')).toBeInTheDocument()
+  })
+
+  it('does not filter before debounce elapses', () => {
+    rstest.useFakeTimers()
+    renderTable()
+    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'alpha' } })
+    expect(screen.getByText('Bravo')).toBeInTheDocument()
+    act(() => { rstest.advanceTimersByTime(200) })
+    expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
+    rstest.useRealTimers()
+  })
+
+  it('onClear immediately resets the filter without debounce delay', () => {
+    rstest.useFakeTimers()
+    renderTable()
+
+    const searchInput = screen.getByPlaceholderText('Search...')
+    fireEvent.change(searchInput, { target: { value: 'alpha' } })
+    act(() => { rstest.advanceTimersByTime(200) })
+    expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
+
+    const clearButton = screen.getByLabelText('Reset')
+    fireEvent.click(clearButton)
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Bravo')).toBeInTheDocument()
+    expect(screen.getByText('Charlie')).toBeInTheDocument()
+
+    rstest.useRealTimers()
   })
 
   it('returns items via useVirtualRows (spacer rows present for large datasets)', () => {

--- a/frontend/src/components/__tests__/VirtualFilterTable.test.tsx
+++ b/frontend/src/components/__tests__/VirtualFilterTable.test.tsx
@@ -67,36 +67,6 @@ describe('VirtualFilterTable', () => {
     expect(screen.queryByText('Charlie')).not.toBeInTheDocument()
   })
 
-  it('search filters items by the searchMatch predicate', () => {
-    rstest.useFakeTimers()
-    renderTable()
-
-    const searchInput = screen.getByPlaceholderText('Search...')
-    fireEvent.change(searchInput, { target: { value: 'alpha' } })
-
-    act(() => { rstest.advanceTimersByTime(200) })
-
-    expect(screen.getByText('Alpha')).toBeInTheDocument()
-    expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
-    expect(screen.queryByText('Charlie')).not.toBeInTheDocument()
-
-    rstest.useRealTimers()
-  })
-
-  it('shows empty message when filter matches nothing', () => {
-    rstest.useFakeTimers()
-    renderTable()
-
-    const searchInput = screen.getByPlaceholderText('Search...')
-    fireEvent.change(searchInput, { target: { value: 'zzz-no-match' } })
-
-    act(() => { rstest.advanceTimersByTime(200) })
-
-    expect(screen.getByText('No items found')).toBeInTheDocument()
-
-    rstest.useRealTimers()
-  })
-
   it('shows all items when "All" toggle is selected', () => {
     renderTable()
 
@@ -109,33 +79,57 @@ describe('VirtualFilterTable', () => {
     expect(screen.getByText('Charlie')).toBeInTheDocument()
   })
 
-  it('does not filter before debounce elapses', () => {
-    rstest.useFakeTimers()
-    renderTable()
-    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'alpha' } })
-    expect(screen.getByText('Bravo')).toBeInTheDocument()
-    act(() => { rstest.advanceTimersByTime(200) })
-    expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
-    rstest.useRealTimers()
-  })
+  describe('search with debounce', () => {
+    beforeEach(() => { rstest.useFakeTimers() })
+    afterEach(() => { rstest.useRealTimers() })
 
-  it('onClear immediately resets the filter without debounce delay', () => {
-    rstest.useFakeTimers()
-    renderTable()
+    it('search filters items by the searchMatch predicate', () => {
+      renderTable()
 
-    const searchInput = screen.getByPlaceholderText('Search...')
-    fireEvent.change(searchInput, { target: { value: 'alpha' } })
-    act(() => { rstest.advanceTimersByTime(200) })
-    expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
+      const searchInput = screen.getByPlaceholderText('Search...')
+      fireEvent.change(searchInput, { target: { value: 'alpha' } })
 
-    const clearButton = screen.getByLabelText('Reset')
-    fireEvent.click(clearButton)
+      act(() => { rstest.advanceTimersByTime(200) })
 
-    expect(screen.getByText('Alpha')).toBeInTheDocument()
-    expect(screen.getByText('Bravo')).toBeInTheDocument()
-    expect(screen.getByText('Charlie')).toBeInTheDocument()
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+      expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
+      expect(screen.queryByText('Charlie')).not.toBeInTheDocument()
+    })
 
-    rstest.useRealTimers()
+    it('shows empty message when filter matches nothing', () => {
+      renderTable()
+
+      const searchInput = screen.getByPlaceholderText('Search...')
+      fireEvent.change(searchInput, { target: { value: 'zzz-no-match' } })
+
+      act(() => { rstest.advanceTimersByTime(200) })
+
+      expect(screen.getByText('No items found')).toBeInTheDocument()
+    })
+
+    it('does not filter before debounce elapses', () => {
+      renderTable()
+      fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'alpha' } })
+      expect(screen.getByText('Bravo')).toBeInTheDocument()
+      act(() => { rstest.advanceTimersByTime(200) })
+      expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
+    })
+
+    it('onClear immediately resets the filter without debounce delay', () => {
+      renderTable()
+
+      const searchInput = screen.getByPlaceholderText('Search...')
+      fireEvent.change(searchInput, { target: { value: 'alpha' } })
+      act(() => { rstest.advanceTimersByTime(200) })
+      expect(screen.queryByText('Bravo')).not.toBeInTheDocument()
+
+      const clearButton = screen.getByLabelText('Reset')
+      fireEvent.click(clearButton)
+
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+      expect(screen.getByText('Bravo')).toBeInTheDocument()
+      expect(screen.getByText('Charlie')).toBeInTheDocument()
+    })
   })
 
   it('returns items via useVirtualRows (spacer rows present for large datasets)', () => {

--- a/frontend/src/hooks/__tests__/useEnrichedControlPlanes.test.ts
+++ b/frontend/src/hooks/__tests__/useEnrichedControlPlanes.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { useEnrichedControlPlanes, __resetEnrichmentCache } from '../useEnrichedControlPlanes'
+import { useEnrichedControlPlanes, __resetEnrichmentCache, getFromEnrichmentCache, setInEnrichmentCache, getConcurrencyLimit } from '../useEnrichedControlPlanes'
 import { fleetK8sGet } from '@stolostron/multicluster-sdk'
 import { makeSearchResult } from '../../__fixtures__/testFactories'
 import type { Istio } from '../../types/istio'
@@ -304,5 +304,77 @@ describe('useEnrichedControlPlanes', () => {
       expect(rstest.mocked(fleetK8sGet).mock.calls.length).toBeGreaterThanOrEqual(2)
     })
     expect(result.current[2]).toBe(true)
+  })
+})
+
+describe('enrichment cache functions', () => {
+  const makeIstioForCache = (namespace = 'istio-system'): Istio => ({
+    apiVersion: 'sailoperator.io/v1',
+    kind: 'Istio',
+    metadata: { name: 'default' },
+    spec: { namespace },
+    status: { conditions: [{ type: 'Ready', status: 'True' as const }] },
+  })
+
+  it('getFromEnrichmentCache returns undefined on cache miss', () => {
+    expect(getFromEnrichmentCache('cluster-a', 'default')).toBeUndefined()
+  })
+
+  it('setInEnrichmentCache writes and getFromEnrichmentCache reads back', () => {
+    const istio = makeIstioForCache()
+    setInEnrichmentCache('cluster-a', 'default', istio)
+    expect(getFromEnrichmentCache('cluster-a', 'default')).toBe(istio)
+  })
+
+  it('getFromEnrichmentCache returns undefined after TTL expires', () => {
+    rstest.useFakeTimers()
+    const istio = makeIstioForCache()
+    setInEnrichmentCache('cluster-a', 'default', istio)
+    expect(getFromEnrichmentCache('cluster-a', 'default')).toBe(istio)
+
+    rstest.setSystemTime(Date.now() + 160_000)
+    expect(getFromEnrichmentCache('cluster-a', 'default')).toBeUndefined()
+  })
+
+  it('setInEnrichmentCache overwrites existing entries', () => {
+    const istio1 = makeIstioForCache('ns-1')
+    const istio2 = makeIstioForCache('ns-2')
+    setInEnrichmentCache('cluster-a', 'default', istio1)
+    setInEnrichmentCache('cluster-a', 'default', istio2)
+    expect(getFromEnrichmentCache('cluster-a', 'default')).toBe(istio2)
+  })
+
+  it('different cluster/name keys are independent', () => {
+    const istioA = makeIstioForCache('ns-a')
+    const istioB = makeIstioForCache('ns-b')
+    setInEnrichmentCache('cluster-a', 'cp-a', istioA)
+    setInEnrichmentCache('cluster-b', 'cp-b', istioB)
+    expect(getFromEnrichmentCache('cluster-a', 'cp-a')).toBe(istioA)
+    expect(getFromEnrichmentCache('cluster-b', 'cp-b')).toBe(istioB)
+    expect(getFromEnrichmentCache('cluster-a', 'cp-b')).toBeUndefined()
+  })
+})
+
+describe('getConcurrencyLimit', () => {
+  it('returns minimum (10) for small fleets', () => {
+    expect(getConcurrencyLimit(5)).toBe(10)
+    expect(getConcurrencyLimit(50)).toBe(10)
+    expect(getConcurrencyLimit(199)).toBe(10)
+  })
+
+  it('scales up for larger fleets', () => {
+    expect(getConcurrencyLimit(200)).toBe(10)
+    expect(getConcurrencyLimit(400)).toBe(20)
+    expect(getConcurrencyLimit(420)).toBe(21)
+  })
+
+  it('caps at maximum (25)', () => {
+    expect(getConcurrencyLimit(500)).toBe(25)
+    expect(getConcurrencyLimit(1000)).toBe(25)
+    expect(getConcurrencyLimit(5000)).toBe(25)
+  })
+
+  it('returns minimum for zero pending', () => {
+    expect(getConcurrencyLimit(0)).toBe(10)
   })
 })

--- a/frontend/src/hooks/__tests__/useEnrichedControlPlanes.test.ts
+++ b/frontend/src/hooks/__tests__/useEnrichedControlPlanes.test.ts
@@ -328,12 +328,16 @@ describe('enrichment cache functions', () => {
 
   it('getFromEnrichmentCache returns undefined after TTL expires', () => {
     rstest.useFakeTimers()
-    const istio = makeIstioForCache()
-    setInEnrichmentCache('cluster-a', 'default', istio)
-    expect(getFromEnrichmentCache('cluster-a', 'default')).toBe(istio)
+    try {
+      const istio = makeIstioForCache()
+      setInEnrichmentCache('cluster-a', 'default', istio)
+      expect(getFromEnrichmentCache('cluster-a', 'default')).toBe(istio)
 
-    rstest.setSystemTime(Date.now() + 160_000)
-    expect(getFromEnrichmentCache('cluster-a', 'default')).toBeUndefined()
+      rstest.setSystemTime(Date.now() + 160_000)
+      expect(getFromEnrichmentCache('cluster-a', 'default')).toBeUndefined()
+    } finally {
+      rstest.useRealTimers()
+    }
   })
 
   it('setInEnrichmentCache overwrites existing entries', () => {

--- a/frontend/src/hooks/__tests__/useMeshControlPlanes.test.ts
+++ b/frontend/src/hooks/__tests__/useMeshControlPlanes.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useMeshControlPlanes } from '../useMeshControlPlanes'
+import { __resetEnrichmentCache, getFromEnrichmentCache, setInEnrichmentCache } from '../useEnrichedControlPlanes'
+import { fleetK8sGet, useFleetSearchPoll } from '@stolostron/multicluster-sdk'
+import { makeSearchResult } from '../../__fixtures__/testFactories'
+import type { Istio } from '../../types/istio'
+import type { MultiClusterMesh } from '../../types/multiClusterMesh'
+
+const makeIstio = (namespace = 'istio-system', meshID?: string): Istio => ({
+  apiVersion: 'sailoperator.io/v1',
+  kind: 'Istio',
+  metadata: { name: 'default' },
+  spec: {
+    namespace,
+    version: 'v1.24.0',
+    values: meshID ? { global: { meshID } } : undefined,
+  },
+  status: { conditions: [{ type: 'Ready', status: 'True' as const }] },
+})
+
+const makeMcm = (clusterNames: string[]): MultiClusterMesh => ({
+  apiVersion: 'mesh.open-cluster-management.io/v1alpha1',
+  kind: 'MultiClusterMesh',
+  metadata: { name: 'my-mesh', namespace: 'mesh-system' },
+  spec: { clusterSet: 'global', controlPlane: { namespace: 'istio-system' } },
+  status: { clusterStatus: clusterNames.map((c) => ({ clusterName: c })) },
+})
+
+afterEach(() => {
+  rstest.clearAllMocks()
+  rstest.useRealTimers()
+  __resetEnrichmentCache()
+})
+
+function setupSearchPoll(results: any[]) {
+  rstest.mocked(useFleetSearchPoll).mockReturnValue([results, true, undefined, rstest.fn()])
+}
+
+describe('useMeshControlPlanes', () => {
+  it('returns empty planes when clusterNames is empty', () => {
+    setupSearchPoll([makeSearchResult('cluster-a', 'default')])
+    const { result } = renderHook(() => useMeshControlPlanes([], []))
+    expect(result.current[0]).toHaveLength(0)
+  })
+
+  it('only enriches CPs on specified clusters', async () => {
+    const allResults = [
+      makeSearchResult('cluster-a', 'default'),
+      makeSearchResult('cluster-b', 'default'),
+      makeSearchResult('cluster-c', 'default'),
+    ]
+    setupSearchPoll(allResults)
+    rstest.mocked(fleetK8sGet).mockResolvedValue(makeIstio('istio-system', 'mesh1'))
+
+    const { result } = renderHook(() => useMeshControlPlanes(['cluster-a', 'cluster-b'], []))
+
+    await waitFor(() => expect(result.current[1]).toBe(true))
+
+    expect(result.current[0]).toHaveLength(2)
+    expect(result.current[0].map((p) => p.clusterName).sort()).toEqual(['cluster-a', 'cluster-b'])
+    expect(rstest.mocked(fleetK8sGet)).toHaveBeenCalledTimes(2)
+  })
+
+  it('populates the shared enrichment cache for bidirectional warming', async () => {
+    setupSearchPoll([makeSearchResult('cluster-a', 'default')])
+    rstest.mocked(fleetK8sGet).mockResolvedValue(makeIstio())
+
+    const { result } = renderHook(() => useMeshControlPlanes(['cluster-a'], []))
+    await waitFor(() => expect(result.current[1]).toBe(true))
+
+    expect(getFromEnrichmentCache('cluster-a', 'default')).toBeDefined()
+  })
+
+  it('reads from warm cache without network calls', async () => {
+    setInEnrichmentCache('cluster-a', 'default', makeIstio('istio-system', 'mesh1'))
+    setupSearchPoll([makeSearchResult('cluster-a', 'default')])
+
+    const { result } = renderHook(() => useMeshControlPlanes(['cluster-a'], []))
+    await waitFor(() => expect(result.current[1]).toBe(true))
+
+    expect(rstest.mocked(fleetK8sGet)).not.toHaveBeenCalled()
+    expect(result.current[0][0].meshID).toBe('mesh1')
+  })
+
+  it('correlates control planes with MCMs', async () => {
+    setupSearchPoll([makeSearchResult('cluster-a', 'default')])
+    rstest.mocked(fleetK8sGet).mockResolvedValue(makeIstio('istio-system'))
+    const mcms = [makeMcm(['cluster-a'])]
+
+    const { result } = renderHook(() => useMeshControlPlanes(['cluster-a'], mcms))
+    await waitFor(() => expect(result.current[1]).toBe(true))
+
+    expect(result.current[0][0].managedBy).toEqual({ name: 'my-mesh', namespace: 'mesh-system' })
+  })
+
+  it('exposes error state from search poll failures', async () => {
+    const searchErr = new Error('network error')
+    rstest.mocked(useFleetSearchPoll).mockReturnValue([
+      [makeSearchResult('cluster-a', 'default')], true, searchErr, rstest.fn(),
+    ])
+    rstest.mocked(fleetK8sGet).mockResolvedValue(makeIstio())
+
+    const { result } = renderHook(() => useMeshControlPlanes(['cluster-a'], []))
+    await waitFor(() => expect(result.current[1]).toBe(true))
+
+    expect(result.current[2]).toBe(searchErr)
+  })
+})

--- a/frontend/src/hooks/__tests__/useMeshControlPlanes.test.ts
+++ b/frontend/src/hooks/__tests__/useMeshControlPlanes.test.ts
@@ -93,6 +93,31 @@ describe('useMeshControlPlanes', () => {
     expect(result.current[0][0].managedBy).toEqual({ name: 'my-mesh', namespace: 'mesh-system' })
   })
 
+  it('handles cluster scope changes on rerender', async () => {
+    const allResults = [
+      makeSearchResult('cluster-a', 'default'),
+      makeSearchResult('cluster-b', 'default'),
+    ]
+    setupSearchPoll(allResults)
+    rstest.mocked(fleetK8sGet).mockResolvedValue(makeIstio('istio-system', 'mesh1'))
+
+    const { result, rerender } = renderHook(
+      ({ clusters }) => useMeshControlPlanes(clusters, []),
+      { initialProps: { clusters: ['cluster-a'] } },
+    )
+
+    await waitFor(() => expect(result.current[1]).toBe(true))
+    expect(result.current[0]).toHaveLength(1)
+    expect(result.current[0][0].clusterName).toBe('cluster-a')
+
+    rerender({ clusters: ['cluster-b'] })
+
+    await waitFor(() => {
+      expect(result.current[0]).toHaveLength(1)
+      expect(result.current[0][0].clusterName).toBe('cluster-b')
+    })
+  })
+
   it('exposes error state from search poll failures', async () => {
     const searchErr = new Error('network error')
     rstest.mocked(useFleetSearchPoll).mockReturnValue([

--- a/frontend/src/hooks/useDiscoveredControlPlanes.ts
+++ b/frontend/src/hooks/useDiscoveredControlPlanes.ts
@@ -1,21 +1,25 @@
+import { useMemo } from 'react'
 import { useFleetSearchPoll, useIsFleetAvailable } from '@stolostron/multicluster-sdk'
-import type { Istio } from '../types/istio'
+import type { FleetIstio, Istio } from '../types/istio'
 import { istioGroupVersionKind } from '../types/istio'
 
-type FleetIstio = Istio & { cluster?: string }
+type RawFleetIstio = Istio & { cluster?: string }
 
 /** Discovers Istio CRs across all managed clusters via ACM Search polling. */
 export function useDiscoveredControlPlanes() {
   const isFleetAvailable = useIsFleetAvailable()
 
-  const [data, loaded, error, refetch] = useFleetSearchPoll<FleetIstio[]>({
+  const [data, loaded, error, refetch] = useFleetSearchPoll<RawFleetIstio[]>({
     groupVersionKind: istioGroupVersionKind,
     isList: true,
     namespaced: false,
   })
 
-  const results = (data ?? []).filter(
-    (r): r is FleetIstio & { cluster: string } => Boolean(r.cluster && r.metadata?.name),
+  const results = useMemo(
+    () => (data ?? []).filter(
+      (r): r is FleetIstio => Boolean(r.cluster && r.metadata?.name),
+    ),
+    [data],
   )
 
   return { error, isFleetAvailable, loaded, refetch, results } as const

--- a/frontend/src/hooks/useEnrichedControlPlanes.ts
+++ b/frontend/src/hooks/useEnrichedControlPlanes.ts
@@ -176,6 +176,11 @@ export function useEnrichedControlPlanes(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchKey])
 
+  // Reads from cache without TTL check: the enrichment effect above already
+  // TTL-filters entries before deciding what to re-fetch (lines 127-131).
+  // Entries here were just written or are within TTL. The scoped hook
+  // (useMeshControlPlanes) uses getFromEnrichmentCache (with TTL) in its memo
+  // instead — a cosmetic inconsistency that self-corrects on the next cycle.
   const enrichedBeforeCorrelation = useMemo(() => {
     return stableResults.map((r) => {
       const cached = enrichmentCache.get(`${r.cluster}/${r.metadata?.name}`)?.data

--- a/frontend/src/hooks/useEnrichedControlPlanes.ts
+++ b/frontend/src/hooks/useEnrichedControlPlanes.ts
@@ -1,11 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { fleetK8sGet } from '@stolostron/multicluster-sdk'
-import type { Istio, EnrichedControlPlane } from '../types/istio'
+import type { FleetIstio, Istio, EnrichedControlPlane } from '../types/istio'
 import { istioModel } from '../types/istio'
 import type { MultiClusterMesh } from '../types/multiClusterMesh'
 import { buildMcmIndex, lookupMcm } from '../utils/correlateMCM'
-
-type FleetIstio = Istio & { cluster: string }
+import { toEnrichedControlPlane } from '../utils/enrichmentUtils'
 
 interface CacheEntry {
   data: Istio
@@ -19,8 +18,14 @@ interface CacheEntry {
 // tradeoff — see docs/DISCOVERY-OPTIONS.md for the design rationale.
 // Exit ramp: if ACM Search gains spec/status indexing for custom resources, or
 // if Istio CRs gain standardized labels for key fields, enrichment can be eliminated.
-const CACHE_TTL_MS = 150_000
-const CONCURRENCY_LIMIT = 10
+export const CACHE_TTL_MS = 150_000
+const CONCURRENCY_MIN = 10
+const CONCURRENCY_MAX = 25
+const MAX_CACHE_SIZE = 2000
+
+export function getConcurrencyLimit(pendingCount: number): number {
+  return Math.max(CONCURRENCY_MIN, Math.min(CONCURRENCY_MAX, Math.ceil(pendingCount / 20)))
+}
 
 // Module-level cache so enrichment data survives component unmounts. When a user
 // navigates from the list page to a detail page, the new component instance reads
@@ -36,15 +41,30 @@ export function __resetEnrichmentCache() {
   enrichmentCache.clear()
 }
 
+/** Reads a cached Istio CR if it exists and is within TTL. */
+export function getFromEnrichmentCache(cluster: string, name: string): Istio | undefined {
+  const entry = enrichmentCache.get(`${cluster}/${name}`)
+  if (entry && Date.now() - entry.fetchedAt <= CACHE_TTL_MS) return entry.data
+  return undefined
+}
+
+/** Writes an Istio CR to the shared cache for bidirectional cache warming. */
+export function setInEnrichmentCache(cluster: string, name: string, data: Istio): void {
+  const cacheKey = `${cluster}/${name}`
+  enrichmentCache.delete(cacheKey)
+  enrichmentCache.set(cacheKey, { data, fetchedAt: Date.now() })
+}
+
 async function fetchInChunks(
   pending: { cluster: string; name: string }[],
   cache: Map<string, CacheEntry>,
   onChunkProcessed: (n: number) => void,
   isCancelled: () => boolean,
 ) {
-  for (let i = 0; i < pending.length; i += CONCURRENCY_LIMIT) {
+  const chunkSize = getConcurrencyLimit(pending.length)
+  for (let i = 0; i < pending.length; i += chunkSize) {
     if (isCancelled()) return
-    const chunk = pending.slice(i, i + CONCURRENCY_LIMIT)
+    const chunk = pending.slice(i, i + chunkSize)
     const results = await Promise.allSettled(
       chunk.map(({ cluster, name }) =>
         fleetK8sGet<Istio>({ model: istioModel, name, cluster })
@@ -55,7 +75,13 @@ async function fetchInChunks(
     for (const result of results) {
       if (result.status === 'fulfilled') {
         const { cluster, name, data } = result.value
-        cache.set(`${cluster}/${name}`, { data, fetchedAt: Date.now() })
+        const cacheKey = `${cluster}/${name}`
+        cache.delete(cacheKey)
+        cache.set(cacheKey, { data, fetchedAt: Date.now() })
+        if (cache.size > MAX_CACHE_SIZE) {
+          const oldest = cache.keys().next().value
+          if (oldest !== undefined) cache.delete(oldest)
+        }
       }
     }
     onChunkProcessed(chunk.length)
@@ -155,23 +181,9 @@ export function useEnrichedControlPlanes(
   }, [searchKey])
 
   const enrichedBeforeCorrelation = useMemo(() => {
-    return stableResults.map((r): EnrichedControlPlane => {
-      const key = `${r.cluster}/${r.metadata?.name}`
-      const cached = enrichmentCache.get(key)?.data
-      const spec = cached?.spec
-      return {
-        metadata: {
-          name: r.metadata?.name ?? '',
-          creationTimestamp: r.metadata?.creationTimestamp,
-          labels: r.metadata?.labels as Record<string, string> | undefined,
-        },
-        clusterName: r.cluster,
-        controlPlaneNamespace: spec?.namespace,
-        meshID: spec?.values?.global?.meshID,
-        network: spec?.values?.global?.network,
-        status: cached?.status,
-        version: spec?.version,
-      }
+    return stableResults.map((r) => {
+      const cached = enrichmentCache.get(`${r.cluster}/${r.metadata?.name}`)?.data
+      return toEnrichedControlPlane(r, cached)
     })
   }, [stableResults, enrichmentVersion])
 

--- a/frontend/src/hooks/useEnrichedControlPlanes.ts
+++ b/frontend/src/hooks/useEnrichedControlPlanes.ts
@@ -53,11 +53,14 @@ export function setInEnrichmentCache(cluster: string, name: string, data: Istio)
   const cacheKey = `${cluster}/${name}`
   enrichmentCache.delete(cacheKey)
   enrichmentCache.set(cacheKey, { data, fetchedAt: Date.now() })
+  if (enrichmentCache.size > MAX_CACHE_SIZE) {
+    const oldest = enrichmentCache.keys().next().value
+    if (oldest !== undefined) enrichmentCache.delete(oldest)
+  }
 }
 
 async function fetchInChunks(
   pending: { cluster: string; name: string }[],
-  cache: Map<string, CacheEntry>,
   onChunkProcessed: (n: number) => void,
   isCancelled: () => boolean,
 ) {
@@ -75,13 +78,7 @@ async function fetchInChunks(
     for (const result of results) {
       if (result.status === 'fulfilled') {
         const { cluster, name, data } = result.value
-        const cacheKey = `${cluster}/${name}`
-        cache.delete(cacheKey)
-        cache.set(cacheKey, { data, fetchedAt: Date.now() })
-        if (cache.size > MAX_CACHE_SIZE) {
-          const oldest = cache.keys().next().value
-          if (oldest !== undefined) cache.delete(oldest)
-        }
+        setInEnrichmentCache(cluster, name, data)
       }
     }
     onChunkProcessed(chunk.length)
@@ -142,7 +139,6 @@ export function useEnrichedControlPlanes(
 
     fetchInChunks(
       pending,
-      enrichmentCache,
       () => {
         if (!cancelled) {
           if (debounceRef.current) clearTimeout(debounceRef.current)

--- a/frontend/src/hooks/useFleetMeshItems.ts
+++ b/frontend/src/hooks/useFleetMeshItems.ts
@@ -23,6 +23,19 @@ export interface UseFleetMeshItemsResult {
   searchLoaded: boolean
 }
 
+function buildManagedByIndex(planes: EnrichedControlPlane[]): Map<string, EnrichedControlPlane[]> {
+  const map = new Map<string, EnrichedControlPlane[]>()
+  for (const cp of planes) {
+    if (cp.managedBy) {
+      const key = `${cp.managedBy.namespace}/${cp.managedBy.name}`
+      const group = map.get(key)
+      if (group) group.push(cp)
+      else map.set(key, [cp])
+    }
+  }
+  return map
+}
+
 function collectManagedMeshIDs(enrichedPlanes: EnrichedControlPlane[]): Set<string> {
   const ids = new Set<string>()
   for (const cp of enrichedPlanes) {
@@ -39,14 +52,13 @@ function buildItems(
   if (!enrichmentLoaded) return []
 
   const managedMeshIDs = collectManagedMeshIDs(enrichedPlanes)
+  const managedByIndex = buildManagedByIndex(enrichedPlanes)
 
   const managedItems: FleetMeshItem[] = mcms.map((mcm): FleetMeshItem => {
     const ns = mcm.metadata?.namespace ?? ''
     const name = mcm.metadata?.name ?? ''
 
-    const correlatedPlanes = enrichedPlanes.filter(
-      (cp) => cp.managedBy?.name === name && cp.managedBy?.namespace === ns
-    )
+    const correlatedPlanes = [...(managedByIndex.get(`${ns}/${name}`) ?? [])]
 
     const { conditions, rank } = correlatedPlanes.length > 0 && correlatedPlanes.some(cp => cp.status?.conditions)
       ? worstConditions(correlatedPlanes)

--- a/frontend/src/hooks/useMeshControlPlanes.ts
+++ b/frontend/src/hooks/useMeshControlPlanes.ts
@@ -1,0 +1,123 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { fleetK8sGet, useFleetSearchPoll } from '@stolostron/multicluster-sdk'
+import type { FleetIstio, Istio, EnrichedControlPlane } from '../types/istio'
+import { istioModel, istioGroupVersionKind } from '../types/istio'
+import type { MultiClusterMesh } from '../types/multiClusterMesh'
+import { buildMcmIndex, lookupMcm } from '../utils/correlateMCM'
+import { toEnrichedControlPlane } from '../utils/enrichmentUtils'
+import {
+  CACHE_TTL_MS,
+  getConcurrencyLimit,
+  getFromEnrichmentCache,
+  setInEnrichmentCache,
+} from './useEnrichedControlPlanes'
+
+/**
+ * Scoped enrichment hook for detail pages. Only discovers and enriches control
+ * planes on the specified clusters, avoiding fleet-wide enrichment. Populates
+ * the shared enrichment cache for bidirectional warming with list pages.
+ */
+export function useMeshControlPlanes(
+  clusterNames: string[],
+  mcms: MultiClusterMesh[],
+): [EnrichedControlPlane[], boolean, unknown] {
+  const [enrichmentVersion, setEnrichmentVersion] = useState(0)
+  const [enrichmentLoaded, setEnrichmentLoaded] = useState(false)
+  const [error, setError] = useState<unknown>(null)
+  const [refreshTick, setRefreshTick] = useState(0)
+  const initialEnrichmentDone = useRef(false)
+
+  useEffect(() => {
+    const id = setInterval(() => setRefreshTick((v) => v + 1), CACHE_TTL_MS)
+    return () => clearInterval(id)
+  }, [])
+
+  const clusterKey = useMemo(() => [...clusterNames].sort().join(','), [clusterNames])
+
+  const [data, searchLoaded, searchError] = useFleetSearchPoll<FleetIstio[]>({
+    groupVersionKind: istioGroupVersionKind,
+    isList: true,
+    namespaced: false,
+  })
+
+  const scopedResults = useMemo(() => {
+    if (!data || clusterNames.length === 0) return []
+    const clusterSet = new Set(clusterNames)
+    return data.filter(
+      (r): r is FleetIstio => Boolean(r.cluster && r.metadata?.name && clusterSet.has(r.cluster)),
+    )
+  }, [data, clusterKey]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    let cancelled = false
+    const now = Date.now()
+    setError(null)
+
+    if (scopedResults.length > 0 && !initialEnrichmentDone.current) {
+      setEnrichmentLoaded(false)
+    }
+
+    const pending = scopedResults.filter((r) => {
+      const cached = getFromEnrichmentCache(r.cluster, r.metadata?.name ?? '')
+      return !cached
+    }).map((r) => ({ cluster: r.cluster, name: r.metadata?.name ?? '' }))
+
+    if (pending.length === 0) {
+      setEnrichmentLoaded(true)
+      if (scopedResults.length > 0) initialEnrichmentDone.current = true
+      setEnrichmentVersion((v) => v + 1)
+      return
+    }
+
+    ;(async () => {
+      try {
+        const chunkSize = getConcurrencyLimit(pending.length)
+        for (let i = 0; i < pending.length; i += chunkSize) {
+          if (cancelled) return
+          const chunk = pending.slice(i, i + chunkSize)
+          const results = await Promise.allSettled(
+            chunk.map(({ cluster, name }) =>
+              fleetK8sGet<Istio>({ model: istioModel, name, cluster })
+                .then((r) => ({ cluster, name, data: r }))
+            ),
+          )
+          if (cancelled) return
+          for (const result of results) {
+            if (result.status === 'fulfilled') {
+              const { cluster, name, data } = result.value
+              setInEnrichmentCache(cluster, name, data)
+            }
+          }
+        }
+        if (!cancelled) {
+          setEnrichmentVersion((v) => v + 1)
+          setEnrichmentLoaded(true)
+          initialEnrichmentDone.current = true
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setEnrichmentLoaded(true)
+          initialEnrichmentDone.current = true
+          setError(e)
+        }
+      }
+    })()
+
+    return () => { cancelled = true }
+  }, [scopedResults, refreshTick])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  const mcmIndex = useMemo(() => buildMcmIndex(mcms), [mcms])
+
+  const enrichedPlanes = useMemo(() => {
+    return scopedResults.map((r) => {
+      const cached = getFromEnrichmentCache(r.cluster, r.metadata?.name ?? '')
+      const plane = toEnrichedControlPlane(r, cached)
+      return {
+        ...plane,
+        managedBy: lookupMcm(mcmIndex, r.cluster, plane.controlPlaneNamespace),
+      }
+    })
+  }, [scopedResults, mcmIndex, enrichmentVersion])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  return [enrichedPlanes, searchLoaded && enrichmentLoaded, error ?? searchError]
+}

--- a/frontend/src/hooks/useMeshControlPlanes.ts
+++ b/frontend/src/hooks/useMeshControlPlanes.ts
@@ -34,6 +34,12 @@ export function useMeshControlPlanes(
 
   const clusterKey = useMemo(() => [...clusterNames].sort().join(','), [clusterNames])
 
+  const prevClusterKey = useRef(clusterKey)
+  if (prevClusterKey.current !== clusterKey) {
+    prevClusterKey.current = clusterKey
+    initialEnrichmentDone.current = false
+  }
+
   const [data, searchLoaded, searchError] = useFleetSearchPoll<FleetIstio[]>({
     groupVersionKind: istioGroupVersionKind,
     isList: true,

--- a/frontend/src/hooks/useVirtualRows.ts
+++ b/frontend/src/hooks/useVirtualRows.ts
@@ -37,25 +37,31 @@ export function useVirtualRows<T>(items: T[], rowHeight = 40, overscan = 5): Vir
   const containerHeightRef = useRef(containerHeight)
   containerHeightRef.current = containerHeight
 
+  const rafRef = useRef(0)
+
   const handleScroll = useCallback(() => {
-    if (!nodeRef.current) return
-    const newScrollTop = nodeRef.current.scrollTop
-    const h = containerHeightRef.current
-    const len = itemsLengthRef.current
-    const rh = rowHeightRef.current
-    const os = overscanRef.current
+    cancelAnimationFrame(rafRef.current)
+    rafRef.current = requestAnimationFrame(() => {
+      if (!nodeRef.current) return
+      const newScrollTop = nodeRef.current.scrollTop
+      const h = containerHeightRef.current
+      const len = itemsLengthRef.current
+      const rh = rowHeightRef.current
+      const os = overscanRef.current
 
-    const [curStart, curEnd] = computeIndices(scrollTopRef.current, h, len, rh, os)
-    const [newStart, newEnd] = computeIndices(newScrollTop, h, len, rh, os)
+      const [curStart, curEnd] = computeIndices(scrollTopRef.current, h, len, rh, os)
+      const [newStart, newEnd] = computeIndices(newScrollTop, h, len, rh, os)
 
-    if (newStart !== curStart || newEnd !== curEnd) {
-      setScrollTop(newScrollTop)
-    }
+      if (newStart !== curStart || newEnd !== curEnd) {
+        setScrollTop(newScrollTop)
+      }
+    })
   }, [])
 
   const containerRef = useCallback((node: HTMLDivElement | null) => {
     if (nodeRef.current) {
       nodeRef.current.removeEventListener('scroll', handleScroll)
+      cancelAnimationFrame(rafRef.current)
     }
     nodeRef.current = node
     if (node) {

--- a/frontend/src/locales/en/plugin__ossm-acm.json
+++ b/frontend/src/locales/en/plugin__ossm-acm.json
@@ -24,6 +24,7 @@
   "Control Planes": "Control Planes",
   "Control Planes ({{count}})": "Control Planes ({{count}})",
   "Created": "Created",
+  "Data may be stale — background refresh failed.": "Data may be stale — background refresh failed.",
   "Degraded": "Degraded",
   "Discovered": "Discovered",
   "Discovered mesh \"{{meshID}}\" was not found.": "Discovered mesh \"{{meshID}}\" was not found.",

--- a/frontend/src/types/istio.ts
+++ b/frontend/src/types/istio.ts
@@ -39,6 +39,8 @@ export interface Istio extends K8sResourceCommon {
   status?: IstioStatus
 }
 
+export type FleetIstio = Istio & { cluster: string }
+
 // useListPageFilter from the Console SDK accesses metadata.name for its
 // built-in name filter, so EnrichedControlPlane must include metadata.
 export interface EnrichedControlPlane {

--- a/frontend/src/utils/enrichmentUtils.ts
+++ b/frontend/src/utils/enrichmentUtils.ts
@@ -1,0 +1,19 @@
+import type { FleetIstio, Istio, EnrichedControlPlane } from '../types/istio'
+
+/** Maps a discovered Istio CR + its cached enrichment data into an EnrichedControlPlane projection. */
+export function toEnrichedControlPlane(r: FleetIstio, cached: Istio | undefined): EnrichedControlPlane {
+  const spec = cached?.spec
+  return {
+    metadata: {
+      name: r.metadata?.name ?? '',
+      creationTimestamp: r.metadata?.creationTimestamp,
+      labels: r.metadata?.labels as Record<string, string> | undefined,
+    },
+    clusterName: r.cluster,
+    controlPlaneNamespace: spec?.namespace,
+    meshID: spec?.values?.global?.meshID,
+    network: spec?.values?.global?.network,
+    status: cached?.status,
+    version: spec?.version,
+  }
+}

--- a/frontend/src/utils/tableCallbacks.ts
+++ b/frontend/src/utils/tableCallbacks.ts
@@ -1,0 +1,6 @@
+import type { ClusterMeshStatus } from '../types/multiClusterMesh'
+
+export const clusterMeshStatusRowKey = (cs: ClusterMeshStatus) => cs.clusterName
+
+export const clusterMeshStatusSearchMatch = (cs: ClusterMeshStatus, query: string) =>
+  cs.clusterName.toLowerCase().includes(query.toLowerCase())

--- a/frontend/src/utils/tableCallbacks.ts
+++ b/frontend/src/utils/tableCallbacks.ts
@@ -4,3 +4,12 @@ export const clusterMeshStatusRowKey = (cs: ClusterMeshStatus) => cs.clusterName
 
 export const clusterMeshStatusSearchMatch = (cs: ClusterMeshStatus, query: string) =>
   cs.clusterName.toLowerCase().includes(query.toLowerCase())
+
+export function sortWithComparator<T>(
+  data: T[],
+  sortDirection: string,
+  compare: (a: T, b: T) => number,
+): T[] {
+  const dir = sortDirection === 'asc' ? 1 : -1
+  return [...data].sort((a, b) => dir * compare(a, b))
+}


### PR DESCRIPTION
Refactor the frontend console plugin to handle hundreds to a thousand clusters, meshes, and control planes without performance degradation.

- Scoped enrichment on detail pages: new `useMeshControlPlanes` hook enriches only the clusters belonging to a specific mesh instead of the entire fleet, reducing API calls from O(fleet) to O(mesh-members)
- O(1) managed mesh correlation: replaced O(M×N) nested filter in `buildItems` with a pre-built `managedByIndex` reverse lookup map
- Stabilized `useDiscoveredControlPlanes` results with `useMemo` to prevent unnecessary downstream recomputation on poll ticks
- Stale-while-revalidate on `ControlPlaneDetailPage`: renders cached data immediately on navigation, refreshes in background, shows warning banner if refresh fails
- Bounded enrichment cache: FIFO eviction cap at 2,000 entries using Map insertion order for O(1) eviction
- Adaptive enrichment concurrency: scales from 10 to 25 concurrent `fleetK8sGet` calls based on fleet size
- Debounced search in `VirtualFilterTable`: 200ms debounce with synchronous `onClear` bypass
- Stabilized inline `VirtualFilterTable` callbacks across `ControlPlanesCard`, `TrustStatusCard`, `ClusterStatusSection`, and `DiscoveredMeshDetailPage` with module-level functions and `useCallback`
- Eliminated `.map()` wrapper allocations in `OverviewPage` by making `countByStatus` generic with an accessor function
- Extracted sort comparators to module-level constants in `ServiceMeshPage` and `ControlPlanesPage`
- Deduplicated shared code: `FleetIstio` type, `toEnrichedControlPlane` mapping utility, and `clusterMeshStatusRowKey`/`clusterMeshStatusSearchMatch` table callbacks extracted to shared modules

Generated-by: Cursor