### PR TITLE
Add UI assets to helm chart

### DIFF
--- a/chart/templates/ui/configmap-nginx.yaml
+++ b/chart/templates/ui/configmap-nginx.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ui.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ossm-acm-plugin-nginx
+  namespace: {{ .Release.Namespace }}
+data:
+  nginx.conf: |
+    worker_processes auto;
+    error_log /dev/stderr;
+    pid /tmp/nginx.pid;
+
+    events {
+      worker_connections 1024;
+    }
+
+    http {
+      include /etc/nginx/mime.types;
+      default_type application/octet-stream;
+      access_log /dev/stdout;
+
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path /tmp/proxy;
+      fastcgi_temp_path /tmp/fastcgi;
+      uwsgi_temp_path /tmp/uwsgi;
+      scgi_temp_path /tmp/scgi;
+
+      server {
+        listen 9443 ssl;
+        root /usr/share/nginx/html;
+
+        ssl_certificate /var/serving-cert/tls.crt;
+        ssl_certificate_key /var/serving-cert/tls.key;
+
+        location / {
+          try_files $uri =404;
+        }
+      }
+    }
+{{- end }}

--- a/chart/templates/ui/consoleplugin.yaml
+++ b/chart/templates/ui/consoleplugin.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.ui.enabled }}
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: ossm-acm
+spec:
+  displayName: OpenShift Service Mesh — ACM Integration
+  backend:
+    type: Service
+    service:
+      name: ossm-acm-plugin
+      namespace: {{ .Release.Namespace }}
+      port: 9443
+      basePath: /
+{{- end }}

--- a/chart/templates/ui/deployment.yaml
+++ b/chart/templates/ui/deployment.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.ui.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ossm-acm-plugin
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ossm-acm-plugin
+  template:
+    metadata:
+      labels:
+        app: ossm-acm-plugin
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: nginx
+          image: {{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          ports:
+            - containerPort: 9443
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /plugin-manifest.json
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /plugin-manifest.json
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          volumeMounts:
+            - name: serving-cert
+              mountPath: /var/serving-cert
+              readOnly: true
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: nginx-log
+              mountPath: /var/log/nginx
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: serving-cert
+          secret:
+            secretName: ossm-acm-plugin-tls
+        - name: nginx-config
+          configMap:
+            name: ossm-acm-plugin-nginx
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-log
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ossm-acm-plugin
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ossm-acm-plugin-tls
+spec:
+  selector:
+    app: ossm-acm-plugin
+  ports:
+    - port: 9443
+      targetPort: 9443
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,3 +9,10 @@ image:
   pullPolicy: Always
 
 platform: openshift
+
+ui:
+  enabled: true
+  image:
+    repository: quay.io/sail-dev/ossm-acm-console-plugin
+    tag: latest
+    pullPolicy: Always


### PR DESCRIPTION
Adds the UI assets to the helm chart so that the UI can be optionally deployed with the addon controller.

AI generated instructions for testing:

  **Prerequisites:** CRC running with ACM installed, `oc` logged in as `kubeadmin`, `podman` available.

  **1) Enable the internal image registry route** (skip if already enabled):

      oc get route -n openshift-image-registry
      oc patch configs.imageregistry.operator.openshift.io cluster --type=merge --patch '{"spec":{"defaultRoute":true}}'

  **2) Build and push images:**

      REGISTRY_EXT="default-route-openshift-image-registry.apps-crc.testing"
      REGISTRY_INT="image-registry.openshift-image-registry.svc:5000"
      NS="ossm-acm-plugin"

      podman login "$REGISTRY_EXT" -u noop -p "$(oc whoami -t)" --tls-verify=false
      oc create namespace "$NS"

      # Controller
      podman build -t "$REGISTRY_EXT/$NS/multicluster-mesh-addon:latest" -f Dockerfile .
      podman push "$REGISTRY_EXT/$NS/multicluster-mesh-addon:latest" --tls-verify=false

      # Frontend
      podman build -t "$REGISTRY_EXT/$NS/ossm-acm-console-plugin:latest" -f frontend/Dockerfile frontend/
      podman push "$REGISTRY_EXT/$NS/ossm-acm-console-plugin:latest" --tls-verify=false

  **3) Install the Helm chart:**

      helm install multicluster-mesh-addon chart/ \
        --namespace "$NS" \
        --set image.repository="$REGISTRY_INT/$NS/multicluster-mesh-addon" \
        --set image.tag=latest \
        --set ui.image.repository="$REGISTRY_INT/$NS/ossm-acm-console-plugin" \
        --set ui.image.tag=latest

      oc get pods -n "$NS" -w

  **4) Enable the console plugin.** Append `ossm-acm` to the existing plugins list — don't replace it, or ACM/MCE will break:

      oc get console.operator.openshift.io cluster -o jsonpath='{.spec.plugins}'

      oc patch console.operator.openshift.io cluster --type=merge \
        --patch '{"spec":{"plugins":["ossm-acm","acm","mce","monitoring-plugin","networking-console-plugin"]}}'

      oc rollout restart deployment/console -n openshift-console
      oc rollout status deployment/console -n openshift-console --timeout=120s

  **5) Verify in the UI.** Navigate to https://console-openshift-console.apps-crc.testing/fleet-mesh/overview — you should see the "Fleet Service Mesh" perspective with Meshes, Control Planes, and Recent Issues cards.

  **Teardown:**

      helm uninstall multicluster-mesh-addon -n "$NS"
      oc delete namespace "$NS"
      oc patch console.operator.openshift.io cluster --type=merge \
        --patch '{"spec":{"plugins":["acm","mce","monitoring-plugin","networking-console-plugin"]}}'
      oc rollout restart deployment/console -n openshift-console