### PR TITLE
Simplify doReconcile and handleDeletion return types

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -147,7 +147,7 @@ func RegisterController(mgr manager.Manager) error {
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 // Reconcile implements the reconcile loop for MultiClusterMesh resources
-func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (result reconcile.Result, reconcileErr error) {
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	klog.Infof("Reconciling MultiClusterMesh: %s/%s", req.Namespace, req.Name)
 
 	// Fetch the MultiClusterMesh resource
@@ -159,7 +159,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 
 	if !mesh.DeletionTimestamp.IsZero() {
 		klog.Infof("MultiClusterMesh being deleted: %s/%s", req.Namespace, req.Name)
-		return r.handleDeletion(ctx, mesh)
+		return reconcile.Result{}, r.handleDeletion(ctx, mesh)
 	}
 
 	if !controllerutil.ContainsFinalizer(mesh, FinalizerName) {
@@ -168,11 +168,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		if err := r.Update(ctx, mesh); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
-		return
+		return reconcile.Result{}, nil
 	}
 
 	oldStatus := mesh.Status.DeepCopy()
 
+	var reconcileErr error
 	var conflict bool
 	if conflict, reconcileErr = r.validate(ctx, mesh); reconcileErr != nil {
 		mesh.SetReadyCondition(metav1.ConditionFalse, meshv1alpha1.ReasonReconcileError, "%v", reconcileErr)
@@ -181,7 +182,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		if err != nil {
 			reconcileErr = fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
 		} else {
-			result, reconcileErr = r.doReconcile(ctx, mesh, clusters)
+			reconcileErr = r.doReconcile(ctx, mesh, clusters)
 		}
 
 		if reconcileErr == nil {
@@ -208,7 +209,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 		})
 	}
 
-	return result, errors.Join(reconcileErr, statusErr)
+	return reconcile.Result{}, errors.Join(reconcileErr, statusErr)
 }
 
 // validate checks for conflicts that prevent reconciliation.
@@ -248,46 +249,46 @@ func isOlderMesh(a, b *meshv1alpha1.MultiClusterMesh) bool {
 			key.For(a).String() < key.For(b).String())
 }
 
-func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) (reconcile.Result, error) {
+func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
 	for _, cluster := range clusters {
 		klog.V(4).Infof("Reconciling cluster %s", cluster.Name)
 
 		work, err := r.workApplier.Apply(ctx, r.buildOperatorManifestWork(mesh, &cluster))
 		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to apply operator ManifestWork on cluster %s: %w", cluster.Name, err)
+			return fmt.Errorf("failed to apply operator ManifestWork on cluster %s: %w", cluster.Name, err)
 		}
 		klog.V(4).Infof("Applied operator ManifestWork %s/%s", work.Namespace, work.Name)
 
 		// Create ManagedServiceAccount resources for each cluster.
 		if err := r.ensureManagedServiceAccountCreated(ctx, mesh, &cluster); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to create ManagedServiceAccounts: %w", err)
+			return fmt.Errorf("failed to create ManagedServiceAccounts: %w", err)
 		}
 
 		if mesh.Spec.Security.Trust.CertManager.IssuerRef.Name != "" {
 			if err := r.ensureCertificateForCluster(ctx, mesh, &cluster); err != nil {
-				return reconcile.Result{}, fmt.Errorf("failed to ensure certificate for cluster %s: %w", cluster.Name, err)
+				return fmt.Errorf("failed to ensure certificate for cluster %s: %w", cluster.Name, err)
 			}
 			if err := r.ensureCacertsManifestWork(ctx, mesh, &cluster); err != nil {
-				return reconcile.Result{}, fmt.Errorf("failed to ensure cacerts ManifestWork for cluster %s: %w", cluster.Name, err)
+				return fmt.Errorf("failed to ensure cacerts ManifestWork for cluster %s: %w", cluster.Name, err)
 			}
 		}
 	}
 
 	forceCleanupAll := mesh.Spec.Security.Trust.CertManager.IssuerRef.Name == ""
 	if err := r.cleanupCertificates(ctx, mesh, clusters, forceCleanupAll); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to cleanup Certificates: %w", err)
+		return fmt.Errorf("failed to cleanup Certificates: %w", err)
 	}
 
 	if err := r.cleanupManifestWorks(ctx, mesh.Spec.ClusterSet); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to cleanup ManifestWorks: %w", err)
+		return fmt.Errorf("failed to cleanup ManifestWorks: %w", err)
 	}
 
 	// Cleanup ManagedServiceAccount when the cluster(s) are removed from the ClusterSet.
 	if err := r.cleanupManagedServiceAccounts(ctx, mesh, clusters); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to cleanup ManagedServiceAccounts: %w", err)
+		return fmt.Errorf("failed to cleanup ManagedServiceAccounts: %w", err)
 	}
 
-	return reconcile.Result{}, nil
+	return nil
 }
 
 // forEachMeshInClusterSet lists all non-deleting meshes targeting the given ClusterSet and calls fn for each.
@@ -350,19 +351,19 @@ func (r *Reconciler) findMeshesForManifestWork(ctx context.Context, obj client.O
 }
 
 // handleDeletion handles cleanup when the MultiClusterMesh is being deleted
-func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) (reconcile.Result, error) {
+func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
 	if !controllerutil.ContainsFinalizer(mesh, FinalizerName) {
 		klog.V(4).Infof("MultiClusterMesh %s/%s has no finalizer, nothing to clean up", mesh.Namespace, mesh.Name)
-		return reconcile.Result{}, nil
+		return nil
 	}
 
 	klog.Infof("Handling deletion for MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
 	if err := r.cleanupManifestWorks(ctx, mesh.Spec.ClusterSet); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to cleanup ManifestWorks: %w", err)
+		return fmt.Errorf("failed to cleanup ManifestWorks: %w", err)
 	}
 
 	if err := r.deleteAllManagedServiceAccounts(ctx, mesh); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to cleanup ManagedServiceAccount resources: %w", err)
+		return fmt.Errorf("failed to cleanup ManagedServiceAccount resources: %w", err)
 	}
 
 	// Trigger reconciliation for other meshes targeting the same cluster set.
@@ -372,10 +373,10 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 	klog.Infof("Removing finalizer from MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
 	controllerutil.RemoveFinalizer(mesh, FinalizerName)
 	if err := r.Update(ctx, mesh); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+		return fmt.Errorf("failed to remove finalizer: %w", err)
 	}
 
-	return reconcile.Result{}, nil
+	return nil
 }
 
 // cleanupManifestWorks deletes ManifestWorks on clusters that no mesh in the given ClusterSet needs anymore.


### PR DESCRIPTION
Both functions always returned a zero-value reconcile.Result alongside
the error. Drop the unused Result return so callers construct it at
their own return sites, making it obvious that no requeue is requested.