### PR TITLE
Fix log message when issuer is removed from the MCM CR

### DIFF
--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -419,13 +419,17 @@ func (r *Reconciler) cleanupCertificates(ctx context.Context, mesh *meshv1alpha1
 		return fmt.Errorf("failed to list Certificates: %w", err)
 	}
 
+	deleteReason := "issuer configuration removed"
 	for _, cert := range certList.Items {
 		clusterName := cert.Labels[ClusterNameLabel]
 		if !forceCleanupAll && clusterNames[clusterName] {
 			continue
 		}
 
-		klog.Infof("Deleting Certificate %s/%s (cluster %s no longer in ClusterSet %s)", cert.Namespace, cert.Name, clusterName, mesh.Spec.ClusterSet)
+		if !forceCleanupAll {
+			deleteReason = fmt.Sprintf("cluster %s no longer in ClusterSet %s", clusterName, mesh.Spec.ClusterSet)
+		}
+		klog.Infof("Deleting Certificate %s/%s (%s)", cert.Namespace, cert.Name, deleteReason)
 		if err := client.IgnoreNotFound(r.Delete(ctx, &cert)); err != nil {
 			return fmt.Errorf("failed to delete Certificate %s/%s: %w", cert.Namespace, cert.Name, err)
 		}

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -274,9 +274,14 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 		}
 	}
 
-	forceCleanupAll := mesh.Spec.Security.Trust.CertManager.IssuerRef.Name == ""
-	if err := r.cleanupCertificates(ctx, mesh, clusters, forceCleanupAll); err != nil {
-		return fmt.Errorf("failed to cleanup Certificates: %w", err)
+	if mesh.Spec.Security.Trust.CertManager.IssuerRef.Name == "" {
+		if err := r.deleteAllCertificates(ctx, mesh); err != nil {
+			return fmt.Errorf("failed to cleanup Certificates: %w", err)
+		}
+	} else {
+		if err := r.deleteCertificatesForRemovedClusters(ctx, mesh, clusters); err != nil {
+			return fmt.Errorf("failed to cleanup Certificates: %w", err)
+		}
 	}
 
 	if err := r.cleanupManifestWorks(ctx, mesh.Spec.ClusterSet); err != nil {
@@ -405,10 +410,28 @@ func (r *Reconciler) cleanupManifestWorks(ctx context.Context, clusterSet string
 	return nil
 }
 
-// cleanupCertificates deletes mesh-owned Certificates. When forceCleanupAll is true, all Certificates for the mesh
-// are removed (e.g. when the issuer is cleared). Otherwise, only Certificates for clusters no longer in the
-// ClusterSet are removed.
-func (r *Reconciler) cleanupCertificates(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster, forceCleanupAll bool) error {
+// deleteAllCertificates deletes all mesh-owned Certificates (e.g. when the issuer is removed).
+func (r *Reconciler) deleteAllCertificates(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
+	certList := &certmanagerv1.CertificateList{}
+	if err := r.List(ctx, certList,
+		client.InNamespace(mesh.Namespace),
+		client.MatchingLabels{MeshNameLabel: mesh.Name, MeshNamespaceLabel: mesh.Namespace},
+	); err != nil {
+		return fmt.Errorf("failed to list Certificates: %w", err)
+	}
+
+	for _, cert := range certList.Items {
+		klog.Infof("Deleting Certificate %s/%s (issuer configuration removed)", cert.Namespace, cert.Name)
+		if err := client.IgnoreNotFound(r.Delete(ctx, &cert)); err != nil {
+			return fmt.Errorf("failed to delete Certificate %s/%s: %w", cert.Namespace, cert.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// deleteCertificatesForRemovedClusters deletes Certificates for clusters no longer in the ClusterSet.
+func (r *Reconciler) deleteCertificatesForRemovedClusters(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
 	clusterNames := clusterNameSet(clusters)
 
 	certList := &certmanagerv1.CertificateList{}
@@ -419,17 +442,13 @@ func (r *Reconciler) cleanupCertificates(ctx context.Context, mesh *meshv1alpha1
 		return fmt.Errorf("failed to list Certificates: %w", err)
 	}
 
-	deleteReason := "issuer configuration removed"
 	for _, cert := range certList.Items {
 		clusterName := cert.Labels[ClusterNameLabel]
-		if !forceCleanupAll && clusterNames[clusterName] {
+		if clusterNames[clusterName] {
 			continue
 		}
 
-		if !forceCleanupAll {
-			deleteReason = fmt.Sprintf("cluster %s no longer in ClusterSet %s", clusterName, mesh.Spec.ClusterSet)
-		}
-		klog.Infof("Deleting Certificate %s/%s (%s)", cert.Namespace, cert.Name, deleteReason)
+		klog.Infof("Deleting Certificate %s/%s (cluster %s no longer in ClusterSet %s)", cert.Namespace, cert.Name, clusterName, mesh.Spec.ClusterSet)
 		if err := client.IgnoreNotFound(r.Delete(ctx, &cert)); err != nil {
 			return fmt.Errorf("failed to delete Certificate %s/%s: %w", cert.Namespace, cert.Name, err)
 		}


### PR DESCRIPTION
Currently, when the spec.security.trust.certManager.issuerRef is removed
from the MCM CR, we see the following log message which is a bit misleading
as the cluster is still part of the clusterSet.

```
controller.go:428] Deleting Certificate mesh-system/cacerts-cluster1 (cluster cluster1 no longer in ClusterSet mesh-cluster-set) controller.go:428] Deleting Certificate mesh-system/cacerts-cluster2 (cluster cluster2 no longer in ClusterSet mesh-cluster-set)
```

This PR modifies the log message as follows.

When the issuer is removed, the following message is logged. 
```
Deleting Certificate mesh-system/cacerts-cluster1 (issuer configuration removed)
```

and when a cluster is actually removed from the ClusterSet, the following message is logged. 
```
Deleting Certificate mesh-system/cacerts-cluster1 (cluster cluster1 no longer in ClusterSet mesh-cluster-set)
```
