### PR TITLE
Fix go list when local vendor dir is present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ test: ## Run unit tests
 update-test-crds: deps ## Update test CRDs from OCM API, managed-serviceaccount and cert-manager dependencies
 	@echo "Updating test CRDs from open-cluster-management.io/api..."
 	@set -e; \
-	OCM_API_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/api); \
+	OCM_API_PATH=$$(go list -m -mod=mod -f '{{.Dir}}' open-cluster-management.io/api); \
 	mkdir -p $(TEST_CRD_DIR)/ocm; \
 	echo "Copying CRDs from $$OCM_API_PATH..."; \
 	cp -fv $$OCM_API_PATH/cluster/v1/*.crd.yaml $(TEST_CRD_DIR)/ocm/ 2>/dev/null || true; \
@@ -141,13 +141,13 @@ update-test-crds: deps ## Update test CRDs from OCM API, managed-serviceaccount 
 	echo "Test CRDs updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from open-cluster-management.io/managed-serviceaccount..."
 	@set -e; \
-	OCM_MSA_PATH=$$(go list -m -f '{{.Dir}}' open-cluster-management.io/managed-serviceaccount); \
+	OCM_MSA_PATH=$$(go list -m -mod=mod -f '{{.Dir}}' open-cluster-management.io/managed-serviceaccount); \
 	echo "Copying CRDs from $$OCM_MSA_PATH..."; \
 	cp -fv $$OCM_MSA_PATH/charts/managed-serviceaccount/crds/*.yaml $(TEST_CRD_DIR)/ocm/; \
 	echo "Test CRDs for MSA updated successfully in $(TEST_CRD_DIR)/ocm/"
 	@echo "Updating test CRDs from cert-manager..."
 	@set -e; \
-	CERTMANAGER_PATH=$$(go list -m -f '{{.Dir}}' github.com/cert-manager/cert-manager); \
+	CERTMANAGER_PATH=$$(go list -m -mod=mod -f '{{.Dir}}' github.com/cert-manager/cert-manager); \
 	mkdir -p $(TEST_CRD_DIR)/cert-manager; \
 	echo "Copying CRDs from $$CERTMANAGER_PATH..."; \
 	cp -fv $$CERTMANAGER_PATH/deploy/crds/cert-manager.io_certificates.yaml $(TEST_CRD_DIR)/cert-manager/ 2>/dev/null || true; \


### PR DESCRIPTION
When a `vendor/` directory exists locally, Go defaults to
`-mod=vendor` and `go list -m -f '{{.Dir}}'` returns empty,
breaking update-test-crds.

This PR adds `-mod=mod` to the `go list` calls to force
module cache lookup. PR #159 added deps as a
prerequisite but didn't account for this.