### PR TITLE
Parallelize dev-env and dev-clean via Make dependency graph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,12 +254,11 @@ DEV_ENV_SCRIPT := $(CURDIR)/hack/dev-env.sh
 export DEV_KUBE_DIR K8S_VERSION OLM_VERSION CERT_MANAGER_VERSION MSA_VERSION
 export KIND CLUSTERADM HELM
 
-# PARALLEL=1 runs independent dev-env steps concurrently
-ifdef PARALLEL
-MAKEFLAGS += --output-sync=line
-ifeq ($(filter -j% --jobs%,$(MAKEFLAGS)),)
-MAKEFLAGS += -j$(shell echo $$(( ($$(getconf _NPROCESSORS_ONLN) + 1) / 2 )))
-endif
+# PARALLEL controls concurrent job count for dev-env/dev-clean (default: half of CPU cores).
+# Set PARALLEL=1 or PARALLEL=0 to run sequentially.
+PARALLEL ?= $(shell echo $$(( $$(getconf _NPROCESSORS_ONLN) / 2 )))
+ifeq ($(PARALLEL),0)
+override PARALLEL := 1
 endif
 
 log = @echo "==> $(1)"
@@ -267,7 +266,7 @@ log = @echo "==> $(1)"
 .PHONY: dev-env
 dev-env: ## Provision full dev environment (Kind + OCM + addon)
 	$(DEV_ENV_SCRIPT) check-host
-	$(MAKE) --no-print-directory install-olm install-cert-manager install-managed-serviceaccount deploy-addon
+	$(MAKE) --no-print-directory -j$(PARALLEL) --output-sync=line install-olm install-cert-manager install-managed-serviceaccount deploy-addon
 	$(call log,Dev environment ready. Use KUBECONFIG=$(HUB_KUBECONFIG) to interact with the hub.)
 
 .PHONY: create-clusters
@@ -337,7 +336,8 @@ dev-clean-meshes: ## Delete all mesh resources, cert-manager trust chain, and me
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete namespace mesh-system --ignore-not-found=true
 
 .PHONY: dev-clean
-dev-clean: $(addprefix delete-,$(CLUSTERS)) ## Destroy dev clusters and remove .kube/ folder
+dev-clean: ## Destroy dev clusters and remove .kube/ folder
+	$(MAKE) --no-print-directory -j$(PARALLEL) --output-sync=line $(addprefix delete-,$(CLUSTERS))
 	rm -rf $(DEV_KUBE_DIR)
 	$(call log,Dev environment cleaned)
 

--- a/Makefile
+++ b/Makefile
@@ -337,5 +337,10 @@ dev-clean-meshes: ## Delete all mesh resources, cert-manager trust chain, and me
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) delete namespace mesh-system --ignore-not-found=true
 
 .PHONY: dev-clean
-dev-clean: ## Destroy dev clusters and remove .kube/ folder
-	$(DEV_ENV_SCRIPT) clean
+dev-clean: $(addprefix delete-,$(CLUSTERS)) ## Destroy dev clusters and remove .kube/ folder
+	rm -rf $(DEV_KUBE_DIR)
+	$(call log,Dev environment cleaned)
+
+.PHONY: $(addprefix delete-,$(CLUSTERS))
+$(addprefix delete-,$(CLUSTERS)): delete-%: $(KIND)
+	$(KIND) delete cluster --name $*

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,8 @@ MSA_VERSION ?= 0.10.0
 
 DEV_KUBE_DIR := $(CURDIR)/.kube
 HUB_KUBECONFIG := $(DEV_KUBE_DIR)/hub.config
+SPOKE_CLUSTERS := cluster1 cluster2
+CLUSTERS := hub $(SPOKE_CLUSTERS)
 
 KIND := $(BIN_DIR)/kind
 CLUSTERADM := $(BIN_DIR)/clusteradm
@@ -252,35 +254,60 @@ DEV_ENV_SCRIPT := $(CURDIR)/hack/dev-env.sh
 export DEV_KUBE_DIR K8S_VERSION OLM_VERSION CERT_MANAGER_VERSION MSA_VERSION
 export KIND CLUSTERADM HELM
 
+# PARALLEL=1 runs independent dev-env steps concurrently
+ifdef PARALLEL
+MAKEFLAGS += --output-sync=line
+ifeq ($(filter -j% --jobs%,$(MAKEFLAGS)),)
+MAKEFLAGS += -j$(shell echo $$(( ($$(getconf _NPROCESSORS_ONLN) + 1) / 2 )))
+endif
+endif
+
+log = @echo "==> $(1)"
+
 .PHONY: dev-env
-dev-env: create-clusters install-olm install-cert-manager init-ocm join-clusters install-managed-serviceaccount deploy-addon ## Provision full dev environment (Kind + OCM + addon)
+dev-env: ## Provision full dev environment (Kind + OCM + addon)
+	$(DEV_ENV_SCRIPT) check-host
+	$(MAKE) --no-print-directory install-olm install-cert-manager install-managed-serviceaccount deploy-addon
+	$(call log,Dev environment ready. Use KUBECONFIG=$(HUB_KUBECONFIG) to interact with the hub.)
 
 .PHONY: create-clusters
-create-clusters: $(KIND) ## Create 3 Kind clusters (hub, cluster1, cluster2)
-	$(DEV_ENV_SCRIPT) create-clusters
+create-clusters: $(addprefix create-,$(CLUSTERS)) ## Create 3 Kind clusters (hub, cluster1, cluster2)
+
+.PHONY: $(addprefix create-,$(CLUSTERS))
+$(addprefix create-,$(CLUSTERS)): create-%: $(KIND)
+	$(call log,Creating cluster: $*)
+	$(DEV_ENV_SCRIPT) create-cluster $*
 
 .PHONY: install-olm
-install-olm: ## Install OLM on managed clusters (cluster1, cluster2)
-	$(DEV_ENV_SCRIPT) install-olm
+install-olm: $(addprefix install-olm-,$(SPOKE_CLUSTERS)) ## Install OLM on managed clusters (cluster1, cluster2)
+
+.PHONY: $(addprefix install-olm-,$(SPOKE_CLUSTERS))
+$(addprefix install-olm-,$(SPOKE_CLUSTERS)): install-olm-%: create-%
+	$(call log,Installing OLM: $*)
+	$(DEV_ENV_SCRIPT) install-olm $*
 
 .PHONY: install-cert-manager
-install-cert-manager: ## Install cert-manager on the hub cluster
+install-cert-manager: create-hub ## Install cert-manager on the hub cluster
+	$(call log,Installing cert-manager: hub)
 	$(DEV_ENV_SCRIPT) install-cert-manager
 
 .PHONY: init-ocm
-init-ocm: $(CLUSTERADM) ## Initialize hub as OCM control plane
+init-ocm: $(CLUSTERADM) create-hub ## Initialize hub as OCM control plane
+	$(call log,Initializing OCM: hub)
 	$(DEV_ENV_SCRIPT) init-ocm
 
 .PHONY: join-clusters
-join-clusters: $(CLUSTERADM) ## Register managed clusters and create ManagedClusterSet
+join-clusters: $(CLUSTERADM) init-ocm $(addprefix create-,$(SPOKE_CLUSTERS)) ## Register managed clusters and create ManagedClusterSet
+	$(call log,Joining clusters to hub)
 	$(DEV_ENV_SCRIPT) join-clusters
 
 .PHONY: install-managed-serviceaccount
-install-managed-serviceaccount: $(HELM_BIN) ## Install managed-serviceaccount addon to the hub cluster
+install-managed-serviceaccount: $(HELM_BIN) join-clusters ## Install managed-serviceaccount addon to the hub cluster
+	$(call log,Installing managed-serviceaccount: hub)
 	$(DEV_ENV_SCRIPT) install-managed-serviceaccount
 
 .PHONY: deploy-addon
-deploy-addon: $(KIND) $(HELM_BIN) gen images ## Build and deploy addon to the hub Kind cluster
+deploy-addon: $(KIND) $(HELM_BIN) gen images join-clusters install-cert-manager ## Build and deploy addon to the hub Kind cluster
 	# We use image-archive instead of docker-image because the latter is Docker-specific
 	# and fails when images are built with Podman (separate image stores).
 	$(CONTAINER_ENGINE) save $(IMG) -o $(DEV_KUBE_DIR)/.addon-image.tar
@@ -297,7 +324,7 @@ deploy-addon: $(KIND) $(HELM_BIN) gen images ## Build and deploy addon to the hu
 		--wait --timeout 180s
 	kubectl --kubeconfig=$(HUB_KUBECONFIG) rollout status deployment/multicluster-mesh-controller \
 		-n $(ADDON_NAMESPACE) --timeout=180s
-	@echo "==> Addon controller deployed successfully. Use KUBECONFIG=$(HUB_KUBECONFIG) to interact with the hub."
+	$(call log,Addon controller deployed successfully. Use KUBECONFIG=$(HUB_KUBECONFIG) to interact with the hub.)
 
 .PHONY: setup-mesh
 setup-mesh: ## Create cert-manager trust chain, mesh-system namespace, and MultiClusterMesh CR

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -4,7 +4,7 @@
 #
 # Usage: hack/dev-env.sh <action> [args...]
 # Actions: check-host, create-cluster <name>, install-olm <name>, install-cert-manager,
-#          install-managed-serviceaccount, init-ocm, join-clusters, setup-mesh, clean
+#          install-managed-serviceaccount, init-ocm, join-clusters, setup-mesh
 
 set -euo pipefail
 
@@ -306,21 +306,6 @@ setup_mesh() {
     log "Monitor progress: $(on "${HUB}" echo kubectl get multiclustermesh -n mesh-system)"
 }
 
-clean() {
-    log "Deleting Kind clusters..."
-    for cluster in "${HUB}" "${CLUSTER1}" "${CLUSTER2}"; do
-        if ${KIND} get clusters 2>/dev/null | grep -qx "${cluster}"; then
-            log "Deleting cluster: ${cluster}"
-            ${KIND} delete cluster --name "${cluster}" || true
-        fi
-    done
-
-    log "Removing dev environment state..."
-    rm -rf "${DEV_KUBE_DIR}"
-
-    log "Clean complete"
-}
-
 ACTION="${1:-}"
 case "${ACTION}" in
     check-host)                      check_host ;;
@@ -331,7 +316,6 @@ case "${ACTION}" in
     init-ocm)                        init_ocm ;;
     join-clusters)                   join_clusters ;;
     setup-mesh)                      setup_mesh ;;
-    clean)                           clean ;;
     *)
-        err "Unknown action: '${ACTION}'. Valid: check-host, create-cluster, install-olm, install-cert-manager, install-managed-serviceaccount, init-ocm, join-clusters, setup-mesh, clean" ;;
+        err "Unknown action: '${ACTION}'. Valid: check-host, create-cluster, install-olm, install-cert-manager, install-managed-serviceaccount, init-ocm, join-clusters, setup-mesh" ;;
 esac

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -2,8 +2,9 @@
 # Provisions and manages a local 3-cluster Kind/OCM development environment.
 # This file is invoked by Makefile targets with an action argument.
 #
-# Usage: hack/dev-env.sh <action>
-# Actions: create-clusters, install-olm, install-cert-manager, install-managed-serviceaccount, init-ocm, join-clusters, setup-mesh, clean
+# Usage: hack/dev-env.sh <action> [args...]
+# Actions: check-host, create-cluster <name>, install-olm <name>, install-cert-manager,
+#          install-managed-serviceaccount, init-ocm, join-clusters, setup-mesh, clean
 
 set -euo pipefail
 
@@ -98,73 +99,67 @@ require_clusters() {
     done
 }
 
-create_clusters() {
+check_host() {
     check_inotify_limits
     check_kernel_keyring_limits
-    mkdir -p "${DEV_KUBE_DIR}"
 
-    local existing_clusters
-    existing_clusters="$(${KIND} get clusters 2>/dev/null || true)"
+    local existing
+    existing="$(${KIND} get clusters 2>/dev/null || true)"
     local found=()
     for cluster in "${HUB}" "${CLUSTER1}" "${CLUSTER2}"; do
-        if echo "${existing_clusters}" | grep -qx "${cluster}"; then
+        if echo "${existing}" | grep -qx "${cluster}"; then
             found+=("${cluster}")
         fi
     done
-
     if [[ ${#found[@]} -gt 0 ]]; then
         err "Kind clusters already exist: ${found[*]}. Run 'make dev-clean' to tear them down first."
     fi
+}
 
-    local kind_node_image="kindest/node:${K8S_VERSION}"
+create_cluster() {
+    local cluster="${1}"
+    mkdir -p "${DEV_KUBE_DIR}"
 
-    for cluster in "${HUB}" "${CLUSTER1}" "${CLUSTER2}"; do
-        log "Creating Kind cluster: ${cluster}"
-        on "${cluster}" "${KIND}" create cluster \
-            --name "${cluster}" \
-            --image "${kind_node_image}" \
-            --wait 120s
+    log "Creating Kind cluster: ${cluster}"
+    on "${cluster}" "${KIND}" create cluster \
+        --name "${cluster}" \
+        --image "kindest/node:${K8S_VERSION}" \
+        --wait 120s
 
-        log "Waiting for cluster ${cluster} API to be ready..."
-        on "${cluster}" kubectl wait --for=condition=Ready nodes --all --timeout=120s
-    done
-
-    log "All clusters created successfully"
-    ${KIND} get clusters
+    log "Waiting for cluster ${cluster} API to be ready..."
+    on "${cluster}" kubectl wait --for=condition=Ready nodes --all --timeout=120s
+    log "Cluster ${cluster} ready"
 }
 
 install_olm() {
-    require_clusters "${CLUSTER1}" "${CLUSTER2}"
+    local cluster="${1}"
+    require_clusters "${cluster}"
     local olm_base_url="https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}"
 
-    for cluster in "${CLUSTER1}" "${CLUSTER2}"; do
-        if on "${cluster}" kubectl get deployment olm-operator -n olm &>/dev/null; then
-            log "OLM already installed on ${cluster}, skipping"
-            continue
-        fi
+    if on "${cluster}" kubectl get deployment olm-operator -n olm &>/dev/null; then
+        log "OLM already installed on ${cluster}, skipping"
+        return
+    fi
 
-        log "Installing OLM ${OLM_VERSION} on ${cluster}..."
+    log "Installing OLM ${OLM_VERSION} on ${cluster}..."
 
-        on "${cluster}" kubectl apply --server-side -f "${olm_base_url}/crds.yaml"
-        on "${cluster}" retry kubectl wait --for=condition=Established \
-            crd/catalogsources.operators.coreos.com \
-            crd/subscriptions.operators.coreos.com \
-            --timeout=60s
+    on "${cluster}" kubectl apply --server-side -f "${olm_base_url}/crds.yaml"
+    on "${cluster}" retry kubectl wait --for=condition=Established \
+        crd/catalogsources.operators.coreos.com \
+        crd/subscriptions.operators.coreos.com \
+        --timeout=60s
 
-        log "Applying OLM components on ${cluster}..."
-        on "${cluster}" kubectl apply -f "${olm_base_url}/olm.yaml"
+    log "Applying OLM components on ${cluster}..."
+    on "${cluster}" kubectl apply -f "${olm_base_url}/olm.yaml"
 
-        log "Waiting for OLM components to be ready on ${cluster}..."
-        on "${cluster}" kubectl rollout status deployment/olm-operator -n olm --timeout=180s
-        on "${cluster}" kubectl rollout status deployment/catalog-operator -n olm --timeout=180s
+    log "Waiting for OLM components to be ready on ${cluster}..."
+    on "${cluster}" kubectl rollout status deployment/olm-operator -n olm --timeout=180s
+    on "${cluster}" kubectl rollout status deployment/catalog-operator -n olm --timeout=180s
 
-        log "OLM ${OLM_VERSION} installed on ${cluster}"
-    done
+    log "Granting klusterlet-work-sa OLM permissions on ${cluster}"
+    on "${cluster}" kubectl apply -f "${SCRIPT_DIR}/hack/kind/klusterlet-work-olm.yaml"
 
-    for cluster in "${CLUSTER1}" "${CLUSTER2}"; do
-        log "Granting klusterlet-work-sa OLM permissions on ${cluster}"
-        on "${cluster}" kubectl apply -f "${SCRIPT_DIR}/hack/kind/klusterlet-work-olm.yaml"
-    done
+    log "OLM ${OLM_VERSION} installed on ${cluster}"
 }
 
 install_cert_manager() {
@@ -328,8 +323,9 @@ clean() {
 
 ACTION="${1:-}"
 case "${ACTION}" in
-    create-clusters)                 create_clusters ;;
-    install-olm)                     install_olm ;;
+    check-host)                      check_host ;;
+    create-cluster)                  create_cluster "${2}" ;;
+    install-olm)                     install_olm "${2}" ;;
     install-cert-manager)            install_cert_manager ;;
     install-managed-serviceaccount)  install_managed_serviceaccount ;;
     init-ocm)                        init_ocm ;;
@@ -337,5 +333,5 @@ case "${ACTION}" in
     setup-mesh)                      setup_mesh ;;
     clean)                           clean ;;
     *)
-        err "Unknown action: '${ACTION}'. Valid: create-clusters, install-olm, install-cert-manager, install-managed-serviceaccount, init-ocm, join-clusters, setup-mesh, clean" ;;
+        err "Unknown action: '${ACTION}'. Valid: check-host, create-cluster, install-olm, install-cert-manager, install-managed-serviceaccount, init-ocm, join-clusters, setup-mesh, clean" ;;
 esac


### PR DESCRIPTION
Split create-clusters, install-olm, and clean into per-cluster Makefile
targets so Make can parallelize independent steps.

**dev-env**: Declare actual dependencies between targets to enable parallel
execution with `PARALLEL=1`:
- All 3 Kind clusters created concurrently
- install-olm, install-cert-manager, init-ocm run as their cluster is ready
- join-clusters, install-managed-serviceaccount, deploy-addon follow

A `check-host` target validates system limits and cluster existence before
any work starts, gated by `.WAIT` (GNU Make 4.4+) to prevent wasted builds
on failure.

Sequential (`make dev-env`): ~8min
Parallel (`make PARALLEL=1 dev-env`): ~5min

**dev-clean**: Cluster deletion moved from the script to per-cluster Makefile
targets, running all 3 deletes concurrently with `PARALLEL=1`.