### PR TITLE
Restructure MSA integration tests

### DIFF
--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -663,31 +663,23 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 	})
 
 	Context("Endpoint discovery", func() {
-		var cluster1, cluster2, cluster3 string
-
-		When("a MultiClusterMesh is created", func() {
+		When("referencing a set with a cluster", func() {
 			BeforeEach(func() {
-				cluster1 = util.UniqueName("cluster1")
-				cluster2 = util.UniqueName("cluster2")
-				util.CreateManagedCluster(ctx, k8sClient, cluster1, testClusterSet)
-				util.CreateManagedCluster(ctx, k8sClient, cluster2, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 			})
 
-			It("should create ManagedServiceAccount resources with default validity for each ManagedCluster in the ClusterSet", func() {
+			It("should create ManagedServiceAccount with correct labels and default validity", func() {
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+				msa := expectManagedServiceAccount(testNs, meshName, clusterName)
 
-				msa1 := expectManagedServiceAccount(testNs, meshName, cluster1)
-				msa2 := expectManagedServiceAccount(testNs, meshName, cluster2)
-
-				Expect(msa1.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
-				Expect(msa1.Labels[meshcontroller.MeshNameLabel]).To(Equal(meshName))
-				Expect(msa1.Labels[meshcontroller.MeshNamespaceLabel]).To(Equal(testNs))
-				Expect(msa1.Labels[meshcontroller.ClusterNameLabel]).To(Equal(cluster1))
-				Expect(msa2.Spec.Rotation.Validity).To(Equal(metav1.Duration{Duration: 360 * time.Hour}))
-				Expect(msa2.Labels[meshcontroller.ClusterNameLabel]).To(Equal(cluster2))
+				Expect(msa.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
+				Expect(msa.Labels[meshcontroller.MeshNameLabel]).To(Equal(meshName))
+				Expect(msa.Labels[meshcontroller.MeshNamespaceLabel]).To(Equal(testNs))
+				Expect(msa.Labels[meshcontroller.ClusterNameLabel]).To(Equal(clusterName))
+				Expect(msa.Spec.Rotation.Validity).To(Equal(metav1.Duration{Duration: 360 * time.Hour}))
 			})
 
-			It("should create ManagedServiceAccount resources with custom TokenValidity value", func() {
+			It("should create ManagedServiceAccount with custom TokenValidity when specified", func() {
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
 					Security: meshv1alpha1.SecurityConfig{
 						Discovery: meshv1alpha1.DiscoveryConfig{
@@ -696,41 +688,52 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 					},
 				})
 
-				msa1 := expectManagedServiceAccount(testNs, meshName, cluster1)
-				Expect(msa1.Spec.Rotation.Validity).To(Equal(metav1.Duration{Duration: 15 * time.Minute}))
-			})
-
-			It("should create a ManagedServiceAccount after adding a cluster to the ClusterSet", func() {
-				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-				cluster3 = util.UniqueName("cluster3")
-				util.CreateManagedCluster(ctx, k8sClient, cluster3, testClusterSet)
-				expectManagedServiceAccount(testNs, meshName, cluster3)
-			})
-
-			It("should cleanup a ManagedServiceAccount after removing a cluster from the ClusterSet", func() {
-				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-				updateClusterSetLabel(cluster2, "")
-				util.ExpectResourceDeleted(ctx, k8sClient, &msav1beta1.ManagedServiceAccount{},
-					expectedManagedServiceAccountName(testNs, meshName), cluster2)
-			})
-		})
-
-		When("a MultiClusterMesh is updated with custom TokenValidity", func() {
-			It("should update ManagedServiceAccount Validity when the mesh spec changes", func() {
-				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-
 				msa := expectManagedServiceAccount(testNs, meshName, clusterName)
-				Expect(msa.Spec.Rotation.Validity).To(Equal(metav1.Duration{Duration: 360 * time.Hour}))
+				Expect(msa.Spec.Rotation.Validity).To(Equal(metav1.Duration{Duration: 15 * time.Minute}))
+			})
 
-				updateMesh(meshName, testNs, func(mesh *meshv1alpha1.MultiClusterMesh) {
-					mesh.Spec.Security.Discovery.TokenValidity = &metav1.Duration{Duration: 15 * time.Minute}
+			It("should create ManagedServiceAccount for newly added cluster", func() {
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+				expectManagedServiceAccount(testNs, meshName, clusterName)
+
+				cluster2 := util.UniqueName("cluster")
+				util.CreateManagedCluster(ctx, k8sClient, cluster2, testClusterSet)
+				expectManagedServiceAccount(testNs, meshName, cluster2)
+			})
+
+			When("the ManagedServiceAccount exists", func() {
+				BeforeEach(func() {
+					util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+					expectManagedServiceAccount(testNs, meshName, clusterName)
 				})
-				Eventually(func(g Gomega) {
-					msa := &msav1beta1.ManagedServiceAccount{}
-					g.Expect(k8sClient.Get(ctx, key.Of(expectedManagedServiceAccountName(testNs, meshName), clusterName), msa)).To(Succeed())
-					g.Expect(msa.Spec.Rotation.Validity).To(Equal(metav1.Duration{Duration: 15 * time.Minute}))
-				}).Should(Succeed())
+
+				It("should update ManagedServiceAccount validity when mesh spec changes", func() {
+					updateMesh(meshName, testNs, func(mesh *meshv1alpha1.MultiClusterMesh) {
+						mesh.Spec.Security.Discovery.TokenValidity = &metav1.Duration{Duration: 15 * time.Minute}
+					})
+					Eventually(func(g Gomega) {
+						msa := getManagedServiceAccount(g, testNs, meshName, clusterName)
+						g.Expect(msa.Spec.Rotation.Validity).To(Equal(metav1.Duration{Duration: 15 * time.Minute}))
+					}).Should(Succeed())
+				})
+
+				It("should cleanup ManagedServiceAccount when cluster is removed from ClusterSet", func() {
+					updateClusterSetLabel(clusterName, "")
+					util.ExpectResourceDeleted(ctx, k8sClient, &msav1beta1.ManagedServiceAccount{},
+						expectedManagedServiceAccountName(testNs, meshName), clusterName)
+				})
+
+				It("should cleanup ManagedServiceAccount when cluster is deleted", func() {
+					util.DeleteResource(ctx, k8sClient, &clusterv1.ManagedCluster{}, clusterName, "")
+					util.ExpectResourceDeleted(ctx, k8sClient, &msav1beta1.ManagedServiceAccount{},
+						expectedManagedServiceAccountName(testNs, meshName), clusterName)
+				})
+
+				It("should cleanup ManagedServiceAccount when ClusterSet is deleted", func() {
+					util.DeleteResource(ctx, k8sClient, &clusterv1beta2.ManagedClusterSet{}, testClusterSet, "")
+					util.ExpectResourceDeleted(ctx, k8sClient, &msav1beta1.ManagedServiceAccount{},
+						expectedManagedServiceAccountName(testNs, meshName), clusterName)
+				})
 			})
 		})
 
@@ -739,20 +742,17 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
 			})
 
-			It("should not process ManagedServiceAccount", func() {
-				expectMeshNotReady(meshName, testNs)
+			It("should not create ManagedServiceAccount", func() {
 				expectNoManagedServiceAccount(testNs, meshName, clusterName)
 			})
 
 			It("shouldn't process a cluster without clusterset label", func() {
 				util.CreateManagedCluster(ctx, k8sClient, clusterName, "")
-				expectMeshNotReady(meshName, testNs)
 				expectNoManagedServiceAccount(testNs, meshName, clusterName)
 			})
 
-			It("should process a cluster when it's added", func() {
+			It("should create ManagedServiceAccount when cluster is added", func() {
 				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-				expectMeshNotReady(meshName, testNs)
 				expectManagedServiceAccount(testNs, meshName, clusterName)
 			})
 		})
@@ -761,10 +761,10 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			var otherNs, otherMesh string
 
 			BeforeEach(func() {
-				cluster1 = util.UniqueName("cluster1")
-				util.CreateManagedCluster(ctx, k8sClient, cluster1, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
 				expectMeshNotReady(meshName, testNs)
+
 				otherNs = util.UniqueName("other-ns")
 				otherMesh = util.UniqueName("other-mesh")
 				util.CreateNamespace(ctx, k8sClient, otherNs)
@@ -775,18 +775,15 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should delete only the removed mesh's ManagedServiceAccount when one mesh is deleted", func() {
-				// Verify both meshes have MSAs
-				expectManagedServiceAccount(testNs, meshName, cluster1)
-				expectManagedServiceAccount(otherNs, otherMesh, cluster1)
+				expectManagedServiceAccount(testNs, meshName, clusterName)
+				expectManagedServiceAccount(otherNs, otherMesh, clusterName)
 
 				util.DeleteResource(ctx, k8sClient, &meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
 				util.ExpectResourceDeleted(ctx, k8sClient, &msav1beta1.ManagedServiceAccount{},
-					expectedManagedServiceAccountName(testNs, meshName), cluster1)
+					expectedManagedServiceAccountName(testNs, meshName), clusterName)
 
-				// Verify the other mesh's MSAs remain
-				Consistently(func() error {
-					msa := &msav1beta1.ManagedServiceAccount{}
-					return k8sClient.Get(ctx, key.Of(expectedManagedServiceAccountName(otherNs, otherMesh), cluster1), msa)
+				Consistently(func(g Gomega) {
+					getManagedServiceAccount(g, otherNs, otherMesh, clusterName)
 				}).Should(Succeed())
 			})
 		})
@@ -928,10 +925,16 @@ func expectedManagedServiceAccountName(meshNamespace, meshName string) string {
 	return fmt.Sprintf("%s-istio-reader-%s", meshNamespace, meshName)
 }
 
-func expectManagedServiceAccount(meshNamespace, meshName, clusterName string) *msav1beta1.ManagedServiceAccount {
+func getManagedServiceAccount(g Gomega, meshNamespace, meshName, clusterName string) *msav1beta1.ManagedServiceAccount {
 	msa := &msav1beta1.ManagedServiceAccount{}
-	Eventually(func() error {
-		return k8sClient.Get(ctx, key.Of(expectedManagedServiceAccountName(meshNamespace, meshName), clusterName), msa)
+	g.Expect(k8sClient.Get(ctx, key.Of(expectedManagedServiceAccountName(meshNamespace, meshName), clusterName), msa)).To(Succeed())
+	return msa
+}
+
+func expectManagedServiceAccount(meshNamespace, meshName, clusterName string) *msav1beta1.ManagedServiceAccount {
+	var msa *msav1beta1.ManagedServiceAccount
+	Eventually(func(g Gomega) {
+		msa = getManagedServiceAccount(g, meshNamespace, meshName, clusterName)
 	}).Should(Succeed())
 	return msa
 }


### PR DESCRIPTION
The MSA tests duplicated mesh creation inside every It block instead of using BeforeEach for shared setup. Restructured to mirror the operator tests: BeforeEach establishes steady state, each It tests one aspect.

Added missing lifecycle tests for MSA cleanup on cluster deletion and ClusterSet deletion.