### PR TITLE
Use unique cacerts ManifestWork names to prevent multi-tenant collisions

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -710,14 +710,26 @@ func (r *Reconciler) mapSecretToMesh(_ context.Context, obj client.Object) []rec
 	return []reconcile.Request{{NamespacedName: key.Of(meshName, meshNamespace)}}
 }
 
-// getCacertsName returns the name for the certificate and secret for a specific cluster
-func getCacertsName(clusterName string) string {
-	return fmt.Sprintf("cacerts-%s", clusterName)
+// CacertsSecretAndCertName returns the Certificate and Secret name for a specific (mesh, cluster) pair.
+// The name includes an FNV-32a hash of the mesh/cluster identity to prevent collisions when two meshes
+// in the same namespace target the same clusters.
+func CacertsSecretAndCertName(meshName, clusterName string) string {
+	h := fnv.New32a()
+	fmt.Fprintf(h, "mesh=%s,cluster=%s", meshName, clusterName)
+	hash := fmt.Sprintf("%08x", h.Sum32())
+
+	full := fmt.Sprintf("cacerts-%s-%s", clusterName, hash)
+	if len(full) <= 253 {
+		return full
+	}
+
+	maxCluster := 253 - len("cacerts-") - 1 - 8
+	return fmt.Sprintf("cacerts-%s-%s", strings.TrimRight(clusterName[:maxCluster], "-"), hash)
 }
 
 // ensureCertificateForCluster applies the desired Certificate state for a specific cluster using server-side apply.
 func (r *Reconciler) ensureCertificateForCluster(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) error {
-	certName := getCacertsName(cluster.Name)
+	certName := CacertsSecretAndCertName(mesh.Name, cluster.Name)
 
 	gvk, err := r.GroupVersionKindFor(mesh)
 	if err != nil {
@@ -764,7 +776,7 @@ func (r *Reconciler) ensureCertificateForCluster(ctx context.Context, mesh *mesh
 
 // ensureCacertsManifestWork creates a ManifestWork to distribute the cacerts secret to a cluster
 func (r *Reconciler) ensureCacertsManifestWork(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) error {
-	secretName := getCacertsName(cluster.Name)
+	secretName := CacertsSecretAndCertName(mesh.Name, cluster.Name)
 	secret := &corev1.Secret{}
 	err := r.Get(ctx, key.Of(secretName, mesh.Namespace), secret)
 

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -454,10 +454,11 @@ func (r *Reconciler) triggerReconcileForNotReadyMeshes(ctx context.Context, mesh
 }
 
 func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
-	mesh.Status.ClusterStatus = make([]meshv1alpha1.ClusterMeshStatus, 0, len(clusters))
 	allReady := len(clusters) > 0
 
+	activeClusterNames := make(map[string]bool, len(clusters))
 	for _, cluster := range clusters {
+		activeClusterNames[cluster.Name] = true
 
 		operatorWork := &workv1.ManifestWork{}
 		if err := r.Get(ctx, key.Of(OperatorManifestWorkName, cluster.Name), operatorWork); err != nil {
@@ -473,6 +474,10 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 				meshv1alpha1.ReasonInstallationPending, "Operator installation is pending")
 		}
 	}
+
+	mesh.Status.ClusterStatus = slices.DeleteFunc(mesh.Status.ClusterStatus, func(cs meshv1alpha1.ClusterMeshStatus) bool {
+		return !activeClusterNames[cs.ClusterName]
+	})
 
 	if allReady {
 		mesh.SetReadyCondition(metav1.ConditionTrue,

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -836,7 +836,7 @@ func CacertsManifestWorkName(meshName, meshNamespace string) string {
 // meshResourceName generates a unique, deterministic resource name for a per-mesh resource.
 // It appends an 8-char FNV-32a hash of "name=<name>,namespace=<namespace>" to avoid
 // collisions when name/namespace pairs differ only in hyphen boundaries (e.g. "a"/"ab" vs "aa"/"b").
-// If the result exceeds maxLen, the mesh name and namespace are truncated to fit.
+// If the result exceeds maxLen, the mesh name is truncated first to preserve the full namespace.
 func meshResourceName(prefix, meshName, meshNamespace string, maxLen int) string {
 	h := fnv.New32a()
 	fmt.Fprintf(h, "name=%s,namespace=%s", meshName, meshNamespace)
@@ -850,13 +850,14 @@ func meshResourceName(prefix, meshName, meshNamespace string, maxLen int) string
 	overhead := len(prefix) + 3 + 8
 	remaining := maxLen - overhead
 
-	nameMax := (remaining + 1) / 2
+	nsLen := len(meshNamespace)
+	if nsLen > remaining {
+		nsLen = remaining
+		meshNamespace = strings.TrimRight(meshNamespace[:nsLen], "-")
+	}
+	nameMax := remaining - nsLen
 	if len(meshName) > nameMax {
 		meshName = strings.TrimRight(meshName[:nameMax], "-")
-	}
-	nsMax := remaining - len(meshName)
-	if len(meshNamespace) > nsMax {
-		meshNamespace = strings.TrimRight(meshNamespace[:nsMax], "-")
 	}
 
 	return fmt.Sprintf("%s-%s-%s-%s", prefix, meshName, meshNamespace, hash)

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"reflect"
 	"slices"
 	"strings"
@@ -278,6 +279,10 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 		return reconcile.Result{}, fmt.Errorf("failed to cleanup Certificates: %w", err)
 	}
 
+	if err := r.cleanupMeshOwnedManifestWorks(ctx, mesh, clusters, forceCleanupAll); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to cleanup mesh-owned ManifestWorks: %w", err)
+	}
+
 	if err := r.cleanupManifestWorks(ctx, mesh.Spec.ClusterSet); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to cleanup ManifestWorks: %w", err)
 	}
@@ -357,6 +362,10 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 	}
 
 	klog.Infof("Handling deletion for MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
+	if err := r.cleanupMeshOwnedManifestWorks(ctx, mesh, nil, true); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to cleanup mesh-owned ManifestWorks: %w", err)
+	}
+
 	if err := r.cleanupManifestWorks(ctx, mesh.Spec.ClusterSet); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to cleanup ManifestWorks: %w", err)
 	}
@@ -396,6 +405,35 @@ func (r *Reconciler) cleanupManifestWorks(ctx context.Context, clusterSet string
 		}
 
 		klog.Infof("Deleting ManifestWork %s/%s (no mesh targets this cluster)", work.Namespace, work.Name)
+		if err := r.workApplier.Delete(ctx, work.Namespace, work.Name); err != nil {
+			return fmt.Errorf("failed to delete ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// cleanupMeshOwnedManifestWorks deletes mesh-owned ManifestWorks. When deleteAll is true, all ManifestWorks for the
+// mesh are removed (e.g. when the mesh is deleted or the issuer is cleared). Otherwise, only ManifestWorks for
+// clusters no longer in the ClusterSet are removed.
+func (r *Reconciler) cleanupMeshOwnedManifestWorks(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster, deleteAll bool) error {
+	clusterNames := clusterNameSet(clusters)
+
+	workList := &workv1.ManifestWorkList{}
+	if err := r.List(ctx, workList, client.MatchingLabels{
+		ManagedByLabel:     ManagedByValue,
+		MeshNameLabel:      mesh.Name,
+		MeshNamespaceLabel: mesh.Namespace,
+	}); err != nil {
+		return fmt.Errorf("failed to list mesh-owned ManifestWorks: %w", err)
+	}
+
+	for _, work := range workList.Items {
+		if !deleteAll && clusterNames[work.Namespace] {
+			continue
+		}
+
+		klog.Infof("Deleting ManifestWork %s/%s", work.Namespace, work.Name)
 		if err := r.workApplier.Delete(ctx, work.Namespace, work.Name); err != nil {
 			return fmt.Errorf("failed to delete ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
 		}
@@ -764,7 +802,7 @@ func (r *Reconciler) buildCacertsManifestWork(mesh *meshv1alpha1.MultiClusterMes
 
 	return &workv1.ManifestWork{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ManifestWorkNameCacerts,
+			Name:      CacertsManifestWorkName(mesh.Name, mesh.Namespace),
 			Namespace: clusterName,
 			Labels:    meshOwnedLabels(mesh, clusterName),
 		},
@@ -786,4 +824,40 @@ func meshOwnedLabels(mesh *meshv1alpha1.MultiClusterMesh, clusterName string) ma
 		MeshNamespaceLabel: mesh.Namespace,
 		ClusterNameLabel:   clusterName,
 	}
+}
+
+// CacertsManifestWorkName returns the ManifestWork name for distributing cacerts for a mesh.
+// The 188-char limit comes from the Klusterlet creating an AppliedManifestWork named
+// "<64-char-hub-hash>-<manifestwork-name>", which must fit within the 253-char CRD name limit.
+func CacertsManifestWorkName(meshName, meshNamespace string) string {
+	return meshResourceName(ManifestWorkNameCacerts, meshName, meshNamespace, 188)
+}
+
+// meshResourceName generates a unique, deterministic resource name for a per-mesh resource.
+// It appends an 8-char FNV-32a hash of "name=<name>,namespace=<namespace>" to avoid
+// collisions when name/namespace pairs differ only in hyphen boundaries (e.g. "a"/"ab" vs "aa"/"b").
+// If the result exceeds maxLen, the mesh name and namespace are truncated to fit.
+func meshResourceName(prefix, meshName, meshNamespace string, maxLen int) string {
+	h := fnv.New32a()
+	fmt.Fprintf(h, "name=%s,namespace=%s", meshName, meshNamespace)
+	hash := fmt.Sprintf("%08x", h.Sum32())
+
+	full := fmt.Sprintf("%s-%s-%s-%s", prefix, meshName, meshNamespace, hash)
+	if len(full) <= maxLen {
+		return full
+	}
+
+	overhead := len(prefix) + 3 + 8
+	remaining := maxLen - overhead
+
+	nameMax := (remaining + 1) / 2
+	if len(meshName) > nameMax {
+		meshName = strings.TrimRight(meshName[:nameMax], "-")
+	}
+	nsMax := remaining - len(meshName)
+	if len(meshNamespace) > nsMax {
+		meshNamespace = strings.TrimRight(meshNamespace[:nsMax], "-")
+	}
+
+	return fmt.Sprintf("%s-%s-%s-%s", prefix, meshName, meshNamespace, hash)
 }

--- a/pkg/hub/mesh/controller_test.go
+++ b/pkg/hub/mesh/controller_test.go
@@ -119,3 +119,27 @@ func meshWith(namespace, name string, ts metav1.Time) *meshv1alpha1.MultiCluster
 		},
 	}
 }
+
+func TestMeshResourceNameIsDeterministic(t *testing.T) {
+	a := meshResourceName("multicluster-mesh-cacerts", "my-mesh", "my-namespace", 188)
+	b := meshResourceName("multicluster-mesh-cacerts", "my-mesh", "my-namespace", 188)
+	if a != b {
+		t.Errorf("not deterministic: %q != %q", a, b)
+	}
+}
+
+func TestMeshResourceNameAvoidsBoundaryCollisions(t *testing.T) {
+	a := meshResourceName("multicluster-mesh-cacerts", "a", "ab", 188)
+	b := meshResourceName("multicluster-mesh-cacerts", "aa", "b", 188)
+	if a == b {
+		t.Errorf("boundary collision: %q == %q", a, b)
+	}
+}
+
+func TestMeshResourceNameTruncatesLongNames(t *testing.T) {
+	long := "abcdefghijklmnopqrstuvwxyz0123456789"
+	result := meshResourceName("multicluster-mesh-cacerts", long, long, 63)
+	if len(result) > 63 {
+		t.Errorf("name exceeds maxLen: %q (len=%d)", result, len(result))
+	}
+}

--- a/pkg/hub/mesh/controller_test.go
+++ b/pkg/hub/mesh/controller_test.go
@@ -2,6 +2,7 @@ package mesh
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -141,5 +142,17 @@ func TestMeshResourceNameTruncatesLongNames(t *testing.T) {
 	result := meshResourceName("multicluster-mesh-cacerts", long, long, 63)
 	if len(result) > 63 {
 		t.Errorf("name exceeds maxLen: %q (len=%d)", result, len(result))
+	}
+}
+
+func TestMeshResourceNamePreservesNamespace(t *testing.T) {
+	longName := strings.Repeat("a", 253)
+	namespace := strings.Repeat("b", 63)
+	result := meshResourceName("multicluster-mesh-cacerts", longName, namespace, 188)
+	if len(result) > 188 {
+		t.Errorf("name exceeds maxLen: %q (len=%d)", result, len(result))
+	}
+	if !strings.Contains(result, namespace) {
+		t.Errorf("namespace was truncated: %q does not contain %q", result, namespace)
 	}
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -150,6 +150,50 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectClusterOperatorConditionReason(meshName, testNs, cluster2Name, meshv1alpha1.ReasonOperatorInstalled)
 				expectMeshReady(meshName, testNs)
 			})
+
+			It("should preserve per-cluster condition LastTransitionTime when status is unchanged", func() {
+				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonInstallationPending)
+
+				var initialTime metav1.Time
+				Eventually(func(g Gomega) {
+					mesh := &meshv1alpha1.MultiClusterMesh{}
+					g.Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
+					for _, cs := range mesh.Status.ClusterStatus {
+						if cs.ClusterName == clusterName {
+							c := findCondition(g, cs.Conditions, meshv1alpha1.ConditionOperatorInstalled)
+							initialTime = c.LastTransitionTime
+							g.Expect(initialTime.IsZero()).To(BeFalse())
+							return
+						}
+					}
+					g.Expect(false).To(BeTrue(), "cluster %s not found in status", clusterName)
+				}).Should(Succeed())
+
+				time.Sleep(2 * time.Second)
+
+				mesh := &meshv1alpha1.MultiClusterMesh{}
+				Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
+				if mesh.Annotations == nil {
+					mesh.Annotations = map[string]string{}
+				}
+				mesh.Annotations["trigger-reconcile"] = "true"
+				Expect(k8sClient.Update(ctx, mesh)).To(Succeed())
+
+				Consistently(func(g Gomega) {
+					mesh := &meshv1alpha1.MultiClusterMesh{}
+					g.Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
+					for _, cs := range mesh.Status.ClusterStatus {
+						if cs.ClusterName == clusterName {
+							c := findCondition(g, cs.Conditions, meshv1alpha1.ConditionOperatorInstalled)
+							g.Expect(c.LastTransitionTime).To(Equal(initialTime),
+								"LastTransitionTime changed from %v — determineStatus is not preserving existing conditions",
+								initialTime)
+							return
+						}
+					}
+					g.Expect(false).To(BeTrue(), "cluster %s not found in status", clusterName)
+				}, 3*time.Second, 500*time.Millisecond).Should(Succeed())
+			})
 		})
 
 		It("should use custom operator configuration when specified", func() {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -622,7 +622,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectCacertsManifestWork(meshName, testNs, clusterName)
 
 				secret := &corev1.Secret{}
-				Expect(k8sClient.Get(ctx, key.Of(fmt.Sprintf("cacerts-%s", clusterName), testNs), secret)).To(Succeed())
+				Expect(k8sClient.Get(ctx, key.Of(meshcontroller.CacertsSecretAndCertName(meshName, clusterName), testNs), secret)).To(Succeed())
 
 				secret.Data["tls.crt"] = []byte("updated-cert-data")
 				Expect(k8sClient.Update(ctx, secret)).To(Succeed())
@@ -747,7 +747,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				updateClusterSetLabel(clusterName, "")
 
 				util.ExpectResourceDeleted(ctx, k8sClient, &certmanagerv1.Certificate{},
-					fmt.Sprintf("cacerts-%s", clusterName), testNs)
+					meshcontroller.CacertsSecretAndCertName(meshName, clusterName), testNs)
 			})
 		})
 
@@ -762,7 +762,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				})
 
 				util.ExpectResourceDeleted(ctx, k8sClient, &certmanagerv1.Certificate{},
-					fmt.Sprintf("cacerts-%s", clusterName), testNs)
+					meshcontroller.CacertsSecretAndCertName(meshName, clusterName), testNs)
 			})
 		})
 
@@ -1003,7 +1003,7 @@ func expectCertificate(namespace, clusterName, meshName, issuerName, issuerKind 
 
 	cert := &certList.Items[0]
 	Expect(cert.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
-	Expect(cert.Spec.SecretName).To(Equal(fmt.Sprintf("cacerts-%s", clusterName)))
+	Expect(cert.Spec.SecretName).To(Equal(meshcontroller.CacertsSecretAndCertName(meshName, clusterName)))
 	Expect(cert.Spec.IsCA).To(BeTrue())
 	Expect(cert.Spec.IssuerRef.Name).To(Equal(issuerName))
 	Expect(cert.Spec.IssuerRef.Kind).To(Equal(issuerKind))

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -613,13 +613,13 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				// simulate creating the cacerts secret by cert-manager
 				util.CreateCacertsSecret(ctx, k8sClient, testNs, clusterName, meshName, testNs)
 
-				work := expectCacertsManifestWork(clusterName)
+				work := expectCacertsManifestWork(meshName, testNs, clusterName)
 				expectCacertsSecret(work)
 			})
 
 			It("should update ManifestWork when cacerts secret is updated", func() {
 				util.CreateCacertsSecret(ctx, k8sClient, testNs, clusterName, meshName, testNs)
-				expectCacertsManifestWork(clusterName)
+				expectCacertsManifestWork(meshName, testNs, clusterName)
 
 				secret := &corev1.Secret{}
 				Expect(k8sClient.Get(ctx, key.Of(fmt.Sprintf("cacerts-%s", clusterName), testNs), secret)).To(Succeed())
@@ -629,7 +629,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 				Eventually(func() string {
 					work := &workv1.ManifestWork{}
-					if err := k8sClient.Get(ctx, key.Of(meshcontroller.ManifestWorkNameCacerts, clusterName), work); err != nil {
+					if err := k8sClient.Get(ctx, key.Of(meshcontroller.CacertsManifestWorkName(meshName, testNs), clusterName), work); err != nil {
 						return ""
 					}
 					manifestSecret := &corev1.Secret{}
@@ -664,8 +664,77 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				util.CreateCacertsSecret(ctx, k8sClient, testNs, cluster1, meshName, testNs)
 				util.CreateCacertsSecret(ctx, k8sClient, testNs, cluster2, meshName, testNs)
 
-				expectCacertsManifestWork(cluster1)
-				expectCacertsManifestWork(cluster2)
+				expectCacertsManifestWork(meshName, testNs, cluster1)
+				expectCacertsManifestWork(meshName, testNs, cluster2)
+			})
+		})
+
+		When("two meshes in different namespaces target the same cluster", func() {
+			var mesh1, mesh1Ns, mesh2, mesh2Ns string
+
+			BeforeEach(func() {
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+
+				mesh1 = util.UniqueName("mesh-1")
+				mesh1Ns = util.UniqueName("mesh-1-ns")
+				mesh2 = util.UniqueName("mesh-2")
+				mesh2Ns = util.UniqueName("mesh-2-ns")
+				util.CreateNamespace(ctx, k8sClient, mesh1Ns)
+				util.CreateNamespace(ctx, k8sClient, mesh2Ns)
+
+				util.CreateMultiClusterMesh(ctx, k8sClient, mesh1, mesh1Ns, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
+					ControlPlane: meshv1alpha1.ControlPlaneConfig{Namespace: "istio-system-1"},
+					Security: meshv1alpha1.SecurityConfig{Trust: meshv1alpha1.TrustConfig{
+						CertManager: meshv1alpha1.CertManagerConfig{IssuerRef: meshv1alpha1.IssuerReference{Name: "mesh-issuer", Kind: "Issuer"}},
+					}},
+				})
+				util.CreateMultiClusterMesh(ctx, k8sClient, mesh2, mesh2Ns, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
+					ControlPlane: meshv1alpha1.ControlPlaneConfig{Namespace: "istio-system-2"},
+					Security: meshv1alpha1.SecurityConfig{Trust: meshv1alpha1.TrustConfig{
+						CertManager: meshv1alpha1.CertManagerConfig{IssuerRef: meshv1alpha1.IssuerReference{Name: "mesh-issuer", Kind: "Issuer"}},
+					}},
+				})
+
+				util.CreateCacertsSecret(ctx, k8sClient, mesh1Ns, clusterName, mesh1, mesh1Ns)
+				util.CreateCacertsSecret(ctx, k8sClient, mesh2Ns, clusterName, mesh2, mesh2Ns)
+			})
+
+			It("should create cacerts ManifestWork for each mesh", func() {
+				expectCacertsManifestWork(mesh1, mesh1Ns, clusterName)
+				expectCacertsManifestWork(mesh2, mesh2Ns, clusterName)
+			})
+
+			It("should delete only the removed mesh's cacerts ManifestWork while keeping the operator ManifestWork", func() {
+				expectCacertsManifestWork(mesh1, mesh1Ns, clusterName)
+				expectCacertsManifestWork(mesh2, mesh2Ns, clusterName)
+
+				util.DeleteResource(ctx, k8sClient, &meshv1alpha1.MultiClusterMesh{}, mesh1, mesh1Ns)
+
+				util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
+					meshcontroller.CacertsManifestWorkName(mesh1, mesh1Ns), clusterName)
+
+				Consistently(func() error {
+					return k8sClient.Get(ctx, key.Of(meshcontroller.CacertsManifestWorkName(mesh2, mesh2Ns), clusterName), &workv1.ManifestWork{})
+				}).Should(Succeed())
+
+				Consistently(func() error {
+					return k8sClient.Get(ctx, key.Of(meshcontroller.OperatorManifestWorkName, clusterName), &workv1.ManifestWork{})
+				}).Should(Succeed())
+			})
+
+			It("should delete all ManifestWorks when the last mesh is deleted", func() {
+				expectCacertsManifestWork(mesh1, mesh1Ns, clusterName)
+				expectCacertsManifestWork(mesh2, mesh2Ns, clusterName)
+
+				util.DeleteResource(ctx, k8sClient, &meshv1alpha1.MultiClusterMesh{}, mesh1, mesh1Ns)
+				util.DeleteResource(ctx, k8sClient, &meshv1alpha1.MultiClusterMesh{}, mesh2, mesh2Ns)
+
+				util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
+					meshcontroller.CacertsManifestWorkName(mesh1, mesh1Ns), clusterName)
+				util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
+					meshcontroller.CacertsManifestWorkName(mesh2, mesh2Ns), clusterName)
+				util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
+					meshcontroller.OperatorManifestWorkName, clusterName)
 			})
 		})
 
@@ -705,7 +774,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 
 			It("should not create cacerts ManifestWork", func() {
 				expectMeshNotReady(meshName, testNs)
-				expectNoCacertsManifestWork(clusterName)
+				expectNoCacertsManifestWork(meshName, testNs, clusterName)
 			})
 		})
 
@@ -896,8 +965,8 @@ func expectOperatorManifestWork(clusterNamespace string) *workv1.ManifestWork {
 	return expectManifestWork(meshcontroller.OperatorManifestWorkName, clusterNamespace)
 }
 
-func expectCacertsManifestWork(clusterNamespace string) *workv1.ManifestWork {
-	return expectManifestWork(meshcontroller.ManifestWorkNameCacerts, clusterNamespace)
+func expectCacertsManifestWork(meshName, meshNamespace, clusterNamespace string) *workv1.ManifestWork {
+	return expectManifestWork(meshcontroller.CacertsManifestWorkName(meshName, meshNamespace), clusterNamespace)
 }
 
 func expectNoCertificate(namespace, meshName string) {
@@ -911,10 +980,10 @@ func expectNoCertificate(namespace, meshName string) {
 	}).Should(BeEmpty())
 }
 
-func expectNoCacertsManifestWork(clusterNamespace string) {
+func expectNoCacertsManifestWork(meshName, meshNamespace, clusterNamespace string) {
 	Consistently(func() bool {
 		work := &workv1.ManifestWork{}
-		err := k8sClient.Get(ctx, key.Of(meshcontroller.ManifestWorkNameCacerts, clusterNamespace), work)
+		err := k8sClient.Get(ctx, key.Of(meshcontroller.CacertsManifestWorkName(meshName, meshNamespace), clusterNamespace), work)
 		return errors.IsNotFound(err)
 	}).Should(BeTrue())
 }

--- a/test/util/k8s.go
+++ b/test/util/k8s.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -43,7 +42,7 @@ func CreateNamespace(ctx context.Context, k8sClient client.Client, name string) 
 func CreateCacertsSecret(ctx context.Context, k8sClient client.Client, namespace, clusterName, meshName, meshNamespace string) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("cacerts-%s", clusterName),
+			Name:      meshcontroller.CacertsSecretAndCertName(meshName, clusterName),
 			Namespace: namespace,
 			Labels: map[string]string{
 				meshcontroller.ManagedByLabel:     meshcontroller.ManagedByValue,


### PR DESCRIPTION
Depends on #209