### PR TITLE
Preserve per-cluster LastTransitionTime in determineStatus

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -454,10 +454,11 @@ func (r *Reconciler) triggerReconcileForNotReadyMeshes(ctx context.Context, mesh
 }
 
 func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
-	mesh.Status.ClusterStatus = make([]meshv1alpha1.ClusterMeshStatus, 0, len(clusters))
 	allReady := len(clusters) > 0
 
+	activeClusterNames := make(map[string]bool, len(clusters))
 	for _, cluster := range clusters {
+		activeClusterNames[cluster.Name] = true
 
 		operatorWork := &workv1.ManifestWork{}
 		if err := r.Get(ctx, key.Of(OperatorManifestWorkName, cluster.Name), operatorWork); err != nil {
@@ -473,6 +474,10 @@ func (r *Reconciler) determineStatus(ctx context.Context, mesh *meshv1alpha1.Mul
 				meshv1alpha1.ReasonInstallationPending, "Operator installation is pending")
 		}
 	}
+
+	mesh.Status.ClusterStatus = slices.DeleteFunc(mesh.Status.ClusterStatus, func(cs meshv1alpha1.ClusterMeshStatus) bool {
+		return !activeClusterNames[cs.ClusterName]
+	})
 
 	if allReady {
 		mesh.SetReadyCondition(metav1.ConditionTrue,

--- a/pkg/hub/mesh/controller_test.go
+++ b/pkg/hub/mesh/controller_test.go
@@ -5,20 +5,19 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 )
 
 func TestGetClustersFromSetReturnsSortedClusters(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clusterv1.Install(scheme)
-	_ = clusterv1beta2.Install(scheme)
-	_ = meshv1alpha1.Install(scheme)
+	scheme := newTestScheme()
 
 	clusterSet := &clusterv1beta2.ManagedClusterSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-set"},
@@ -110,12 +109,169 @@ func TestIsOlderMesh(t *testing.T) {
 	}
 }
 
+func TestDetermineStatusPreservesLastTransitionTime(t *testing.T) {
+	scheme := newTestScheme()
+	clusterName := "cluster-a"
+
+	hourAgo := metav1.NewTime(time.Now().Add(-time.Hour))
+	mesh := &meshv1alpha1.MultiClusterMesh{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mesh", Namespace: "default", Generation: 1},
+		Status: meshv1alpha1.MultiClusterMeshStatus{
+			ClusterStatus: []meshv1alpha1.ClusterMeshStatus{{
+				ClusterName: clusterName,
+				Conditions: []metav1.Condition{{
+					Type:               meshv1alpha1.ConditionOperatorInstalled,
+					Status:             metav1.ConditionTrue,
+					Reason:             meshv1alpha1.ReasonOperatorInstalled,
+					Message:            "Operator installed: " + testInstalledCSV,
+					LastTransitionTime: hourAgo,
+				}},
+			}},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(operatorManifestWorkWithInstalledCSV(clusterName)).
+		WithStatusSubresource(operatorManifestWorkWithInstalledCSV(clusterName)).
+		Build()
+
+	r := &Reconciler{Client: client, Scheme: scheme}
+	clusters := []clusterv1.ManagedCluster{{ObjectMeta: metav1.ObjectMeta{Name: clusterName}}}
+
+	if err := r.determineStatus(context.Background(), mesh, clusters); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c := meta.FindStatusCondition(mesh.Status.ClusterStatus[0].Conditions, meshv1alpha1.ConditionOperatorInstalled)
+	if c == nil {
+		t.Fatal("OperatorInstalled condition not found")
+	}
+	if !c.LastTransitionTime.Equal(&hourAgo) {
+		t.Errorf("LastTransitionTime changed from %v to %v", hourAgo, c.LastTransitionTime)
+	}
+}
+
+func TestDetermineStatusPrunesStaleCluster(t *testing.T) {
+	scheme := newTestScheme()
+	activeCluster := "cluster-a"
+
+	mesh := &meshv1alpha1.MultiClusterMesh{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mesh", Namespace: "default", Generation: 1},
+		Status: meshv1alpha1.MultiClusterMeshStatus{
+			ClusterStatus: []meshv1alpha1.ClusterMeshStatus{
+				{ClusterName: activeCluster},
+				{ClusterName: "removed-cluster"},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(operatorManifestWorkWithInstalledCSV(activeCluster)).
+		WithStatusSubresource(operatorManifestWorkWithInstalledCSV(activeCluster)).
+		Build()
+
+	r := &Reconciler{Client: client, Scheme: scheme}
+	clusters := []clusterv1.ManagedCluster{{ObjectMeta: metav1.ObjectMeta{Name: activeCluster}}}
+
+	if err := r.determineStatus(context.Background(), mesh, clusters); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mesh.Status.ClusterStatus) != 1 {
+		t.Fatalf("expected 1 cluster status, got %d", len(mesh.Status.ClusterStatus))
+	}
+	if mesh.Status.ClusterStatus[0].ClusterName != activeCluster {
+		t.Errorf("expected cluster %s, got %s", activeCluster, mesh.Status.ClusterStatus[0].ClusterName)
+	}
+}
+
+func TestDetermineStatusUpdatesLastTransitionTimeOnStatusChange(t *testing.T) {
+	scheme := newTestScheme()
+	clusterName := "cluster-a"
+
+	hourAgo := metav1.NewTime(time.Now().Add(-time.Hour))
+	mesh := &meshv1alpha1.MultiClusterMesh{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mesh", Namespace: "default", Generation: 1},
+		Status: meshv1alpha1.MultiClusterMeshStatus{
+			ClusterStatus: []meshv1alpha1.ClusterMeshStatus{{
+				ClusterName: clusterName,
+				Conditions: []metav1.Condition{{
+					Type:               meshv1alpha1.ConditionOperatorInstalled,
+					Status:             metav1.ConditionFalse,
+					Reason:             meshv1alpha1.ReasonInstallationPending,
+					Message:            "Operator installation is pending",
+					LastTransitionTime: hourAgo,
+				}},
+			}},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(operatorManifestWorkWithInstalledCSV(clusterName)).
+		WithStatusSubresource(operatorManifestWorkWithInstalledCSV(clusterName)).
+		Build()
+
+	r := &Reconciler{Client: client, Scheme: scheme}
+	clusters := []clusterv1.ManagedCluster{{ObjectMeta: metav1.ObjectMeta{Name: clusterName}}}
+
+	if err := r.determineStatus(context.Background(), mesh, clusters); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c := meta.FindStatusCondition(mesh.Status.ClusterStatus[0].Conditions, meshv1alpha1.ConditionOperatorInstalled)
+	if c == nil {
+		t.Fatal("OperatorInstalled condition not found")
+	}
+	if c.Status != metav1.ConditionTrue {
+		t.Errorf("expected status %s, got %s", metav1.ConditionTrue, c.Status)
+	}
+	if c.LastTransitionTime.Equal(&hourAgo) {
+		t.Error("LastTransitionTime should have changed after status transition")
+	}
+}
+
 func meshWith(namespace, name string, ts metav1.Time) *meshv1alpha1.MultiClusterMesh {
 	return &meshv1alpha1.MultiClusterMesh{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
 			Namespace:         namespace,
 			CreationTimestamp: ts,
+		},
+	}
+}
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = clusterv1.Install(scheme)
+	_ = clusterv1beta2.Install(scheme)
+	_ = meshv1alpha1.Install(scheme)
+	_ = workv1.Install(scheme)
+	return scheme
+}
+
+const testInstalledCSV = "istio-operator.v1.0.0"
+
+func operatorManifestWorkWithInstalledCSV(clusterName string) *workv1.ManifestWork {
+	csv := testInstalledCSV
+	return &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      OperatorManifestWorkName,
+			Namespace: clusterName,
+		},
+		Status: workv1.ManifestWorkStatus{
+			ResourceStatus: workv1.ManifestResourceStatus{
+				Manifests: []workv1.ManifestCondition{{
+					StatusFeedbacks: workv1.StatusFeedbackResult{
+						Values: []workv1.FeedbackValue{{
+							Name:  FeedbackInstalledCSV,
+							Value: workv1.FieldValue{String: &csv},
+						}},
+					},
+				}},
+			},
 		},
 	}
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -150,44 +150,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectClusterOperatorConditionReason(meshName, testNs, cluster2Name, meshv1alpha1.ReasonOperatorInstalled)
 				expectMeshReady(meshName, testNs)
 			})
-
-			It("should preserve per-cluster condition LastTransitionTime when status is unchanged", func() {
-				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonInstallationPending)
-
-				var initialTime metav1.Time
-				Eventually(func(g Gomega) {
-					mesh := &meshv1alpha1.MultiClusterMesh{}
-					g.Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
-					for _, cs := range mesh.Status.ClusterStatus {
-						if cs.ClusterName == clusterName {
-							c := findCondition(g, cs.Conditions, meshv1alpha1.ConditionOperatorInstalled)
-							initialTime = c.LastTransitionTime
-							g.Expect(initialTime.IsZero()).To(BeFalse())
-							return
-						}
-					}
-					g.Expect(false).To(BeTrue(), "cluster %s not found in status", clusterName)
-				}).Should(Succeed())
-
-				time.Sleep(2 * time.Second)
-
-				triggerReconcile(meshName, testNs)
-
-				Consistently(func(g Gomega) {
-					mesh := &meshv1alpha1.MultiClusterMesh{}
-					g.Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
-					for _, cs := range mesh.Status.ClusterStatus {
-						if cs.ClusterName == clusterName {
-							c := findCondition(g, cs.Conditions, meshv1alpha1.ConditionOperatorInstalled)
-							g.Expect(c.LastTransitionTime).To(Equal(initialTime),
-								"LastTransitionTime changed from %v - determineStatus is not preserving existing conditions",
-								initialTime)
-							return
-						}
-					}
-					g.Expect(false).To(BeTrue(), "cluster %s not found in status", clusterName)
-				}, 3*time.Second, 500*time.Millisecond).Should(Succeed())
-			})
 		})
 
 		It("should use custom operator configuration when specified", func() {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -150,6 +150,44 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectClusterOperatorConditionReason(meshName, testNs, cluster2Name, meshv1alpha1.ReasonOperatorInstalled)
 				expectMeshReady(meshName, testNs)
 			})
+
+			It("should preserve per-cluster condition LastTransitionTime when status is unchanged", func() {
+				expectClusterOperatorConditionReason(meshName, testNs, clusterName, meshv1alpha1.ReasonInstallationPending)
+
+				var initialTime metav1.Time
+				Eventually(func(g Gomega) {
+					mesh := &meshv1alpha1.MultiClusterMesh{}
+					g.Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
+					for _, cs := range mesh.Status.ClusterStatus {
+						if cs.ClusterName == clusterName {
+							c := findCondition(g, cs.Conditions, meshv1alpha1.ConditionOperatorInstalled)
+							initialTime = c.LastTransitionTime
+							g.Expect(initialTime.IsZero()).To(BeFalse())
+							return
+						}
+					}
+					g.Expect(false).To(BeTrue(), "cluster %s not found in status", clusterName)
+				}).Should(Succeed())
+
+				time.Sleep(2 * time.Second)
+
+				triggerReconcile(meshName, testNs)
+
+				Consistently(func(g Gomega) {
+					mesh := &meshv1alpha1.MultiClusterMesh{}
+					g.Expect(k8sClient.Get(ctx, key.Of(meshName, testNs), mesh)).To(Succeed())
+					for _, cs := range mesh.Status.ClusterStatus {
+						if cs.ClusterName == clusterName {
+							c := findCondition(g, cs.Conditions, meshv1alpha1.ConditionOperatorInstalled)
+							g.Expect(c.LastTransitionTime).To(Equal(initialTime),
+								"LastTransitionTime changed from %v — determineStatus is not preserving existing conditions",
+								initialTime)
+							return
+						}
+					}
+					g.Expect(false).To(BeTrue(), "cluster %s not found in status", clusterName)
+				}, 3*time.Second, 500*time.Millisecond).Should(Succeed())
+			})
 		})
 
 		It("should use custom operator configuration when specified", func() {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -180,7 +180,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 						if cs.ClusterName == clusterName {
 							c := findCondition(g, cs.Conditions, meshv1alpha1.ConditionOperatorInstalled)
 							g.Expect(c.LastTransitionTime).To(Equal(initialTime),
-								"LastTransitionTime changed from %v — determineStatus is not preserving existing conditions",
+								"LastTransitionTime changed from %v - determineStatus is not preserving existing conditions",
 								initialTime)
 							return
 						}


### PR DESCRIPTION
determineStatus() reset ClusterStatus to a fresh empty slice on every reconcile, then re-appended entries via SetClusterCondition. Even when the condition status hadn't changed, meta.SetStatusCondition only preserves LastTransitionTime when it finds an existing condition in the slice - but the slice was just recreated empty, so every condition got a new LastTransitionTime. This made the status always differ from the persisted version, triggering a status update on every reconcile.

Fix: preserve existing ClusterStatus entries so meta.SetStatusCondition can find and keep stable LastTransitionTime values. Use slices.DeleteFunc to prune entries for clusters no longer in the ClusterSet.