### PR TITLE
Fix gofmt mismatch in make verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ deps: go.mod go.sum
 
 .PHONY: fmt
 fmt: ## Format Go code
-	go fmt ./...
+	gofmt -s -w $$(git ls-files '*.go')
 
 .PHONY: gen-code
 gen-code: ## Generate DeepCopy code


### PR DESCRIPTION
Run `gofmt -s` in `make fmt` so formatting fixes match the stricter
check enforced by `make verify`.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
