### PR TITLE
ManifestWorkReplicaSet: Add remote secrets distribution change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ update-test-crds: deps ## Update test CRDs from OCM API, managed-serviceaccount 
 	cp -fv $$OCM_API_PATH/cluster/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	cp -fv $$OCM_API_PATH/cluster/v1beta2/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	cp -fv $$OCM_API_PATH/work/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
+	cp -fv $$OCM_API_PATH/work/v1alpha1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
 	echo "Test CRDs updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from open-cluster-management.io/managed-serviceaccount..."
 	@set -e; \

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -11,8 +11,11 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
+  - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - authentication.open-cluster-management.io

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -11,11 +11,9 @@ rules:
   resources:
   - secrets
   verbs:
-  - create
   - delete
   - get
   - list
-  - update
   - watch
 - apiGroups:
   - authentication.open-cluster-management.io

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -83,6 +83,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - work.open-cluster-management.io
   resources:

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -11,7 +11,6 @@ rules:
   resources:
   - secrets
   verbs:
-  - delete
   - get
   - list
   - watch

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -76,6 +76,16 @@ rules:
 - apiGroups:
   - work.open-cluster-management.io
   resources:
+  - manifestworkreplicasets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
   - manifestworks
   verbs:
   - create

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -105,7 +105,6 @@ rules:
   - manifestworkreplicasets
   verbs:
   - create
-  - delete
   - get
   - list
   - update

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -188,6 +188,12 @@ init_ocm() {
     log "Waiting for OCM hub components to be ready..."
     on "${HUB}" retry kubectl wait --for=condition=Available \
         deployment/cluster-manager -n open-cluster-management --timeout=120s
+
+    log "Enabling feature ManifestWorkReplicaSet on cluster: ${HUB}"
+    on "${HUB}" kubectl patch clustermanager cluster-manager --type=merge \
+        -p '{"spec":{"workConfiguration":{"featureGates":[{"feature":"ManifestWorkReplicaSet","mode":"Enable"}]}}}'
+    on "${HUB}" retry kubectl wait --for=condition=Available \
+        deployment/cluster-manager -n open-cluster-management --timeout=120s
 }
 
 join_clusters() {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
+	workv1alpha1 "open-cluster-management.io/api/work/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -44,6 +45,7 @@ func init() {
 	utilruntime.Must(clusterv1.Install(runtimeScheme))
 	utilruntime.Must(clusterv1beta2.Install(runtimeScheme))
 	utilruntime.Must(workv1.Install(runtimeScheme))
+	utilruntime.Must(workv1alpha1.Install(runtimeScheme))
 	utilruntime.Must(operatorsv1.AddToScheme(runtimeScheme))
 	utilruntime.Must(operatorsv1alpha1.AddToScheme(runtimeScheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(runtimeScheme))

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -145,7 +145,7 @@ func RegisterController(mgr manager.Manager) error {
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch;create;update;delete
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;delete
 
 // Reconcile implements the reconcile loop for MultiClusterMesh resources
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -46,8 +46,9 @@ const (
 	// When the operator targets this namespace, the controller skips creating Namespace and OperatorGroup.
 	BuiltinOperatorNamespace = "openshift-operators"
 
-	OperatorManifestWorkName = "multicluster-mesh-operator"
-	ManifestWorkNameCacerts  = "multicluster-mesh-cacerts"
+	OperatorManifestWorkName      = "multicluster-mesh-operator"
+	ManifestWorkNameCacerts       = "multicluster-mesh-cacerts"
+	ManifestWorkNameRemoteSecrets = "multicluster-mesh-remote-secrets"
 
 	FeedbackInstalledCSV = "installedCSV"
 
@@ -144,7 +145,7 @@ func RegisterController(mgr manager.Manager) error {
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch;create;update;delete
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete
 
 // Reconcile implements the reconcile loop for MultiClusterMesh resources
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -273,6 +274,10 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 		}
 	}
 
+	if err := r.ensureRemoteSecretDistributed(ctx, mesh, clusters); err != nil {
+		return fmt.Errorf("failed to ensure remote secret distribution for mesh %s: %w", mesh.Name, err)
+	}
+
 	forceCleanupAll := mesh.Spec.Security.Trust.CertManager.IssuerRef.Name == ""
 	if err := r.cleanupCertificates(ctx, mesh, clusters, forceCleanupAll); err != nil {
 		return fmt.Errorf("failed to cleanup Certificates: %w", err)
@@ -282,9 +287,12 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 		return fmt.Errorf("failed to cleanup ManifestWorks: %w", err)
 	}
 
-	// Cleanup ManagedServiceAccount when the cluster(s) are removed from the ClusterSet.
 	if err := r.cleanupManagedServiceAccounts(ctx, mesh, clusters); err != nil {
 		return fmt.Errorf("failed to cleanup ManagedServiceAccounts: %w", err)
+	}
+
+	if err := r.cleanupRemoteSecrets(ctx, mesh, clusters); err != nil {
+		return fmt.Errorf("failed to cleanup Istio remote secrets: %w", err)
 	}
 
 	return nil
@@ -363,6 +371,10 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 
 	if err := r.deleteAllManagedServiceAccounts(ctx, mesh); err != nil {
 		return fmt.Errorf("failed to cleanup ManagedServiceAccount resources: %w", err)
+	}
+
+	if err := r.deleteAllRemoteSecrets(ctx, mesh); err != nil {
+		return fmt.Errorf("failed to cleanup Istio remote access secrets: %w", err)
 	}
 
 	// Trigger reconciliation for other meshes targeting the same cluster set.
@@ -724,7 +736,6 @@ func (r *Reconciler) ensureCacertsManifestWork(ctx context.Context, mesh *meshv1
 	secretName := getCacertsName(cluster.Name)
 	secret := &corev1.Secret{}
 	err := r.Get(ctx, key.Of(secretName, mesh.Namespace), secret)
-
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(4).Infof("Secret %s/%s not found yet, waiting for cert-manager to create it", mesh.Namespace, secretName)

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -42,10 +42,10 @@ import (
 )
 
 const (
-	OperatorManifestWorkName      = "multicluster-mesh-operator"
-	ManifestWorkNameCacerts       = "multicluster-mesh-cacerts"
-	ManifestWorkReplicaSetName    = "multicluster-mesh-mwrset"
-	ManifestWorkNameCPNSPrefix    = "multicluster-mesh-cp-ns-"
+	OperatorManifestWorkName   = "multicluster-mesh-operator"
+	ManifestWorkNameCacerts    = "multicluster-mesh-cacerts"
+	ManifestWorkReplicaSetName = "multicluster-mesh-mwrset"
+	ManifestWorkNameCPNSPrefix = "multicluster-mesh-cp-ns-"
 
 	FeedbackInstalledCSV = "installedCSV"
 
@@ -311,10 +311,6 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 
 	if err := r.ensureManifestWorkReplicaSet(ctx, mesh); err != nil {
 		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet for mesh %s: %w", mesh.Name, err)
-	}
-
-	if err := r.cleanupRemoteSecrets(ctx, mesh, clusters); err != nil {
-		return fmt.Errorf("failed to cleanup Istio remote secrets: %w", err)
 	}
 
 	return nil

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -141,7 +141,7 @@ func RegisterController(mgr manager.Manager) error {
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworkreplicasets,verbs=get;list;create;update;delete
+//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworkreplicasets,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;delete

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -327,7 +327,11 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 	}
 
 	if err := r.ensureManifestWorkReplicaSet(ctx, mesh); err != nil {
-		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet for mesh %s/%s: %w", mesh.Namespace, mesh.Name, err)
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("managedServiceAccount secret not found yet, waiting for ManagedServiceAccount controller to create it: %s", err)
+		} else {
+			return fmt.Errorf("failed to ensure ManifestWorkReplicaSet for mesh %s/%s: %w", mesh.Namespace, mesh.Name, err)
+		}
 	}
 
 	return nil

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -45,7 +45,6 @@ import (
 const (
 	OperatorManifestWorkName   = "multicluster-mesh-operator"
 	ManifestWorkNameCacerts    = "multicluster-mesh-cacerts"
-	ManifestWorkReplicaSetName = "multicluster-mesh-mwrset"
 	ManifestWorkNameCPNSPrefix = "multicluster-mesh-cp-ns-"
 
 	FeedbackInstalledCSV = "installedCSV"
@@ -145,7 +144,7 @@ func RegisterController(mgr manager.Manager) error {
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersets/bind,verbs=create
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworkreplicasets,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworkreplicasets,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;delete
@@ -328,7 +327,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 	}
 
 	if err := r.ensureManifestWorkReplicaSet(ctx, mesh); err != nil {
-		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet for mesh %s: %w", mesh.Name, err)
+		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet for mesh %s/%s: %w", mesh.Namespace, mesh.Name, err)
 	}
 
 	return nil

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -147,7 +147,7 @@ func RegisterController(mgr manager.Manager) error {
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworkreplicasets,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch;create;update;delete
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;delete
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 // Reconcile implements the reconcile loop for MultiClusterMesh resources
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -415,10 +415,6 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 
 	if err := r.cleanupManagedClusterSetBinding(ctx, mesh); err != nil {
 		return fmt.Errorf("failed to cleanup ManagedClusterSetBinding: %w", err)
-	}
-
-	if err := r.deleteAllRemoteSecrets(ctx, mesh); err != nil {
-		return fmt.Errorf("failed to cleanup Istio remote access secrets: %w", err)
 	}
 
 	// Trigger reconciliation for other meshes targeting the same cluster set.

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -45,7 +45,6 @@ const (
 	OperatorManifestWorkName      = "multicluster-mesh-operator"
 	ManifestWorkNameCacerts       = "multicluster-mesh-cacerts"
 	ManifestWorkReplicaSetName    = "multicluster-mesh-mwrset"
-	ManifestWorkNameRemoteSecrets = "multicluster-mesh-remote-secrets"
 	ManifestWorkNameCPNSPrefix    = "multicluster-mesh-cp-ns-"
 
 	FeedbackInstalledCSV = "installedCSV"
@@ -288,10 +287,6 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 		}
 	}
 
-	if err := r.ensureRemoteSecretDistributed(ctx, mesh, clusters); err != nil {
-		return fmt.Errorf("failed to ensure remote secret distribution for mesh %s: %w", mesh.Name, err)
-	}
-
 	if mesh.Spec.Security.Trust.CertManager.IssuerRef.Name == "" {
 		if err := r.deleteAllCertificates(ctx, mesh); err != nil {
 			return fmt.Errorf("failed to cleanup Certificates: %w", err)
@@ -312,6 +307,10 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 
 	if err := r.cleanupManagedServiceAccounts(ctx, mesh, clusters); err != nil {
 		return fmt.Errorf("failed to cleanup ManagedServiceAccounts: %w", err)
+	}
+
+	if err := r.ensureManifestWorkReplicaSet(ctx, mesh); err != nil {
+		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet for mesh %s: %w", mesh.Name, err)
 	}
 
 	if err := r.cleanupRemoteSecrets(ctx, mesh, clusters); err != nil {

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -42,9 +42,11 @@ import (
 )
 
 const (
-	OperatorManifestWorkName   = "multicluster-mesh-operator"
-	ManifestWorkNameCacerts    = "multicluster-mesh-cacerts"
-	ManifestWorkNameCPNSPrefix = "multicluster-mesh-cp-ns-"
+	OperatorManifestWorkName      = "multicluster-mesh-operator"
+	ManifestWorkNameCacerts       = "multicluster-mesh-cacerts"
+	ManifestWorkReplicaSetName    = "multicluster-mesh-mwrset"
+	ManifestWorkNameRemoteSecrets = "multicluster-mesh-remote-secrets"
+	ManifestWorkNameCPNSPrefix    = "multicluster-mesh-cp-ns-"
 
 	FeedbackInstalledCSV = "installedCSV"
 
@@ -140,6 +142,7 @@ func RegisterController(mgr manager.Manager) error {
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworkreplicasets,verbs=get;list;create;update;delete
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;delete
@@ -283,6 +286,10 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 				return fmt.Errorf("failed to ensure cacerts ManifestWork for cluster %s: %w", cluster.Name, err)
 			}
 		}
+	}
+
+	if err := r.ensureRemoteSecretDistributed(ctx, mesh, clusters); err != nil {
+		return fmt.Errorf("failed to ensure remote secret distribution for mesh %s: %w", mesh.Name, err)
 	}
 
 	if mesh.Spec.Security.Trust.CertManager.IssuerRef.Name == "" {
@@ -795,6 +802,7 @@ func (r *Reconciler) ensureCacertsManifestWork(ctx context.Context, mesh *meshv1
 	secretName := getCacertsName(cluster.Name)
 	secret := &corev1.Secret{}
 	err := r.Get(ctx, key.Of(secretName, mesh.Namespace), secret)
+
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(4).Infof("Secret %s/%s not found yet, waiting for cert-manager to create it", mesh.Namespace, secretName)

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"sort"
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
@@ -122,18 +123,20 @@ func (r *Reconciler) ensureRemoteSecretDistributed(ctx context.Context, mesh *me
 		if err != nil {
 			if errors.IsNotFound(err) {
 				klog.V(4).Infof("ManagedServiceAccount secret %s/%s not found yet, waiting for its controller to create it", cluster.Name, msaSecretName)
-				return nil
 			}
+			msaSecret = nil
 		}
 
-		remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
-		msaSecrets[remoteSecret.Name] = remoteSecret
+		if msaSecret != nil {
+			remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
+			msaSecrets[remoteSecret.Name] = remoteSecret
+		}
 	}
 
 	for _, cluster := range clusters {
 		work, err := r.workApplier.Apply(ctx, r.buildRemoteSecretManifestWork(mesh, &cluster, msaSecrets))
 		if err != nil {
-			return fmt.Errorf("failed to apply remote secret ManifestWork %s/%s", work.Namespace, work.Name)
+			return fmt.Errorf("failed to apply remote secret ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
 		}
 	}
 
@@ -167,11 +170,16 @@ func buildMeshRemoteSecret(mesh *meshv1alpha1.MultiClusterMesh, cluster *cluster
 
 // buildRemoteSecretManifestWork builds a ManifestWork using remote access secrets from other clusters.
 func (r *Reconciler) buildRemoteSecretManifestWork(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster, remoteSecrets map[string]*corev1.Secret) *workv1.ManifestWork {
-	manifests := []workv1.Manifest{}
+	names := make([]string, 0, len(remoteSecrets))
+	for name := range remoteSecrets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
 
-	for _, secret := range remoteSecrets {
+	manifests := []workv1.Manifest{}
+	for _, name := range names {
 		manifests = append(manifests, workv1.Manifest{
-			RawExtension: runtime.RawExtension{Object: secret},
+			RawExtension: runtime.RawExtension{Object: remoteSecrets[name]},
 		})
 	}
 

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -134,9 +134,9 @@ func (r *Reconciler) ensureRemoteSecretDistributed(ctx context.Context, mesh *me
 	}
 
 	for _, cluster := range clusters {
-		work, err := r.workApplier.Apply(ctx, r.buildRemoteSecretManifestWork(mesh, &cluster, msaSecrets))
+		_, err := r.workApplier.Apply(ctx, r.buildRemoteSecretManifestWork(mesh, &cluster, msaSecrets))
 		if err != nil {
-			return fmt.Errorf("failed to apply remote secret ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
+			return fmt.Errorf("failed to apply remote secret ManifestWork for cluster %s: %w", cluster.Name, err)
 		}
 	}
 

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -7,10 +7,13 @@ import (
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
 	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -104,5 +107,130 @@ func (r *Reconciler) ensureManagedServiceAccountUpdated(ctx context.Context, mes
 	}
 
 	klog.V(4).Infof("Updated ManagedServiceAccount %s/%s", existing.Namespace, existing.Name)
+	return nil
+}
+
+// The ManagedServiceAccount controller generates an access secret with the name of the ManagedServiceAccount.
+// ensureRemoteSecretDistributed creates a ManifestWork to distribute the access secrets.
+func (r *Reconciler) ensureRemoteSecretDistributed(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
+	msaSecretName := fmt.Sprintf("%s-%s-%s", mesh.Namespace, "istio-reader", mesh.Name)
+	msaSecrets := make(map[string]*corev1.Secret) // secret name to secret
+
+	for _, cluster := range clusters {
+		msaSecret := &corev1.Secret{}
+		err := r.Get(ctx, key.Of(msaSecretName, cluster.Name), msaSecret)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				klog.V(4).Infof("ManagedServiceAccount secret %s/%s not found yet, waiting for its controller to create it", cluster.Name, msaSecretName)
+				return nil
+			}
+		}
+
+		remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
+		msaSecrets[remoteSecret.Name] = remoteSecret
+	}
+
+	for _, cluster := range clusters {
+		work, err := r.workApplier.Apply(ctx, r.buildRemoteSecretManifestWork(mesh, &cluster, msaSecrets))
+		if err != nil {
+			return fmt.Errorf("failed to apply remote secret ManifestWork %s/%s", work.Namespace, work.Name)
+		}
+	}
+
+	return nil
+}
+
+// buildMeshRemoteSecret builds a remote API server access secret.
+// The secret includes required label and annotation for Istio remote endpoint discovery and data from the ManageServiceAccount secret.
+func buildMeshRemoteSecret(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster, msaSecret *corev1.Secret) *corev1.Secret {
+	istioRemoteSecretName := fmt.Sprintf("%s-%s-%s-%s", mesh.Namespace, "istio-remote-secret", mesh.Name, cluster.Name)
+	istioRemoteSecretLabels := meshOwnedLabels(mesh, cluster.Name)
+	istioRemoteSecretLabels["istio/multiCluster"] = "true"
+
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      istioRemoteSecretName,
+			Namespace: mesh.GetControlPlaneNamespace(),
+			Labels:    istioRemoteSecretLabels,
+			Annotations: map[string]string{
+				"networking.istio.io/cluster": cluster.Name,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: msaSecret.Data,
+	}
+}
+
+// buildRemoteSecretManifestWork builds a ManifestWork using remote access secrets from other clusters.
+func (r *Reconciler) buildRemoteSecretManifestWork(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster, remoteSecrets map[string]*corev1.Secret) *workv1.ManifestWork {
+	manifests := []workv1.Manifest{}
+
+	for _, secret := range remoteSecrets {
+		manifests = append(manifests, workv1.Manifest{
+			RawExtension: runtime.RawExtension{Object: secret},
+		})
+	}
+
+	return &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ManifestWorkNameRemoteSecrets,
+			Namespace: cluster.Name,
+			Labels:    meshOwnedLabels(mesh, cluster.Name),
+		},
+		Spec: workv1.ManifestWorkSpec{
+			Workload: workv1.ManifestsTemplate{
+				Manifests: manifests,
+			},
+		},
+	}
+}
+
+// cleanupRemoteSecrets deletes Istio remote access secrets when the cluster(s) are removed from the given mesh's ClusterSet.
+func (r *Reconciler) cleanupRemoteSecrets(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
+	clusterNames := clusterNameSet(clusters)
+	secretList := &corev1.SecretList{}
+	if err := r.List(ctx, secretList, client.InNamespace(mesh.Namespace), client.MatchingLabels{
+		"networking.istio.io/cluster": "true", MeshNameLabel: mesh.Name, MeshNamespaceLabel: mesh.Namespace,
+	}); err != nil {
+		return fmt.Errorf("failed to list Istio remote secrets managed by mesh %s: %w", mesh.Name, err)
+	}
+
+	for _, secret := range secretList.Items {
+		clusterName := secret.Labels[ClusterNameLabel]
+		if clusterNames[clusterName] {
+			continue
+		}
+
+		klog.Infof("Deleting Istio remote secret %s/%s (cluster %s no longer in ClusterSet %s)", secret.Namespace, secret.Name, clusterName, mesh.Spec.ClusterSet)
+		if err := client.IgnoreNotFound(r.Delete(ctx, &secret)); err != nil {
+			return fmt.Errorf("failed to delete Istio remote secret %s/%s: %w", secret.Namespace, secret.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// deleteAllRemoteSecrets deletes all Istio remote access secrets managed by a mesh.
+func (r *Reconciler) deleteAllRemoteSecrets(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
+	secretList := &corev1.SecretList{}
+	if err := r.List(ctx, secretList, client.MatchingLabels{
+		"networking.istio.io/cluster": "true",
+		MeshNameLabel:                 mesh.Name,
+		MeshNamespaceLabel:            mesh.Namespace,
+	}); err != nil {
+		return fmt.Errorf("failed to list Istio remote secret managed by mesh %s: %w", mesh.Name, err)
+	}
+
+	for _, secret := range secretList.Items {
+		klog.Infof("Deleting Istio remote secret %s/%s", secret.Namespace, secret.Name)
+		if err := client.IgnoreNotFound(r.Delete(ctx, &secret)); err != nil {
+			return fmt.Errorf("failed to delete Istio remote secret %s/%s: %w", secret.Namespace, secret.Name, err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -119,10 +119,7 @@ func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *mes
 
 	placement := &clusterv1beta1.Placement{ObjectMeta: metav1.ObjectMeta{Name: mesh.Name, Namespace: mesh.Namespace}}
 	if err := r.Get(ctx, key.Of(mesh.Name, mesh.Namespace), placement); err != nil {
-		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("Placement %s/%s not found: %w", mesh.Namespace, mesh.Name, err)
-		}
-		return fmt.Errorf("failed to get Placement: %w", err)
+		return fmt.Errorf("failed to get Placement %s/%s: %w", mesh.Namespace, mesh.Name, err)
 	}
 
 	workTemplate, err := r.buildManifestWorkSpec(ctx, mesh)

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -10,13 +10,17 @@ import (
 	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	workv1 "open-cluster-management.io/api/work/v1"
+	workv1alpha1 "open-cluster-management.io/api/work/v1alpha1"
 	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // ensureManagedServiceAccount applies the desired ManagedServiceAccount state for a specific cluster using mesh's TokenValidity.
@@ -108,6 +112,51 @@ func (r *Reconciler) ensureManagedServiceAccountUpdated(ctx context.Context, mes
 	}
 
 	klog.V(4).Infof("Updated ManagedServiceAccount %s/%s", existing.Namespace, existing.Name)
+	return nil
+}
+
+// ensureManifestWorkReplicaSet creates a ManifestWorkReplicaSet to distribute ManifestWork resources for clusters selected by a Placement
+func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
+
+	// TODO: implement buildRemoteSecrets and buildManifestWorkSpec
+	workTemplate := workv1.ManifestWorkSpec{}
+
+	placement := &clusterv1beta1.Placement{}
+	if err := r.Get(ctx, key.Of(mesh.Name, mesh.Namespace), placement); err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("Placement %s/%s not found", mesh.Namespace, mesh.Name)
+			return nil
+		}
+		return fmt.Errorf("failed to get Placement: %w", err)
+	}
+
+	mwrc := &workv1alpha1.ManifestWorkReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ManifestWorkReplicaSetName,
+			Namespace: mesh.Namespace,
+			Labels: map[string]string{
+				ManagedByLabel:     ManagedByValue,
+				MeshNameLabel:      mesh.Name,
+				MeshNamespaceLabel: mesh.Namespace,
+			},
+		},
+		Spec: workv1alpha1.ManifestWorkReplicaSetSpec{
+			PlacementRefs: []workv1alpha1.LocalPlacementReference{
+				{Name: placement.Name},
+			},
+			ManifestWorkTemplate: workTemplate,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, mwrc, func() error {
+		mwrc.Spec.PlacementRefs = []workv1alpha1.LocalPlacementReference{{Name: placement.Name}}
+		mwrc.Spec.ManifestWorkTemplate = workTemplate
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet %s/%s: %w", mesh.Namespace, mwrc.Name, err)
+	}
 	return nil
 }
 

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -1,6 +1,7 @@
 package mesh
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"maps"
@@ -11,14 +12,21 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/clientcmd/api/latest"
 	"k8s.io/klog/v2"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	workv1alpha1 "open-cluster-management.io/api/work/v1alpha1"
 	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var (
+	errMissingRootCAKey = fmt.Errorf("no %q data found", corev1.ServiceAccountRootCAKey)
+	errMissingTokenKey  = fmt.Errorf("no %q data found", corev1.ServiceAccountTokenKey)
 )
 
 // ensureManagedServiceAccount applies the desired ManagedServiceAccount state for a specific cluster using mesh's TokenValidity.
@@ -115,11 +123,6 @@ func (r *Reconciler) ensureManagedServiceAccountUpdated(ctx context.Context, mes
 
 // ensureManifestWorkReplicaSet creates a ManifestWorkReplicaSet to distribute remote access secrets for clusters selected by a Placement
 func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
-	placement := &clusterv1beta1.Placement{}
-	if err := r.Get(ctx, key.Of(mesh.Name, mesh.Namespace), placement); err != nil {
-		return fmt.Errorf("failed to get Placement %s/%s: %w", mesh.Namespace, mesh.Name, err)
-	}
-
 	workTemplate, err := r.buildManifestWorkSpec(ctx, mesh)
 	if err != nil {
 		return fmt.Errorf("failed to build ManifestWorkSpec Template: %w", err)
@@ -129,14 +132,14 @@ func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *mes
 		ObjectMeta: metav1.ObjectMeta{Name: mesh.Name, Namespace: mesh.Namespace},
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, mwrset, func() error {
+	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, mwrset, func() error {
 		if mwrset.Labels == nil {
 			mwrset.Labels = make(map[string]string)
 		}
 		mwrset.Labels[ManagedByLabel] = ManagedByValue
 		mwrset.Labels[MeshNameLabel] = mesh.Name
 		mwrset.Labels[MeshNamespaceLabel] = mesh.Namespace
-		mwrset.Spec.PlacementRefs = []workv1alpha1.LocalPlacementReference{{Name: placement.Name}}
+		mwrset.Spec.PlacementRefs = []workv1alpha1.LocalPlacementReference{{Name: mesh.Name}}
 		mwrset.Spec.ManifestWorkTemplate = *workTemplate
 		return controllerutil.SetControllerReference(mesh, mwrset, r.Scheme)
 	})
@@ -145,38 +148,21 @@ func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *mes
 		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet %s/%s: %w", mesh.Namespace, mesh.Name, err)
 	}
 
-	klog.Infof("Successfully created a ManifestWorkReplicaSet %s/%s", mesh.Namespace, mesh.Name)
+	var state string
+	switch result {
+	case controllerutil.OperationResultCreated:
+		state = "created"
+	case controllerutil.OperationResultUpdated:
+		state = "updated"
+	case controllerutil.OperationResultNone:
+		state = "up to date"
+	}
+
+	klog.Infof("ManifestWorkReplicaSet %s/%s successfully %s", mesh.Namespace, mesh.Name, state)
 	return nil
 }
 
-// buildMeshRemoteSecret builds a remote API server access secret.
-// The secret includes required label and annotation for Istio remote endpoint discovery and data from a ManageServiceAccount secret.
-func buildMeshRemoteSecret(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster, msaSecret *corev1.Secret) *corev1.Secret {
-	istioRemoteSecretName := fmt.Sprintf("%s-%s-%s-%s", mesh.Namespace, mesh.Name, "istio-remote-secret", cluster.Name)
-	istioRemoteSecretLabels := meshOwnedLabels(mesh, cluster.Name)
-	istioRemoteSecretLabels["istio/multiCluster"] = "true"
-
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      istioRemoteSecretName,
-			Namespace: mesh.GetControlPlaneNamespace(),
-			Labels:    istioRemoteSecretLabels,
-			Annotations: map[string]string{
-				"networking.istio.io/cluster": cluster.Name,
-			},
-			OwnerReferences: msaSecret.OwnerReferences,
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: msaSecret.Data,
-	}
-}
-
 func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) (*workv1.ManifestWorkSpec, error) {
-	msaName := fmt.Sprintf("%s-%s-%s", mesh.Namespace, "istio-reader", mesh.Name)
 	clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
@@ -184,15 +170,10 @@ func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alph
 
 	manifests := []workv1.Manifest{}
 	for _, cluster := range clusters {
-		msaSecret := &corev1.Secret{}
-		if err := r.Get(ctx, key.Of(msaName, cluster.Name), msaSecret); err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.V(4).Infof("ManagedServiceAccount Secret %s/%s not found yet, waiting for ManagedServiceAccount to create it", cluster.Name, msaName)
-				continue
-			}
-			return nil, fmt.Errorf("failed to get ManagedServiceAccount Secret %s/%s: %w", cluster.Name, msaName, err)
+		remoteSecret, err := r.createRemoteSecret(ctx, mesh, &cluster)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create remote secret: %w", err)
 		}
-		remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
 		manifests = append(manifests, workv1.Manifest{
 			RawExtension: runtime.RawExtension{Object: remoteSecret},
 		})
@@ -201,24 +182,147 @@ func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alph
 	return &workv1.ManifestWorkSpec{Workload: workv1.ManifestsTemplate{Manifests: manifests}}, nil
 }
 
-// deleteAllRemoteSecrets deletes all Istio remote access secrets managed by a mesh.
-func (r *Reconciler) deleteAllRemoteSecrets(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
-	secretList := &corev1.SecretList{}
-	if err := r.List(ctx, secretList, client.InNamespace(mesh.Spec.ControlPlane.Namespace), client.MatchingLabels{
-		"istio/multiCluster": "true",
-		ManagedByLabel:       ManagedByValue,
-		MeshNameLabel:        mesh.Name,
-		MeshNamespaceLabel:   mesh.Namespace,
-	}); err != nil {
-		return fmt.Errorf("failed to list Istio remote secret managed by mesh %s: %w", mesh.Name, err)
+// createRemoteSecret builds a remote API server access secret.
+// The secret includes required label and annotation for Istio remote endpoint discovery and data from a ManageServiceAccount secret.
+func (r *Reconciler) createRemoteSecret(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) (*corev1.Secret, error) {
+	secName := "istio-remote-secret-" + cluster.Name
+	serviceAccountName := fmt.Sprintf("%s-%s-%s", mesh.Namespace, "istio-reader", mesh.Name)
+
+	tokenSecret, err := r.getServiceAccountSecret(ctx, serviceAccountName, cluster.Name)
+	if err != nil {
+		return nil, err
 	}
 
-	for _, secret := range secretList.Items {
-		klog.V(4).Infof("Deleting Istio remote secret %s/%s", secret.Namespace, secret.Name)
-		if err := client.IgnoreNotFound(r.Delete(ctx, &secret)); err != nil {
-			return fmt.Errorf("failed to delete Istio remote secret %s/%s: %w", secret.Namespace, secret.Name, err)
+	server := cluster.Spec.ManagedClusterClientConfigs[0].URL
+	// TODO: Get TLSServerName (SNI) from ManagedCluster if needed. If tlsServerName is empty, the hostname used to contact the server is used.
+	tlsServerName := ""
+	remoteSecret, err := createRemoteSecretFromTokenAndServer(tokenSecret, server, tlsServerName, cluster.Name, secName)
+	if err != nil {
+		return nil, err
+	}
+	remoteSecret.Namespace = mesh.Spec.ControlPlane.Namespace
+	maps.Copy(remoteSecret.Labels, meshOwnedLabels(mesh, cluster.Name))
+	return remoteSecret, nil
+}
+
+func (r *Reconciler) getServiceAccountSecret(ctx context.Context, serviceAccountName, clusterName string) (*corev1.Secret, error) {
+	sa := &corev1.ServiceAccount{}
+	if err := r.Get(ctx, key.Of(serviceAccountName, clusterName), sa); err != nil {
+		return nil, fmt.Errorf("failed to get ManagedServiceAccount %s/%s: %w", clusterName, serviceAccountName, err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, key.Of(serviceAccountName, clusterName), secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("secret %s/%s not found yet, waiting for ManagedServiceAccount controller to create it", clusterName, serviceAccountName)
 		}
+		return nil, fmt.Errorf("failed to get ManagedServiceAccount Secret %s/%s: %w", clusterName, serviceAccountName, err)
 	}
 
+	if err := secretReferencesServiceAccount(sa, secret); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+func secretReferencesServiceAccount(serviceAccount *corev1.ServiceAccount, secret *corev1.Secret) error {
+	if secret.Type != corev1.SecretTypeServiceAccountToken ||
+		secret.Annotations[corev1.ServiceAccountNameKey] != serviceAccount.Name {
+		return fmt.Errorf("secret %s/%s does not reference ServiceAccount %s",
+			secret.Namespace, secret.Name, serviceAccount.Name)
+	}
 	return nil
+}
+
+func createRemoteSecretFromTokenAndServer(tokenSecret *corev1.Secret, server, tlsServerName, clusterName, secName string) (*corev1.Secret, error) {
+	caData, token, err := tokenDataFromSecret(tokenSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a Kubeconfig to access the remote cluster using the remote service account credentials.
+	kubeconfig := createBearerTokenKubeconfig(caData, token, clusterName, server, tlsServerName)
+	if err := clientcmd.Validate(*kubeconfig); err != nil {
+		return nil, fmt.Errorf("invalid kubeconfig: %w", err)
+	}
+
+	// Encode the Kubeconfig in a secret that can be loaded by Istio to dynamically discover and access the remote cluster.
+	return createRemoteServiceAccountSecret(kubeconfig, clusterName, secName)
+}
+
+func tokenDataFromSecret(tokenSecret *corev1.Secret) (ca, token []byte, err error) {
+	var ok bool
+	ca, ok = tokenSecret.Data[corev1.ServiceAccountRootCAKey]
+	if !ok {
+		err = errMissingRootCAKey
+		return ca, token, err
+	}
+	token, ok = tokenSecret.Data[corev1.ServiceAccountTokenKey]
+	if !ok {
+		err = errMissingTokenKey
+		return ca, token, err
+	}
+	return ca, token, err
+}
+
+func createBearerTokenKubeconfig(caData, token []byte, clusterName, server, tlsServerName string) *api.Config {
+	c := createBaseKubeconfig(caData, clusterName, server, tlsServerName)
+	c.AuthInfos[c.CurrentContext] = &api.AuthInfo{
+		Token: string(token),
+	}
+	return c
+}
+
+func createBaseKubeconfig(caData []byte, clusterName, server, tlsServerName string) *api.Config {
+	return &api.Config{
+		Clusters: map[string]*api.Cluster{
+			clusterName: {
+				CertificateAuthorityData: caData,
+				Server:                   server,
+				TLSServerName:            tlsServerName,
+			},
+		},
+		AuthInfos: map[string]*api.AuthInfo{},
+		Contexts: map[string]*api.Context{
+			clusterName: {
+				Cluster:  clusterName,
+				AuthInfo: clusterName,
+			},
+		},
+		CurrentContext: clusterName,
+	}
+}
+
+func createRemoteServiceAccountSecret(kubeconfig *api.Config, clusterName, secName string) (*corev1.Secret, error) {
+	var data bytes.Buffer
+	if err := latest.Codec.Encode(kubeconfig, &data); err != nil {
+		return nil, err
+	}
+	key := clusterName
+
+	out := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secName,
+			Annotations: map[string]string{
+				"networking.istio.io/cluster": clusterName,
+			},
+			Labels: map[string]string{
+				"istio/multiCluster": "true",
+			},
+		},
+		Data: map[string][]byte{
+			key: data.Bytes(),
+		},
+	}
+	return out, nil
+}
+
+// convertDataBinaryToString is used in testing expected remoteSecret data
+func convertDataBinaryToString(remoteSecret *corev1.Secret) *corev1.Secret {
+	remoteSecret.StringData = make(map[string]string, len(remoteSecret.Data))
+	for k, v := range remoteSecret.Data {
+		remoteSecret.StringData[k] = string(v)
+	}
+	remoteSecret.Data = nil
+	return remoteSecret
 }

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -114,7 +114,7 @@ func (r *Reconciler) ensureManagedServiceAccountUpdated(ctx context.Context, mes
 	return nil
 }
 
-// ensureManifestWorkReplicaSet creates a ManifestWorkReplicaSet to distribute ManifestWork resources for clusters selected by a Placement
+// ensureManifestWorkReplicaSet creates a ManifestWorkReplicaSet to distribute remote access secrets for clusters selected by a Placement
 func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
 	placement := &clusterv1beta1.Placement{}
 	if err := r.Get(ctx, key.Of(mesh.Name, mesh.Namespace), placement); err != nil {
@@ -170,6 +170,7 @@ func buildMeshRemoteSecret(mesh *meshv1alpha1.MultiClusterMesh, cluster *cluster
 			Annotations: map[string]string{
 				"networking.istio.io/cluster": cluster.Name,
 			},
+			OwnerReferences: msaSecret.OwnerReferences,
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: msaSecret.Data,
@@ -188,9 +189,10 @@ func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alph
 		msaSecret := &corev1.Secret{}
 		if err := r.Get(ctx, key.Of(msaName, cluster.Name), msaSecret); err != nil {
 			if apierrors.IsNotFound(err) {
-				return nil, fmt.Errorf("MSA Secret %s/%s not found: %w", cluster.Name, msaName, err)
+				klog.V(4).Infof("ManagedServiceAccount Secret %s/%s not found yet, waiting for ManagedServiceAccount to create it", cluster.Name, msaName)
+				return nil, nil
 			}
-			return nil, fmt.Errorf("failed to get MSA Secret: %w", err)
+			return nil, fmt.Errorf("failed to get ManagedServiceAccount Secret: %w", err)
 		}
 
 		remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
@@ -203,36 +205,12 @@ func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alph
 	return &workv1.ManifestWorkSpec{Workload: workv1.ManifestsTemplate{Manifests: manifests}}, nil
 }
 
-// cleanupRemoteSecrets deletes Istio remote access secrets when the cluster(s) are removed from the given mesh's ClusterSet.
-func (r *Reconciler) cleanupRemoteSecrets(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
-	clusterNames := clusterNameSet(clusters)
-	secretList := &corev1.SecretList{}
-	if err := r.List(ctx, secretList, client.InNamespace(mesh.Namespace), client.MatchingLabels{
-		"networking.istio.io/cluster": "true", MeshNameLabel: mesh.Name, MeshNamespaceLabel: mesh.Namespace,
-	}); err != nil {
-		return fmt.Errorf("failed to list Istio remote secrets managed by mesh %s: %w", mesh.Name, err)
-	}
-
-	for _, secret := range secretList.Items {
-		clusterName := secret.Labels[ClusterNameLabel]
-		if clusterNames[clusterName] {
-			continue
-		}
-
-		klog.Infof("Deleting Istio remote secret %s/%s (cluster %s no longer in ClusterSet %s)", secret.Namespace, secret.Name, clusterName, mesh.Spec.ClusterSet)
-		if err := client.IgnoreNotFound(r.Delete(ctx, &secret)); err != nil {
-			return fmt.Errorf("failed to delete Istio remote secret %s/%s: %w", secret.Namespace, secret.Name, err)
-		}
-	}
-
-	return nil
-}
-
 // deleteAllRemoteSecrets deletes all Istio remote access secrets managed by a mesh.
 func (r *Reconciler) deleteAllRemoteSecrets(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
 	secretList := &corev1.SecretList{}
 	if err := r.List(ctx, secretList, client.MatchingLabels{
 		"networking.istio.io/cluster": "true",
+		ManagedByLabel:                ManagedByValue,
 		MeshNameLabel:                 mesh.Name,
 		MeshNamespaceLabel:            mesh.Namespace,
 	}); err != nil {

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -214,7 +214,7 @@ func (r *Reconciler) deleteAllRemoteSecrets(ctx context.Context, mesh *meshv1alp
 	}
 
 	for _, secret := range secretList.Items {
-		klog.Infof("Deleting Istio remote secret %s/%s", secret.Namespace, secret.Name)
+		klog.V(4).Infof("Deleting Istio remote secret %s/%s", secret.Namespace, secret.Name)
 		if err := client.IgnoreNotFound(r.Delete(ctx, &secret)); err != nil {
 			return fmt.Errorf("failed to delete Istio remote secret %s/%s: %w", secret.Namespace, secret.Name, err)
 		}

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -115,9 +115,7 @@ func (r *Reconciler) ensureManagedServiceAccountUpdated(ctx context.Context, mes
 
 // ensureManifestWorkReplicaSet creates a ManifestWorkReplicaSet to distribute remote access secrets for clusters selected by a Placement
 func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
-	mwrsetName := fmt.Sprintf("%s-%s-%s", mesh.Namespace, ManifestWorkReplicaSetName, mesh.Name)
-
-	placement := &clusterv1beta1.Placement{ObjectMeta: metav1.ObjectMeta{Name: mesh.Name, Namespace: mesh.Namespace}}
+	placement := &clusterv1beta1.Placement{}
 	if err := r.Get(ctx, key.Of(mesh.Name, mesh.Namespace), placement); err != nil {
 		return fmt.Errorf("failed to get Placement %s/%s: %w", mesh.Namespace, mesh.Name, err)
 	}
@@ -128,7 +126,7 @@ func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *mes
 	}
 
 	mwrset := &workv1alpha1.ManifestWorkReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{Name: mwrsetName, Namespace: mesh.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: mesh.Name, Namespace: mesh.Namespace},
 	}
 
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, mwrset, func() error {
@@ -144,10 +142,10 @@ func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *mes
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet %s/%s: %w", mesh.Namespace, mwrset.Name, err)
+		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet %s/%s: %w", mesh.Namespace, mesh.Name, err)
 	}
 
-	klog.Infof("Successfully created a ManifestWorkReplicaSet %s/%s", mesh.Namespace, mwrsetName)
+	klog.Infof("Successfully created a ManifestWorkReplicaSet %s/%s", mesh.Namespace, mesh.Name)
 	return nil
 }
 

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -204,11 +204,11 @@ func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alph
 // deleteAllRemoteSecrets deletes all Istio remote access secrets managed by a mesh.
 func (r *Reconciler) deleteAllRemoteSecrets(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
 	secretList := &corev1.SecretList{}
-	if err := r.List(ctx, secretList, client.MatchingLabels{
-		"networking.istio.io/cluster": "true",
-		ManagedByLabel:                ManagedByValue,
-		MeshNameLabel:                 mesh.Name,
-		MeshNamespaceLabel:            mesh.Namespace,
+	if err := r.List(ctx, secretList, client.InNamespace(mesh.Spec.ControlPlane.Namespace), client.MatchingLabels{
+		"istio/multiCluster": "true",
+		ManagedByLabel:       ManagedByValue,
+		MeshNameLabel:        mesh.Name,
+		MeshNamespaceLabel:   mesh.Namespace,
 	}); err != nil {
 		return fmt.Errorf("failed to list Istio remote secret managed by mesh %s: %w", mesh.Name, err)
 	}

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -8,7 +8,6 @@ import (
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,7 +27,7 @@ func (r *Reconciler) ensureManagedServiceAccount(ctx context.Context, mesh *mesh
 	existing := &msav1beta1.ManagedServiceAccount{}
 	if err := r.Get(ctx, key.Of(msaName, cluster.Name), existing); err == nil {
 		return r.ensureManagedServiceAccountUpdated(ctx, mesh, existing)
-	} else if !errors.IsNotFound(err) {
+	} else if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get ManagedServiceAccount %s/%s: %w", cluster.Name, msaName, err)
 	}
 
@@ -193,8 +192,8 @@ func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alph
 	}
 
 	manifests := []workv1.Manifest{}
-	msaSecret := &corev1.Secret{}
 	for _, cluster := range clusters {
+		msaSecret := &corev1.Secret{}
 		if err := r.Get(ctx, key.Of(msaName, cluster.Name), msaSecret); err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.V(4).Infof("ManagedServiceAccount Secret %s/%s not found yet, waiting for ManagedServiceAccount to create it", cluster.Name, msaName)
@@ -202,13 +201,10 @@ func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alph
 			}
 			return nil, fmt.Errorf("failed to get ManagedServiceAccount Secret %s/%s: %w", cluster.Name, msaName, err)
 		}
-
-		if msaSecret != nil {
-			remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
-			manifests = append(manifests, workv1.Manifest{
-				RawExtension: runtime.RawExtension{Object: remoteSecret},
-			})
-		}
+		remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
+		manifests = append(manifests, workv1.Manifest{
+			RawExtension: runtime.RawExtension{Object: remoteSecret},
+		})
 	}
 
 	return &workv1.ManifestWorkSpec{Workload: workv1.ManifestsTemplate{Manifests: manifests}}, nil

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -123,9 +123,26 @@ func (r *Reconciler) ensureManagedServiceAccountUpdated(ctx context.Context, mes
 
 // ensureManifestWorkReplicaSet creates a ManifestWorkReplicaSet to distribute remote access secrets for clusters selected by a Placement
 func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
-	workTemplate, err := r.buildManifestWorkSpec(ctx, mesh)
+	clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
 	if err != nil {
-		return fmt.Errorf("failed to build ManifestWorkSpec Template: %w", err)
+		return fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
+	}
+
+	msaName := fmt.Sprintf("%s-%s-%s", mesh.Namespace, "istio-reader", mesh.Name)
+	manifests := []workv1.Manifest{}
+	for _, cluster := range clusters {
+		tokenSecret, err := r.getServiceAccountSecret(ctx, msaName, cluster.Name)
+		if err != nil {
+			return err
+		}
+
+		remoteSecret, err := r.createRemoteSecret(ctx, mesh, &cluster, tokenSecret)
+		if err != nil {
+			return fmt.Errorf("failed create Istio remote secret for cluster %s: %w", cluster.Name, err)
+		}
+		manifests = append(manifests, workv1.Manifest{
+			RawExtension: runtime.RawExtension{Object: remoteSecret},
+		})
 	}
 
 	mwrset := &workv1alpha1.ManifestWorkReplicaSet{
@@ -140,7 +157,7 @@ func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *mes
 		mwrset.Labels[MeshNameLabel] = mesh.Name
 		mwrset.Labels[MeshNamespaceLabel] = mesh.Namespace
 		mwrset.Spec.PlacementRefs = []workv1alpha1.LocalPlacementReference{{Name: mesh.Name}}
-		mwrset.Spec.ManifestWorkTemplate = *workTemplate
+		mwrset.Spec.ManifestWorkTemplate = workv1.ManifestWorkSpec{Workload: workv1.ManifestsTemplate{Manifests: manifests}}
 		return controllerutil.SetControllerReference(mesh, mwrset, r.Scheme)
 	})
 
@@ -162,61 +179,15 @@ func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *mes
 	return nil
 }
 
-func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) (*workv1.ManifestWorkSpec, error) {
-	clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
-	}
-
-	manifests := []workv1.Manifest{}
-	for _, cluster := range clusters {
-		remoteSecret, err := r.createRemoteSecret(ctx, mesh, &cluster)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create remote secret: %w", err)
-		}
-		manifests = append(manifests, workv1.Manifest{
-			RawExtension: runtime.RawExtension{Object: remoteSecret},
-		})
-	}
-
-	return &workv1.ManifestWorkSpec{Workload: workv1.ManifestsTemplate{Manifests: manifests}}, nil
-}
-
-// createRemoteSecret builds a remote API server access secret.
-// The secret includes required label and annotation for Istio remote endpoint discovery and data from a ManageServiceAccount secret.
-func (r *Reconciler) createRemoteSecret(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) (*corev1.Secret, error) {
-	secName := "istio-remote-secret-" + cluster.Name
-	serviceAccountName := fmt.Sprintf("%s-%s-%s", mesh.Namespace, "istio-reader", mesh.Name)
-
-	tokenSecret, err := r.getServiceAccountSecret(ctx, serviceAccountName, cluster.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	server := cluster.Spec.ManagedClusterClientConfigs[0].URL
-	// TODO: Get TLSServerName (SNI) from ManagedCluster if needed. If tlsServerName is empty, the hostname used to contact the server is used.
-	tlsServerName := ""
-	remoteSecret, err := createRemoteSecretFromTokenAndServer(tokenSecret, server, tlsServerName, cluster.Name, secName)
-	if err != nil {
-		return nil, err
-	}
-	remoteSecret.Namespace = mesh.Spec.ControlPlane.Namespace
-	maps.Copy(remoteSecret.Labels, meshOwnedLabels(mesh, cluster.Name))
-	return remoteSecret, nil
-}
-
 func (r *Reconciler) getServiceAccountSecret(ctx context.Context, serviceAccountName, clusterName string) (*corev1.Secret, error) {
 	sa := &corev1.ServiceAccount{}
 	if err := r.Get(ctx, key.Of(serviceAccountName, clusterName), sa); err != nil {
-		return nil, fmt.Errorf("failed to get ManagedServiceAccount %s/%s: %w", clusterName, serviceAccountName, err)
+		return nil, err
 	}
 
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, key.Of(serviceAccountName, clusterName), secret); err != nil {
-		if apierrors.IsNotFound(err) {
-			klog.V(4).Infof("secret %s/%s not found yet, waiting for ManagedServiceAccount controller to create it", clusterName, serviceAccountName)
-		}
-		return nil, fmt.Errorf("failed to get ManagedServiceAccount Secret %s/%s: %w", clusterName, serviceAccountName, err)
+		return nil, err
 	}
 
 	if err := secretReferencesServiceAccount(sa, secret); err != nil {
@@ -232,6 +203,24 @@ func secretReferencesServiceAccount(serviceAccount *corev1.ServiceAccount, secre
 			secret.Namespace, secret.Name, serviceAccount.Name)
 	}
 	return nil
+}
+
+// createRemoteSecret builds a remote API server access secret.
+// The secret includes required label and annotation for Istio remote endpoint discovery and data from a ManageServiceAccount secret.
+func (r *Reconciler) createRemoteSecret(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh,
+	cluster *clusterv1.ManagedCluster, tokenSecret *corev1.Secret) (*corev1.Secret, error) {
+	secName := "istio-remote-secret-" + cluster.Name
+	server := cluster.Spec.ManagedClusterClientConfigs[0].URL
+	// TODO: Get TLSServerName (SNI) from ManagedCluster if needed. If tlsServerName is empty, the hostname used to contact the server is used.
+	tlsServerName := ""
+
+	remoteSecret, err := createRemoteSecretFromTokenAndServer(tokenSecret, server, tlsServerName, cluster.Name, secName)
+	if err != nil {
+		return nil, err
+	}
+	remoteSecret.Namespace = mesh.Spec.ControlPlane.Namespace
+	maps.Copy(remoteSecret.Labels, meshOwnedLabels(mesh, cluster.Name))
+	return remoteSecret, nil
 }
 
 func createRemoteSecretFromTokenAndServer(tokenSecret *corev1.Secret, server, tlsServerName, clusterName, secName string) (*corev1.Secret, error) {

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -116,12 +116,18 @@ func (r *Reconciler) ensureManagedServiceAccountUpdated(ctx context.Context, mes
 
 // ensureManifestWorkReplicaSet creates a ManifestWorkReplicaSet to distribute remote access secrets for clusters selected by a Placement
 func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
-	placement := &clusterv1beta1.Placement{}
+	mwrsetName := fmt.Sprintf("%s-%s-%s", mesh.Namespace, ManifestWorkReplicaSetName, mesh.Name)
+
+	// TODO: update placement part after PR 221 is merged. This is a placeholder placement
+	placement := &clusterv1beta1.Placement{
+		ObjectMeta: metav1.ObjectMeta{Name: mesh.Name, Namespace: mesh.Namespace},
+	}
+	// TODO: update return error after PR 221 is merged.
 	if err := r.Get(ctx, key.Of(mesh.Name, mesh.Namespace), placement); err != nil {
 		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("Placement %s/%s not found: %w", mesh.Namespace, mesh.Name, err)
+			klog.V(4).Infof("Placement %s/%s not found: %s", mesh.Namespace, mesh.Name, err)
 		}
-		return fmt.Errorf("failed to get Placement: %w", err)
+		klog.V(4).Infof("failed to get Placement: %s", err)
 	}
 
 	workTemplate, err := r.buildManifestWorkSpec(ctx, mesh)
@@ -129,25 +135,27 @@ func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *mes
 		return fmt.Errorf("failed to build ManifestWorkSpec Template: %w", err)
 	}
 
-	mwrs := &workv1alpha1.ManifestWorkReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{Name: ManifestWorkReplicaSetName, Namespace: mesh.Namespace},
+	mwrset := &workv1alpha1.ManifestWorkReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: mwrsetName, Namespace: mesh.Namespace},
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, mwrs, func() error {
-		if mwrs.Labels == nil {
-			mwrs.Labels = make(map[string]string)
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, mwrset, func() error {
+		if mwrset.Labels == nil {
+			mwrset.Labels = make(map[string]string)
 		}
-		mwrs.Labels[ManagedByLabel] = ManagedByValue
-		mwrs.Labels[MeshNameLabel] = mesh.Name
-		mwrs.Labels[MeshNamespaceLabel] = mesh.Namespace
-		mwrs.Spec.PlacementRefs = []workv1alpha1.LocalPlacementReference{{Name: placement.Name}}
-		mwrs.Spec.ManifestWorkTemplate = *workTemplate
-		return controllerutil.SetControllerReference(mesh, mwrs, r.Scheme)
+		mwrset.Labels[ManagedByLabel] = ManagedByValue
+		mwrset.Labels[MeshNameLabel] = mesh.Name
+		mwrset.Labels[MeshNamespaceLabel] = mesh.Namespace
+		mwrset.Spec.PlacementRefs = []workv1alpha1.LocalPlacementReference{{Name: placement.Name}}
+		mwrset.Spec.ManifestWorkTemplate = *workTemplate
+		return controllerutil.SetControllerReference(mesh, mwrset, r.Scheme)
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet %s/%s: %w", mesh.Namespace, mwrs.Name, err)
+		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet %s/%s: %w", mesh.Namespace, mwrset.Name, err)
 	}
+
+	klog.Infof("Successfully created a ManifestWorkReplicaSet %s/%s", mesh.Namespace, mwrsetName)
 	return nil
 }
 
@@ -185,21 +193,22 @@ func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alph
 	}
 
 	manifests := []workv1.Manifest{}
+	msaSecret := &corev1.Secret{}
 	for _, cluster := range clusters {
-		msaSecret := &corev1.Secret{}
 		if err := r.Get(ctx, key.Of(msaName, cluster.Name), msaSecret); err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.V(4).Infof("ManagedServiceAccount Secret %s/%s not found yet, waiting for ManagedServiceAccount to create it", cluster.Name, msaName)
-				return nil, nil
+				continue
 			}
-			return nil, fmt.Errorf("failed to get ManagedServiceAccount Secret: %w", err)
+			return nil, fmt.Errorf("failed to get ManagedServiceAccount Secret %s/%s: %w", cluster.Name, msaName, err)
 		}
 
-		remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
-
-		manifests = append(manifests, workv1.Manifest{
-			RawExtension: runtime.RawExtension{Object: remoteSecret},
-		})
+		if msaSecret != nil {
+			remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
+			manifests = append(manifests, workv1.Manifest{
+				RawExtension: runtime.RawExtension{Object: remoteSecret},
+			})
+		}
 	}
 
 	return &workv1.ManifestWorkSpec{Workload: workv1.ManifestsTemplate{Manifests: manifests}}, nil

--- a/pkg/hub/mesh/endpoint_discovery.go
+++ b/pkg/hub/mesh/endpoint_discovery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"sort"
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
@@ -117,85 +116,45 @@ func (r *Reconciler) ensureManagedServiceAccountUpdated(ctx context.Context, mes
 
 // ensureManifestWorkReplicaSet creates a ManifestWorkReplicaSet to distribute ManifestWork resources for clusters selected by a Placement
 func (r *Reconciler) ensureManifestWorkReplicaSet(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
-
-	// TODO: implement buildRemoteSecrets and buildManifestWorkSpec
-	workTemplate := workv1.ManifestWorkSpec{}
-
 	placement := &clusterv1beta1.Placement{}
 	if err := r.Get(ctx, key.Of(mesh.Name, mesh.Namespace), placement); err != nil {
 		if apierrors.IsNotFound(err) {
-			klog.V(4).Infof("Placement %s/%s not found", mesh.Namespace, mesh.Name)
-			return nil
+			return fmt.Errorf("Placement %s/%s not found: %w", mesh.Namespace, mesh.Name, err)
 		}
 		return fmt.Errorf("failed to get Placement: %w", err)
 	}
 
-	mwrc := &workv1alpha1.ManifestWorkReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ManifestWorkReplicaSetName,
-			Namespace: mesh.Namespace,
-			Labels: map[string]string{
-				ManagedByLabel:     ManagedByValue,
-				MeshNameLabel:      mesh.Name,
-				MeshNamespaceLabel: mesh.Namespace,
-			},
-		},
-		Spec: workv1alpha1.ManifestWorkReplicaSetSpec{
-			PlacementRefs: []workv1alpha1.LocalPlacementReference{
-				{Name: placement.Name},
-			},
-			ManifestWorkTemplate: workTemplate,
-		},
+	workTemplate, err := r.buildManifestWorkSpec(ctx, mesh)
+	if err != nil {
+		return fmt.Errorf("failed to build ManifestWorkSpec Template: %w", err)
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, mwrc, func() error {
-		mwrc.Spec.PlacementRefs = []workv1alpha1.LocalPlacementReference{{Name: placement.Name}}
-		mwrc.Spec.ManifestWorkTemplate = workTemplate
-		return nil
+	mwrs := &workv1alpha1.ManifestWorkReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: ManifestWorkReplicaSetName, Namespace: mesh.Namespace},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, mwrs, func() error {
+		if mwrs.Labels == nil {
+			mwrs.Labels = make(map[string]string)
+		}
+		mwrs.Labels[ManagedByLabel] = ManagedByValue
+		mwrs.Labels[MeshNameLabel] = mesh.Name
+		mwrs.Labels[MeshNamespaceLabel] = mesh.Namespace
+		mwrs.Spec.PlacementRefs = []workv1alpha1.LocalPlacementReference{{Name: placement.Name}}
+		mwrs.Spec.ManifestWorkTemplate = *workTemplate
+		return controllerutil.SetControllerReference(mesh, mwrs, r.Scheme)
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet %s/%s: %w", mesh.Namespace, mwrc.Name, err)
+		return fmt.Errorf("failed to ensure ManifestWorkReplicaSet %s/%s: %w", mesh.Namespace, mwrs.Name, err)
 	}
-	return nil
-}
-
-// The ManagedServiceAccount controller generates an access secret with the name of the ManagedServiceAccount.
-// ensureRemoteSecretDistributed creates a ManifestWork to distribute the access secrets.
-func (r *Reconciler) ensureRemoteSecretDistributed(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
-	msaSecretName := fmt.Sprintf("%s-%s-%s", mesh.Namespace, "istio-reader", mesh.Name)
-	msaSecrets := make(map[string]*corev1.Secret) // secret name to secret
-
-	for _, cluster := range clusters {
-		msaSecret := &corev1.Secret{}
-		err := r.Get(ctx, key.Of(msaSecretName, cluster.Name), msaSecret)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				klog.V(4).Infof("ManagedServiceAccount secret %s/%s not found yet, waiting for its controller to create it", cluster.Name, msaSecretName)
-			}
-			msaSecret = nil
-		}
-
-		if msaSecret != nil {
-			remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
-			msaSecrets[remoteSecret.Name] = remoteSecret
-		}
-	}
-
-	for _, cluster := range clusters {
-		_, err := r.workApplier.Apply(ctx, r.buildRemoteSecretManifestWork(mesh, &cluster, msaSecrets))
-		if err != nil {
-			return fmt.Errorf("failed to apply remote secret ManifestWork for cluster %s: %w", cluster.Name, err)
-		}
-	}
-
 	return nil
 }
 
 // buildMeshRemoteSecret builds a remote API server access secret.
-// The secret includes required label and annotation for Istio remote endpoint discovery and data from the ManageServiceAccount secret.
+// The secret includes required label and annotation for Istio remote endpoint discovery and data from a ManageServiceAccount secret.
 func buildMeshRemoteSecret(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster, msaSecret *corev1.Secret) *corev1.Secret {
-	istioRemoteSecretName := fmt.Sprintf("%s-%s-%s-%s", mesh.Namespace, "istio-remote-secret", mesh.Name, cluster.Name)
+	istioRemoteSecretName := fmt.Sprintf("%s-%s-%s-%s", mesh.Namespace, mesh.Name, "istio-remote-secret", cluster.Name)
 	istioRemoteSecretLabels := meshOwnedLabels(mesh, cluster.Name)
 	istioRemoteSecretLabels["istio/multiCluster"] = "true"
 
@@ -217,33 +176,31 @@ func buildMeshRemoteSecret(mesh *meshv1alpha1.MultiClusterMesh, cluster *cluster
 	}
 }
 
-// buildRemoteSecretManifestWork builds a ManifestWork using remote access secrets from other clusters.
-func (r *Reconciler) buildRemoteSecretManifestWork(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster, remoteSecrets map[string]*corev1.Secret) *workv1.ManifestWork {
-	names := make([]string, 0, len(remoteSecrets))
-	for name := range remoteSecrets {
-		names = append(names, name)
+func (r *Reconciler) buildManifestWorkSpec(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) (*workv1.ManifestWorkSpec, error) {
+	msaName := fmt.Sprintf("%s-%s-%s", mesh.Namespace, "istio-reader", mesh.Name)
+	clusters, err := r.getClustersFromSet(ctx, mesh.Spec.ClusterSet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get clusters from set %s: %w", mesh.Spec.ClusterSet, err)
 	}
-	sort.Strings(names)
 
 	manifests := []workv1.Manifest{}
-	for _, name := range names {
+	for _, cluster := range clusters {
+		msaSecret := &corev1.Secret{}
+		if err := r.Get(ctx, key.Of(msaName, cluster.Name), msaSecret); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("MSA Secret %s/%s not found: %w", cluster.Name, msaName, err)
+			}
+			return nil, fmt.Errorf("failed to get MSA Secret: %w", err)
+		}
+
+		remoteSecret := buildMeshRemoteSecret(mesh, &cluster, msaSecret)
+
 		manifests = append(manifests, workv1.Manifest{
-			RawExtension: runtime.RawExtension{Object: remoteSecrets[name]},
+			RawExtension: runtime.RawExtension{Object: remoteSecret},
 		})
 	}
 
-	return &workv1.ManifestWork{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ManifestWorkNameRemoteSecrets,
-			Namespace: cluster.Name,
-			Labels:    meshOwnedLabels(mesh, cluster.Name),
-		},
-		Spec: workv1.ManifestWorkSpec{
-			Workload: workv1.ManifestsTemplate{
-				Manifests: manifests,
-			},
-		},
-	}
+	return &workv1.ManifestWorkSpec{Workload: workv1.ManifestsTemplate{Manifests: manifests}}, nil
 }
 
 // cleanupRemoteSecrets deletes Istio remote access secrets when the cluster(s) are removed from the given mesh's ClusterSet.

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -701,6 +702,19 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectManagedServiceAccount(testNs, meshName, cluster2)
 			})
 
+			When("the ManagedServiceAccount secret is created", func() {
+				BeforeEach(func() {
+					util.CreateMsaSecret(ctx, k8sClient, clusterName, meshName, testNs)
+					util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+					expectManagedServiceAccount(testNs, meshName, clusterName)
+				})
+
+				It("should create ManifestWork with remote access secrets", func() {
+					work := expectRemoteSecretsManifestWork(clusterName)
+					expectRemoteSecrets(work, testNs, meshName, []string{clusterName})
+				})
+			})
+
 			When("the ManagedServiceAccount exists", func() {
 				BeforeEach(func() {
 					util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
@@ -723,16 +737,40 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 						expectedManagedServiceAccountName(testNs, meshName), clusterName)
 				})
 
+				It("should cleanup ManifestWork and remote secrets when cluster is removed from ClusterSet", func() {
+					updateClusterSetLabel(clusterName, "")
+					util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
+						meshcontroller.ManifestWorkNameRemoteSecrets, clusterName)
+					util.ExpectResourceDeleted(ctx, k8sClient, &corev1.Secret{},
+						expectedRemoteSecretName(testNs, meshName, clusterName), "istio-system")
+				})
+
 				It("should cleanup ManagedServiceAccount when cluster is deleted", func() {
 					util.DeleteResource(ctx, k8sClient, &clusterv1.ManagedCluster{}, clusterName, "")
 					util.ExpectResourceDeleted(ctx, k8sClient, &msav1beta1.ManagedServiceAccount{},
 						expectedManagedServiceAccountName(testNs, meshName), clusterName)
 				})
 
+				It("should cleanup ManifestWork and remote secrets when cluster is deleted", func() {
+					util.DeleteResource(ctx, k8sClient, &clusterv1.ManagedCluster{}, clusterName, "")
+					util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
+						meshcontroller.ManifestWorkNameRemoteSecrets, clusterName)
+					util.ExpectResourceDeleted(ctx, k8sClient, &corev1.Secret{},
+						expectedRemoteSecretName(testNs, meshName, clusterName), "istio-system")
+				})
+
 				It("should cleanup ManagedServiceAccount when ClusterSet is deleted", func() {
 					util.DeleteResource(ctx, k8sClient, &clusterv1beta2.ManagedClusterSet{}, testClusterSet, "")
 					util.ExpectResourceDeleted(ctx, k8sClient, &msav1beta1.ManagedServiceAccount{},
 						expectedManagedServiceAccountName(testNs, meshName), clusterName)
+				})
+
+				It("should cleanup ManifestWork and remote secrets when ClusterSet is deleted", func() {
+					util.DeleteResource(ctx, k8sClient, &clusterv1beta2.ManagedClusterSet{}, testClusterSet, "")
+					util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
+						meshcontroller.ManifestWorkNameRemoteSecrets, clusterName)
+					util.ExpectResourceDeleted(ctx, k8sClient, &corev1.Secret{},
+						expectedRemoteSecretName(testNs, meshName, clusterName), "istio-system")
 				})
 			})
 		})
@@ -868,6 +906,10 @@ func expectCacertsManifestWork(clusterNamespace string) *workv1.ManifestWork {
 	return expectManifestWork(meshcontroller.ManifestWorkNameCacerts, clusterNamespace)
 }
 
+func expectRemoteSecretsManifestWork(clusterNamespace string) *workv1.ManifestWork {
+	return expectManifestWork(meshcontroller.ManifestWorkNameRemoteSecrets, clusterNamespace)
+}
+
 func expectNoCertificate(namespace, meshName string) {
 	Consistently(func() []certmanagerv1.Certificate {
 		certList := &certmanagerv1.CertificateList{}
@@ -919,6 +961,41 @@ func expectCacertsSecret(work *workv1.ManifestWork) {
 	Expect(secret.Data).To(HaveKey("tls.crt"))
 	Expect(secret.Data).To(HaveKey("tls.key"))
 	Expect(secret.Data).To(HaveKey("ca.crt"))
+}
+
+func expectedRemoteSecretName(meshNamespace, meshName, clusterName string) string {
+	return fmt.Sprintf("%s-%s-%s-%s", meshNamespace, "istio-remote-secret", meshName, clusterName)
+}
+
+func expectRemoteSecrets(work *workv1.ManifestWork, meshNamespace, meshName string, clusterNames []string) {
+	Expect(work.Spec.Workload.Manifests).To(HaveLen(len(clusterNames)))
+	sort.Strings(clusterNames)
+
+	for i, clusterName := range clusterNames {
+		secret := &corev1.Secret{}
+		Expect(unmarshalManifest(work.Spec.Workload.Manifests[i], secret)).To(Succeed())
+		Expect(secret.Name).To(Equal(expectedRemoteSecretName(meshNamespace, meshName, clusterName)))
+		Expect(secret.Namespace).To(Equal("istio-system"))
+		Expect(secret.ObjectMeta.Labels).To(HaveKeyWithValue("istio/multiCluster", "true"))
+		Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue("networking.istio.io/cluster", clusterName))
+		Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+		Expect(secret.Data).To(HaveKey("ca.crt"))
+		Expect(secret.Data).To(HaveKey("token"))
+	}
+}
+
+func getRemoteSecret(g Gomega, meshNamespace, meshName, clusterName string) *corev1.Secret {
+	secret := &corev1.Secret{}
+	g.Expect(k8sClient.Get(ctx, key.Of(expectedRemoteSecretName(meshNamespace, meshName, clusterName), "istio-system"), secret)).To(Succeed())
+	return secret
+}
+
+func expectRemoteSecret(meshNamespace, meshName, clusterName string) *corev1.Secret {
+	var secret *corev1.Secret
+	Eventually(func(g Gomega) {
+		secret = getRemoteSecret(g, meshNamespace, meshName, clusterName)
+	}).Should(Succeed())
+	return secret
 }
 
 func expectedManagedServiceAccountName(meshNamespace, meshName string) string {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -1074,6 +1075,41 @@ func expectInvalidCreateMeshFailure(name, namespace string, spec meshv1alpha1.Mu
 	Expect(err).To(HaveOccurred())
 	Expect(errors.IsInvalid(err)).To(BeTrue())
 	Expect(err.Error()).To(ContainSubstring(messageSubstring))
+}
+
+func expectedRemoteSecretName(meshNamespace, meshName, clusterName string) string {
+	return fmt.Sprintf("%s-%s-%s-%s", meshNamespace, "istio-remote-secret", meshName, clusterName)
+}
+
+func expectRemoteSecrets(work *workv1.ManifestWork, meshNamespace, meshName string, clusterNames []string) {
+	Expect(work.Spec.Workload.Manifests).To(HaveLen(len(clusterNames)))
+	sort.Strings(clusterNames)
+
+	for i, clusterName := range clusterNames {
+		secret := &corev1.Secret{}
+		Expect(unmarshalManifest(work.Spec.Workload.Manifests[i], secret)).To(Succeed())
+		Expect(secret.Name).To(Equal(expectedRemoteSecretName(meshNamespace, meshName, clusterName)))
+		Expect(secret.Namespace).To(Equal("istio-system"))
+		Expect(secret.ObjectMeta.Labels).To(HaveKeyWithValue("istio/multiCluster", "true"))
+		Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue("networking.istio.io/cluster", clusterName))
+		Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+		Expect(secret.Data).To(HaveKey("ca.crt"))
+		Expect(secret.Data).To(HaveKey("token"))
+	}
+}
+
+func getRemoteSecret(g Gomega, meshNamespace, meshName, clusterName string) *corev1.Secret {
+	secret := &corev1.Secret{}
+	g.Expect(k8sClient.Get(ctx, key.Of(expectedRemoteSecretName(meshNamespace, meshName, clusterName), "istio-system"), secret)).To(Succeed())
+	return secret
+}
+
+func expectRemoteSecret(meshNamespace, meshName, clusterName string) *corev1.Secret {
+	var secret *corev1.Secret
+	Eventually(func(g Gomega) {
+		secret = getRemoteSecret(g, meshNamespace, meshName, clusterName)
+	}).Should(Succeed())
+	return secret
 }
 
 func expectedManagedServiceAccountName(meshNamespace, meshName string) string {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -807,7 +807,12 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			It("should create ManifestWorkReplicaSet after ManagedServiceAccount Secret is created", func() {
 				util.CreateMsaSecret(ctx, k8sClient, clusterName, meshName, testNs)
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-				expectManifestWorkReplicaSet(testNs, meshName)
+				mwrset := expectManifestWorkReplicaSet(testNs, meshName)
+				Expect(mwrset.OwnerReferences).To(HaveLen(1))
+				Expect(mwrset.OwnerReferences[0].Name).To(Equal(meshName))
+				Expect(mwrset.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
+				Expect(mwrset.Labels[meshcontroller.MeshNameLabel]).To(Equal(meshName))
+				Expect(mwrset.Labels[meshcontroller.MeshNamespaceLabel]).To(Equal(testNs))
 			})
 
 			When("the ManagedServiceAccount exists", func() {
@@ -1170,14 +1175,10 @@ func expectPlacement(meshName, meshNamespace string) *clusterv1beta1.Placement {
 	return placement
 }
 
-func expectedManifestWorkReplicaSetName(meshNamespace, meshName string) string {
-	return fmt.Sprintf("%s-%s-%s", meshNamespace, meshcontroller.ManifestWorkReplicaSetName, meshName)
-}
-
 func expectManifestWorkReplicaSet(meshNamespace, meshName string) *workv1alpha1.ManifestWorkReplicaSet {
 	mwrset := &workv1alpha1.ManifestWorkReplicaSet{}
 	Eventually(func() error {
-		return k8sClient.Get(ctx, key.Of(expectedManifestWorkReplicaSetName(meshNamespace, meshName), meshNamespace), mwrset)
+		return k8sClient.Get(ctx, key.Of(meshName, meshNamespace), mwrset)
 	}).Should(Succeed())
 	return mwrset
 }

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -804,17 +804,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				Expect(placement.Spec.ClusterSets).To(ContainElement(testClusterSet))
 			})
 
-			It("should create ManifestWorkReplicaSet after ManagedServiceAccount Secret is created", func() {
-				util.CreateMsaSecret(ctx, k8sClient, clusterName, meshName, testNs)
-				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-				mwrset := expectManifestWorkReplicaSet(testNs, meshName)
-				Expect(mwrset.OwnerReferences).To(HaveLen(1))
-				Expect(mwrset.OwnerReferences[0].Name).To(Equal(meshName))
-				Expect(mwrset.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
-				Expect(mwrset.Labels[meshcontroller.MeshNameLabel]).To(Equal(meshName))
-				Expect(mwrset.Labels[meshcontroller.MeshNamespaceLabel]).To(Equal(testNs))
-			})
-
 			When("the ManagedServiceAccount exists", func() {
 				BeforeEach(func() {
 					util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
@@ -851,6 +840,46 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 		})
 
+		When("two clusters have ManagedServiceAccount secrets", func() {
+			var cluster2Name string
+
+			BeforeEach(func() {
+				cluster2Name = util.UniqueName("cluster")
+
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+				util.CreateManagedCluster(ctx, k8sClient, cluster2Name, testClusterSet)
+				util.CreateMsaSecret(ctx, k8sClient, clusterName, meshName, testNs)
+				util.CreateMsaSecret(ctx, k8sClient, cluster2Name, meshName, testNs)
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
+					ControlPlane: meshv1alpha1.ControlPlaneConfig{Namespace: "istio-system"},
+				})
+			})
+
+			It("should create ManifestWorkReplicaSet with two Manifests", func() {
+				placement := expectPlacement(meshName, testNs)
+				mwrset := expectManifestWorkReplicaSet(testNs, meshName)
+				Expect(mwrset.OwnerReferences).To(HaveLen(1))
+				Expect(mwrset.OwnerReferences[0].Name).To(Equal(meshName))
+				Expect(mwrset.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
+				Expect(mwrset.Labels[meshcontroller.MeshNameLabel]).To(Equal(meshName))
+				Expect(mwrset.Labels[meshcontroller.MeshNamespaceLabel]).To(Equal(testNs))
+				Expect(mwrset.Spec.PlacementRefs[0].Name).To(Equal(placement.Name))
+				Expect(mwrset.Spec.ManifestWorkTemplate.Workload.Manifests).To(HaveLen(2))
+			})
+
+			It("should cleanup remote access secrets when mesh is deleted", func() {
+				util.CreateNamespace(ctx, k8sClient, "istio-system")
+				util.CreateIstioRemoteSecret(ctx, k8sClient, clusterName, meshName, testNs, "istio-system")
+				util.CreateIstioRemoteSecret(ctx, k8sClient, cluster2Name, meshName, testNs, "istio-system")
+				util.DeleteResource(ctx, k8sClient, &meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
+
+				util.ExpectResourceDeleted(ctx, k8sClient, &corev1.Secret{},
+					expectedIstioRemoteSecretName(testNs, meshName, clusterName), "istio-system")
+				util.ExpectResourceDeleted(ctx, k8sClient, &corev1.Secret{},
+					expectedIstioRemoteSecretName(testNs, meshName, cluster2Name), "istio-system")
+			})
+		})
+
 		When("referencing a non-existing ClusterSet", func() {
 			var otherClusterSet string
 
@@ -869,12 +898,19 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectNoPlacement(testNs)
 			})
 
+			It("should not create a ManifestWorkReplicaSet", func() {
+				expectMeshNotReady(meshName, testNs)
+				expectNoManifestWorkReplicaSet(testNs)
+			})
+
 			It("should reconcile when the ClusterSet is created", func() {
 				expectMeshNotReady(meshName, testNs)
 				util.CreateManagedCluster(ctx, k8sClient, clusterName, otherClusterSet)
+				util.CreateMsaSecret(ctx, k8sClient, clusterName, meshName, testNs)
 				util.CreateManagedClusterSet(ctx, k8sClient, otherClusterSet)
 				expectManagedClusterSetBinding(testNs, otherClusterSet)
 				expectPlacement(meshName, testNs)
+				expectManifestWorkReplicaSet(testNs, meshName)
 			})
 		})
 
@@ -1112,6 +1148,10 @@ func expectedManagedServiceAccountName(meshNamespace, meshName string) string {
 	return fmt.Sprintf("%s-istio-reader-%s", meshNamespace, meshName)
 }
 
+func expectedIstioRemoteSecretName(meshNamespace, meshName, clusterName string) string {
+	return fmt.Sprintf("%s-%s-%s-%s", meshNamespace, meshName, "istio-remote-secret", clusterName)
+}
+
 func getManagedServiceAccount(g Gomega, meshNamespace, meshName, clusterName string) *msav1beta1.ManagedServiceAccount {
 	msa := &msav1beta1.ManagedServiceAccount{}
 	g.Expect(k8sClient.Get(ctx, key.Of(expectedManagedServiceAccountName(meshNamespace, meshName), clusterName), msa)).To(Succeed())
@@ -1148,6 +1188,14 @@ func expectNoPlacement(namespace string) {
 		placementList := &clusterv1beta1.PlacementList{}
 		Expect(k8sClient.List(ctx, placementList, client.InNamespace(namespace))).To(Succeed())
 		return placementList.Items
+	}).Should(BeEmpty())
+}
+
+func expectNoManifestWorkReplicaSet(namespace string) {
+	Consistently(func() []workv1alpha1.ManifestWorkReplicaSet {
+		mwrsetList := &workv1alpha1.ManifestWorkReplicaSetList{}
+		Expect(k8sClient.List(ctx, mwrsetList, client.InNamespace(namespace))).To(Succeed())
+		return mwrsetList.Items
 	}).Should(BeEmpty())
 }
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -26,6 +25,7 @@ import (
 	"github.com/stolostron/multicluster-mesh-addon/pkg/key"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
+	workv1alpha1 "open-cluster-management.io/api/work/v1alpha1"
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
 	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
@@ -786,17 +786,10 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				expectManagedServiceAccount(testNs, meshName, cluster2)
 			})
 
-			When("the ManagedServiceAccount secret is created", func() {
-				BeforeEach(func() {
-					util.CreateMsaSecret(ctx, k8sClient, clusterName, meshName, testNs)
-					util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
-					expectManagedServiceAccount(testNs, meshName, clusterName)
-				})
-
-				It("should create ManifestWork with remote access secrets", func() {
-					work := expectRemoteSecretsManifestWork(clusterName)
-					expectRemoteSecrets(work, testNs, meshName, []string{clusterName})
-				})
+			It("should create ManifestWorkReplicaSet after ManagedServiceAccount Secret is created", func() {
+				util.CreateMsaSecret(ctx, k8sClient, clusterName, meshName, testNs)
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+				expectManifestWorkReplicaSet(testNs, meshName)
 			})
 
 			When("the ManagedServiceAccount exists", func() {
@@ -821,40 +814,16 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 						expectedManagedServiceAccountName(testNs, meshName), clusterName)
 				})
 
-				It("should cleanup ManifestWork and remote secrets when cluster is removed from ClusterSet", func() {
-					updateClusterSetLabel(clusterName, "")
-					util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
-						meshcontroller.ManifestWorkNameRemoteSecrets, clusterName)
-					util.ExpectResourceDeleted(ctx, k8sClient, &corev1.Secret{},
-						expectedRemoteSecretName(testNs, meshName, clusterName), "istio-system")
-				})
-
 				It("should cleanup ManagedServiceAccount when cluster is deleted", func() {
 					util.DeleteResource(ctx, k8sClient, &clusterv1.ManagedCluster{}, clusterName, "")
 					util.ExpectResourceDeleted(ctx, k8sClient, &msav1beta1.ManagedServiceAccount{},
 						expectedManagedServiceAccountName(testNs, meshName), clusterName)
 				})
 
-				It("should cleanup ManifestWork and remote secrets when cluster is deleted", func() {
-					util.DeleteResource(ctx, k8sClient, &clusterv1.ManagedCluster{}, clusterName, "")
-					util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
-						meshcontroller.ManifestWorkNameRemoteSecrets, clusterName)
-					util.ExpectResourceDeleted(ctx, k8sClient, &corev1.Secret{},
-						expectedRemoteSecretName(testNs, meshName, clusterName), "istio-system")
-				})
-
 				It("should cleanup ManagedServiceAccount when ClusterSet is deleted", func() {
 					util.DeleteResource(ctx, k8sClient, &clusterv1beta2.ManagedClusterSet{}, testClusterSet, "")
 					util.ExpectResourceDeleted(ctx, k8sClient, &msav1beta1.ManagedServiceAccount{},
 						expectedManagedServiceAccountName(testNs, meshName), clusterName)
-				})
-
-				It("should cleanup ManifestWork and remote secrets when ClusterSet is deleted", func() {
-					util.DeleteResource(ctx, k8sClient, &clusterv1beta2.ManagedClusterSet{}, testClusterSet, "")
-					util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{},
-						meshcontroller.ManifestWorkNameRemoteSecrets, clusterName)
-					util.ExpectResourceDeleted(ctx, k8sClient, &corev1.Secret{},
-						expectedRemoteSecretName(testNs, meshName, clusterName), "istio-system")
 				})
 			})
 		})
@@ -1001,10 +970,6 @@ func expectCacertsManifestWork(clusterNamespace string) *workv1.ManifestWork {
 	return expectManifestWork(meshcontroller.ManifestWorkNameCacerts, clusterNamespace)
 }
 
-func expectRemoteSecretsManifestWork(clusterNamespace string) *workv1.ManifestWork {
-	return expectManifestWork(meshcontroller.ManifestWorkNameRemoteSecrets, clusterNamespace)
-}
-
 func expectNoCertificate(namespace, meshName string) {
 	Consistently(func() []certmanagerv1.Certificate {
 		certList := &certmanagerv1.CertificateList{}
@@ -1077,41 +1042,6 @@ func expectInvalidCreateMeshFailure(name, namespace string, spec meshv1alpha1.Mu
 	Expect(err.Error()).To(ContainSubstring(messageSubstring))
 }
 
-func expectedRemoteSecretName(meshNamespace, meshName, clusterName string) string {
-	return fmt.Sprintf("%s-%s-%s-%s", meshNamespace, "istio-remote-secret", meshName, clusterName)
-}
-
-func expectRemoteSecrets(work *workv1.ManifestWork, meshNamespace, meshName string, clusterNames []string) {
-	Expect(work.Spec.Workload.Manifests).To(HaveLen(len(clusterNames)))
-	sort.Strings(clusterNames)
-
-	for i, clusterName := range clusterNames {
-		secret := &corev1.Secret{}
-		Expect(unmarshalManifest(work.Spec.Workload.Manifests[i], secret)).To(Succeed())
-		Expect(secret.Name).To(Equal(expectedRemoteSecretName(meshNamespace, meshName, clusterName)))
-		Expect(secret.Namespace).To(Equal("istio-system"))
-		Expect(secret.ObjectMeta.Labels).To(HaveKeyWithValue("istio/multiCluster", "true"))
-		Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue("networking.istio.io/cluster", clusterName))
-		Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
-		Expect(secret.Data).To(HaveKey("ca.crt"))
-		Expect(secret.Data).To(HaveKey("token"))
-	}
-}
-
-func getRemoteSecret(g Gomega, meshNamespace, meshName, clusterName string) *corev1.Secret {
-	secret := &corev1.Secret{}
-	g.Expect(k8sClient.Get(ctx, key.Of(expectedRemoteSecretName(meshNamespace, meshName, clusterName), "istio-system"), secret)).To(Succeed())
-	return secret
-}
-
-func expectRemoteSecret(meshNamespace, meshName, clusterName string) *corev1.Secret {
-	var secret *corev1.Secret
-	Eventually(func(g Gomega) {
-		secret = getRemoteSecret(g, meshNamespace, meshName, clusterName)
-	}).Should(Succeed())
-	return secret
-}
-
 func expectedManagedServiceAccountName(meshNamespace, meshName string) string {
 	return fmt.Sprintf("%s-istio-reader-%s", meshNamespace, meshName)
 }
@@ -1137,6 +1067,18 @@ func expectNoManagedServiceAccount(meshNamespace, meshName, clusterName string) 
 		err := k8sClient.Get(ctx, key.Of(expectedManagedServiceAccountName(meshNamespace, meshName), clusterName), msa)
 		return errors.IsNotFound(err)
 	}).Should(BeTrue())
+}
+
+func expectedManifestWorkReplicaSetName(meshNamespace, meshName string) string {
+	return fmt.Sprintf("%s-%s-%s", meshNamespace, meshcontroller.ManifestWorkReplicaSetName, meshName)
+}
+
+func expectManifestWorkReplicaSet(meshNamespace, meshName string) *workv1alpha1.ManifestWorkReplicaSet {
+	mwrset := &workv1alpha1.ManifestWorkReplicaSet{}
+	Eventually(func() error {
+		return k8sClient.Get(ctx, key.Of(expectedManifestWorkReplicaSetName(meshNamespace, meshName), meshNamespace), mwrset)
+	}).Should(Succeed())
+	return mwrset
 }
 
 func unmarshalManifest(manifest workv1.Manifest, into interface{}) error {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -18,6 +18,7 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	workv1 "open-cluster-management.io/api/work/v1"
+	workv1alpha1 "open-cluster-management.io/api/work/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -68,6 +69,7 @@ var _ = BeforeSuite(func() {
 		clusterv1.Install,
 		clusterv1beta2.Install,
 		workv1.Install,
+		workv1alpha1.Install,
 		operatorsv1.AddToScheme,
 		operatorsv1alpha1.AddToScheme,
 		certmanagerv1.AddToScheme,

--- a/test/util/k8s.go
+++ b/test/util/k8s.go
@@ -62,6 +62,25 @@ func CreateCacertsSecret(ctx context.Context, k8sClient client.Client, namespace
 	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 }
 
+// CreateMsaSecret creates a ServiceAccount secret that simulates what ManagedServiceAccount controller would create.
+func CreateMsaSecret(ctx context.Context, k8sClient client.Client, clusterName, meshName, meshNamespace string) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-%s", meshNamespace, "istio-reader", meshName),
+			Namespace: clusterName,
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": fmt.Sprintf("%s-%s-%s", meshNamespace, "istio-reader", meshName),
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+		Data: map[string][]byte{
+			"ca.crt": []byte("test-ca-data"),
+			"token":  []byte("test-token-data"),
+		},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+}
+
 // DeleteResource deletes a Kubernetes resource and waits for it to be fully removed.
 func DeleteResource(ctx context.Context, k8sClient client.Client, obj client.Object, name, namespace string) {
 	Expect(k8sClient.Get(ctx, key.Of(name, namespace), obj)).To(Succeed())

--- a/test/util/k8s.go
+++ b/test/util/k8s.go
@@ -65,8 +65,16 @@ func CreateCacertsSecret(ctx context.Context, k8sClient client.Client, namespace
 	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 }
 
-// CreateMsaSecret creates a ServiceAccount secret that simulates what ManagedServiceAccount controller would create.
+// CreateMsaSecret creates a ServiceAccount and a secret that simulates what ManagedServiceAccount controller would create.
 func CreateMsaSecret(ctx context.Context, k8sClient client.Client, clusterName, meshName, meshNamespace string) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-%s", meshNamespace, "istio-reader", meshName),
+			Namespace: clusterName,
+		},
+	}
+	Expect(k8sClient.Create(ctx, sa)).To(Succeed())
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s-%s", meshNamespace, "istio-reader", meshName),

--- a/test/util/k8s.go
+++ b/test/util/k8s.go
@@ -81,6 +81,32 @@ func CreateMsaSecret(ctx context.Context, k8sClient client.Client, clusterName, 
 	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 }
 
+// CreateIstioRemoteSecret creates a secret that simulates what ManifestWorkReplicaSet controller would distribute.
+func CreateIstioRemoteSecret(ctx context.Context, k8sClient client.Client, clusterName, meshName, meshNamespace, cpNamespace string) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-%s-%s", meshNamespace, meshName, "istio-remote-secret", clusterName),
+			Namespace: cpNamespace,
+			Labels: map[string]string{
+				"istio/multiCluster":              "true",
+				meshcontroller.ManagedByLabel:     meshcontroller.ManagedByValue,
+				meshcontroller.MeshNameLabel:      meshName,
+				meshcontroller.MeshNamespaceLabel: meshNamespace,
+				meshcontroller.ClusterNameLabel:   clusterName,
+			},
+			Annotations: map[string]string{
+				"networking.istio.io/cluster": clusterName,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"ca.crt": []byte("test-ca-data"),
+			"token":  []byte("test-token-data"),
+		},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+}
+
 // DeleteResource deletes a Kubernetes resource and waits for it to be fully removed.
 func DeleteResource(ctx context.Context, k8sClient client.Client, obj client.Object, name, namespace string) {
 	Expect(k8sClient.Get(ctx, key.Of(name, namespace), obj)).To(Succeed())


### PR DESCRIPTION
This PR builds remote cluster API server access secrets from each cluster's `ManagedServiceAccount` secret. And it creates a `ManifestWorkReplicaSet` for distributing those secrets.

The `ManifestWorkReplicaSet` feature is **Not** enabled by default. See ref:
https://open-cluster-management.io/docs/concepts/work-distribution/manifestworkreplicaset/

Enabling this feature is a prerequisite manual configuration step at the moment.

After setting up N-to-N remote access secrets distribution, users can create Istio control planes and Istio will pick up those secrets in the control plane namespace. All the RBAC requirements are handled by `istio-reader` ClusterRole and service account. Those are created by default when users create an Istio control plane.

This PR resolves #214 

WIP: updating e2e tests. 
