### PR TITLE
Create control plane namespace on spoke clusters

### DIFF
--- a/chart/crds/mesh.open-cluster-management.io_multiclustermeshes.yaml
+++ b/chart/crds/mesh.open-cluster-management.io_multiclustermeshes.yaml
@@ -54,9 +54,14 @@ spec:
                 properties:
                   namespace:
                     default: istio-system
-                    description: Namespace is the namespace where Istio will be installed
-                      on each cluster
+                    description: |-
+                      Namespace is the namespace where Istio will be installed on each cluster.
+                      This namespace is created and deleted by the addon as part of the mesh lifecycle.
+                    maxLength: 63
                     type: string
+                    x-kubernetes-validations:
+                    - message: spec.controlPlane.namespace is immutable
+                      rule: self == oldSelf
                 type: object
               operator:
                 description: Operator defines the service mesh operator installation

--- a/docs/design.md
+++ b/docs/design.md
@@ -119,6 +119,17 @@ flowchart TD
 
 The MVP supports the [Multi-Primary Multi-Network] mesh topology. This aligns with OCM's model where each cluster runs its own control plane. Support for other topologies (e.g., Primary-Remote, External Control Plane) can be added with backwards-compatible API changes.
 
+### Network Partitioning
+
+In a multi-network mesh, each cluster's control plane namespace must be labeled with `topology.istio.io/network` so that istiod knows which network the cluster belongs to.
+The controller reads this label from the `ManagedCluster` object on the hub.
+If the label is not set, the controller falls back to using the cluster name as the network identifier.
+
+```bash
+kubectl label managedcluster cluster1 topology.istio.io/network=network-a
+kubectl label managedcluster cluster2 topology.istio.io/network=network-b
+```
+
 ## Custom Resource
 
 `MultiClusterMesh` is a namespaced resource. The namespace provides tenant isolation on the hub.

--- a/docs/design.md
+++ b/docs/design.md
@@ -214,6 +214,15 @@ In both cases, the add-on will never forcibly uninstall, downgrade, or overwrite
 
 The add-on does not validate OpenShift version compatibility with the requested operator channel. It delegates this to OLM - if a cluster's OCP version is incompatible with the requested operator version, the OLM installation will stall, preventing the cluster from joining the mesh with an unsupported control plane.
 
+## Control Plane Namespace
+
+The controller creates the control plane namespace (default: `istio-system`) on each managed cluster via ManifestWork.
+The namespace is labeled with the cluster's network identity for istiod (see [Network Partitioning](#network-partitioning)).
+
+The namespace ManifestWork is owned by the mesh, not shared across meshes.
+Deleting the mesh deletes the namespace and everything in it on the spoke, including any Istio control plane resources the user deployed there.
+Users should be aware that removing a mesh will clean up the entire control plane namespace on each cluster.
+
 ## Trust Distribution
 
 Trust distribution requires [cert-manager] to be installed on the hub cluster. The user is responsible for setting up cert-manager and creating the `Issuer` or `ClusterIssuer` resource that acts as the Root CA.
@@ -251,6 +260,7 @@ For multi-primary mesh topologies, each control plane needs API access to its pe
 The user is responsible for:
 
 - Creating and managing Istio custom resources on each spoke cluster (directly or via GitOps)
+- Setting `values.global.network` in the Istio CR to match the cluster's network identity (cluster name by default, or the value of `topology.istio.io/network` on the ManagedCluster if set). See [Network Partitioning](#network-partitioning).
 - Enabling Istio CNI on OpenShift clusters
 - Configuring `discoverySelectors` in multi-tenant environments to prevent cross-mesh service visibility
 - Labeling application namespaces to match discovery selector configuration

--- a/pkg/apis/mesh/v1alpha1/types.go
+++ b/pkg/apis/mesh/v1alpha1/types.go
@@ -93,9 +93,12 @@ type MultiClusterMeshSpec struct {
 
 // ControlPlaneConfig defines where the mesh control plane will be installed
 type ControlPlaneConfig struct {
-	// Namespace is the namespace where Istio will be installed on each cluster
+	// Namespace is the namespace where Istio will be installed on each cluster.
+	// This namespace is created and deleted by the addon as part of the mesh lifecycle.
 	// +optional
 	// +kubebuilder:default="istio-system"
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.controlPlane.namespace is immutable"
 	Namespace string `json:"namespace,omitempty"`
 }
 

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -42,8 +42,9 @@ import (
 )
 
 const (
-	OperatorManifestWorkName = "multicluster-mesh-operator"
-	ManifestWorkNameCacerts  = "multicluster-mesh-cacerts"
+	OperatorManifestWorkName   = "multicluster-mesh-operator"
+	ManifestWorkNameCacerts    = "multicluster-mesh-cacerts"
+	ManifestWorkNameCPNSPrefix = "multicluster-mesh-cp-ns-"
 
 	FeedbackInstalledCSV = "installedCSV"
 
@@ -57,7 +58,8 @@ const (
 	MeshNameLabel      = "mesh.open-cluster-management.io/mesh-name"
 	MeshNamespaceLabel = "mesh.open-cluster-management.io/mesh-namespace"
 
-	ClusterSetLabel = "cluster.open-cluster-management.io/clusterset"
+	ClusterSetLabel   = "cluster.open-cluster-management.io/clusterset"
+	IstioNetworkLabel = "topology.istio.io/network"
 
 	Day = 24 * time.Hour
 )
@@ -211,6 +213,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 // validate checks for conflicts that prevent reconciliation.
 // Sets a condition on the mesh and returns true if a conflict is found.
 func (r *Reconciler) validate(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) (conflict bool, err error) {
+	// CEL cross-field rule on the spec struct exceeds the estimated cost budget,
+	// so this is validated here instead of via kubebuilder markers.
+	if mesh.GetControlPlaneNamespace() == mesh.Spec.Operator.Namespace {
+		mesh.SetReadyCondition(metav1.ConditionFalse, meshv1alpha1.ReasonNamespaceConflict,
+			"controlPlane.namespace %q must not equal operator.namespace", mesh.GetControlPlaneNamespace())
+		return true, nil
+	}
+
 	if err = r.forEachMeshInClusterSet(ctx, mesh.Spec.ClusterSet, func(other *meshv1alpha1.MultiClusterMesh) {
 		if other.UID == mesh.UID || conflict {
 			return
@@ -249,6 +259,12 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 	for _, cluster := range clusters {
 		klog.V(4).Infof("Reconciling cluster %s", cluster.Name)
 
+		cpNsWork, err := r.workApplier.Apply(ctx, r.buildControlPlaneNamespaceManifestWork(mesh, &cluster))
+		if err != nil {
+			return fmt.Errorf("failed to apply control plane namespace ManifestWork on cluster %s: %w", cluster.Name, err)
+		}
+		klog.V(4).Infof("Applied control plane namespace ManifestWork %s/%s", cpNsWork.Namespace, cpNsWork.Name)
+
 		work, err := r.workApplier.Apply(ctx, r.buildOperatorManifestWork(mesh, &cluster))
 		if err != nil {
 			return fmt.Errorf("failed to apply operator ManifestWork on cluster %s: %w", cluster.Name, err)
@@ -272,6 +288,10 @@ func (r *Reconciler) doReconcile(ctx context.Context, mesh *meshv1alpha1.MultiCl
 	forceCleanupAll := mesh.Spec.Security.Trust.CertManager.IssuerRef.Name == ""
 	if err := r.cleanupCertificates(ctx, mesh, clusters, forceCleanupAll); err != nil {
 		return fmt.Errorf("failed to cleanup Certificates: %w", err)
+	}
+
+	if err := r.cleanupMeshOwnedManifestWorks(ctx, mesh, clusters); err != nil {
+		return fmt.Errorf("failed to cleanup mesh-owned ManifestWorks: %w", err)
 	}
 
 	if err := r.cleanupManifestWorks(ctx, mesh.Spec.ClusterSet); err != nil {
@@ -353,6 +373,11 @@ func (r *Reconciler) handleDeletion(ctx context.Context, mesh *meshv1alpha1.Mult
 	}
 
 	klog.Infof("Handling deletion for MultiClusterMesh %s/%s", mesh.Namespace, mesh.Name)
+
+	if err := r.cleanupMeshOwnedManifestWorks(ctx, mesh, nil); err != nil {
+		return fmt.Errorf("failed to cleanup mesh-owned ManifestWorks: %w", err)
+	}
+
 	if err := r.cleanupManifestWorks(ctx, mesh.Spec.ClusterSet); err != nil {
 		return fmt.Errorf("failed to cleanup ManifestWorks: %w", err)
 	}
@@ -423,6 +448,30 @@ func (r *Reconciler) cleanupCertificates(ctx context.Context, mesh *meshv1alpha1
 		klog.Infof("Deleting Certificate %s/%s (cluster %s no longer in ClusterSet %s)", cert.Namespace, cert.Name, clusterName, mesh.Spec.ClusterSet)
 		if err := client.IgnoreNotFound(r.Delete(ctx, &cert)); err != nil {
 			return fmt.Errorf("failed to delete Certificate %s/%s: %w", cert.Namespace, cert.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) cleanupMeshOwnedManifestWorks(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh, clusters []clusterv1.ManagedCluster) error {
+	clusterNames := clusterNameSet(clusters)
+
+	workList := &workv1.ManifestWorkList{}
+	if err := r.List(ctx, workList,
+		client.MatchingLabels{MeshNameLabel: mesh.Name, MeshNamespaceLabel: mesh.Namespace},
+	); err != nil {
+		return fmt.Errorf("failed to list mesh-owned ManifestWorks: %w", err)
+	}
+
+	for _, work := range workList.Items {
+		if clusterNames[work.Namespace] {
+			continue
+		}
+
+		klog.Infof("Deleting mesh-owned ManifestWork %s/%s", work.Namespace, work.Name)
+		if err := r.workApplier.Delete(ctx, work.Namespace, work.Name); err != nil {
+			return fmt.Errorf("failed to delete ManifestWork %s/%s: %w", work.Namespace, work.Name, err)
 		}
 	}
 
@@ -734,6 +783,23 @@ func (r *Reconciler) ensureCacertsManifestWork(ctx context.Context, mesh *meshv1
 	return nil
 }
 
+func (r *Reconciler) buildControlPlaneNamespaceManifestWork(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) *workv1.ManifestWork {
+	cpNamespace := mesh.GetControlPlaneNamespace()
+
+	return buildMeshOwnedManifestWork(mesh, cluster.Name, ManifestWorkNameCPNSPrefix+cpNamespace, &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cpNamespace,
+			Labels: map[string]string{
+				IstioNetworkLabel: cluster.Name,
+			},
+		},
+	})
+}
+
 // buildCacertsManifestWork builds a ManifestWork for distributing the cacerts secret
 func (r *Reconciler) buildCacertsManifestWork(mesh *meshv1alpha1.MultiClusterMesh, clusterName string, secret *corev1.Secret) *workv1.ManifestWork {
 	cacertsSecret := &corev1.Secret{
@@ -749,16 +815,20 @@ func (r *Reconciler) buildCacertsManifestWork(mesh *meshv1alpha1.MultiClusterMes
 		Data: secret.Data,
 	}
 
+	return buildMeshOwnedManifestWork(mesh, clusterName, ManifestWorkNameCacerts, cacertsSecret)
+}
+
+func buildMeshOwnedManifestWork(mesh *meshv1alpha1.MultiClusterMesh, clusterName, name string, obj runtime.Object) *workv1.ManifestWork {
 	return &workv1.ManifestWork{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ManifestWorkNameCacerts,
+			Name:      name,
 			Namespace: clusterName,
 			Labels:    meshOwnedLabels(mesh, clusterName),
 		},
 		Spec: workv1.ManifestWorkSpec{
 			Workload: workv1.ManifestsTemplate{
 				Manifests: []workv1.Manifest{{
-					RawExtension: runtime.RawExtension{Object: cacertsSecret},
+					RawExtension: runtime.RawExtension{Object: obj},
 				}},
 			},
 		},

--- a/pkg/hub/mesh/controller.go
+++ b/pkg/hub/mesh/controller.go
@@ -786,6 +786,11 @@ func (r *Reconciler) ensureCacertsManifestWork(ctx context.Context, mesh *meshv1
 func (r *Reconciler) buildControlPlaneNamespaceManifestWork(mesh *meshv1alpha1.MultiClusterMesh, cluster *clusterv1.ManagedCluster) *workv1.ManifestWork {
 	cpNamespace := mesh.GetControlPlaneNamespace()
 
+	network := cluster.Name
+	if v, ok := cluster.Labels[IstioNetworkLabel]; ok && v != "" {
+		network = v
+	}
+
 	return buildMeshOwnedManifestWork(mesh, cluster.Name, ManifestWorkNameCPNSPrefix+cpNamespace, &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -794,7 +799,7 @@ func (r *Reconciler) buildControlPlaneNamespaceManifestWork(mesh *meshv1alpha1.M
 		ObjectMeta: metav1.ObjectMeta{
 			Name: cpNamespace,
 			Labels: map[string]string{
-				IstioNetworkLabel: cluster.Name,
+				IstioNetworkLabel: network,
 			},
 		},
 	})

--- a/test/e2e/mesh_lifecycle_test.go
+++ b/test/e2e/mesh_lifecycle_test.go
@@ -129,6 +129,13 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 			Expect(meta.IsStatusConditionTrue(cs.Conditions, meshv1alpha1.ConditionOperatorInstalled)).To(BeTrue(),
 				"expected OperatorInstalled=True for %s", cluster)
 
+			Step("Verifying control plane namespace exists on %s", cluster)
+			ns := &corev1.Namespace{}
+			Eventually(func(g Gomega) {
+				g.Expect(spokeClient.Get(ctx, key.Of("istio-system"), ns)).To(Succeed())
+				g.Expect(ns.Labels[meshcontroller.IstioNetworkLabel]).To(Equal(cluster))
+			}).Should(Succeed())
+
 			Step("Verifying operator namespace exists on %s", cluster)
 			err := spokeClient.Get(ctx, key.Of(testOperatorNamespace), &corev1.Namespace{})
 			Expect(err).NotTo(HaveOccurred())
@@ -170,6 +177,11 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 		Step("Verifying ManifestWorks are removed from hub")
 		for _, cluster := range clusters {
 			util.ExpectResourceDeleted(ctx, hubClient, &workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, cluster)
+		}
+
+		Step("Verifying control plane namespaces are removed from spoke clusters")
+		for _, spokeClient := range spokeClients {
+			util.ExpectResourceDeleted(ctx, spokeClient, &corev1.Namespace{}, "istio-system", "", 2*time.Minute)
 		}
 
 		Step("Verifying Subscriptions are removed from spoke clusters")

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -102,8 +102,8 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should create ManifestWorks for each cluster", func() {
-				cpNsWork1 := expectControlPlaneNamespaceManifestWork(clusterName, "istio-system")
-				cpNsWork2 := expectControlPlaneNamespaceManifestWork(cluster2Name, "istio-system")
+				cpNsWork1, _ := expectControlPlaneNamespaceManifestWork(clusterName, "istio-system")
+				cpNsWork2, _ := expectControlPlaneNamespaceManifestWork(cluster2Name, "istio-system")
 
 				expectMeshOwnedLabels(cpNsWork1.Labels, meshName, testNs, clusterName)
 				expectMeshOwnedLabels(cpNsWork2.Labels, meshName, testNs, cluster2Name)
@@ -176,16 +176,6 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			expectSubscription(work, 2, customConfig)
 		})
 
-		It("should use custom control plane namespace when specified", func() {
-			ns := "istio-system-2"
-			util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
-			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
-				ControlPlane: meshv1alpha1.ControlPlaneConfig{Namespace: ns},
-			})
-
-			expectControlPlaneNamespaceManifestWork(clusterName, ns)
-		})
-
 		When("referencing a non-existent ClusterSet", func() {
 			var otherClusterSet string
 
@@ -236,6 +226,47 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 		It("should add finalizer on MultiClusterMesh creation", func() {
 			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
 			expectFinalizer(meshName, testNs)
+		})
+
+		Context("Control plane namespace", func() {
+			BeforeEach(func() {
+				util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			})
+
+			It("should use custom control plane namespace when specified", func() {
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
+					ControlPlane: meshv1alpha1.ControlPlaneConfig{Namespace: "istio-system-2"},
+				})
+
+				expectControlPlaneNamespaceManifestWork(clusterName, "istio-system-2")
+			})
+
+			It("should default network label to cluster name", func() {
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+
+				_, ns := expectControlPlaneNamespaceManifestWork(clusterName, "istio-system")
+				Expect(ns.Labels[meshcontroller.IstioNetworkLabel]).To(Equal(clusterName))
+			})
+
+			It("should use network label from ManagedCluster when set", func() {
+				updateClusterLabel(clusterName, meshcontroller.IstioNetworkLabel, "network-east")
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+
+				_, ns := expectControlPlaneNamespaceManifestWork(clusterName, "istio-system")
+				Expect(ns.Labels[meshcontroller.IstioNetworkLabel]).To(Equal("network-east"))
+			})
+
+			It("should sync network label when ManagedCluster label is updated after mesh creation", func() {
+				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
+				expectControlPlaneNamespaceManifestWork(clusterName, "istio-system")
+
+				updateClusterLabel(clusterName, meshcontroller.IstioNetworkLabel, "network-west")
+
+				Eventually(func() string {
+					_, ns := expectControlPlaneNamespaceManifestWork(clusterName, "istio-system")
+					return ns.Labels[meshcontroller.IstioNetworkLabel]
+				}).Should(Equal("network-west"))
+			})
 		})
 
 		When("referencing a set with a cluster", func() {
@@ -853,11 +884,15 @@ func expectFinalizer(name, namespace string) {
 	}).Should(ContainElement(meshcontroller.FinalizerName))
 }
 
-func updateClusterSetLabel(clusterName, newClusterSet string) {
+func updateClusterLabel(clusterName, labelKey, labelValue string) {
 	cluster := &clusterv1.ManagedCluster{}
 	Expect(k8sClient.Get(ctx, key.Of(clusterName), cluster)).To(Succeed())
-	cluster.Labels[meshcontroller.ClusterSetLabel] = newClusterSet
+	cluster.Labels[labelKey] = labelValue
 	Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+}
+
+func updateClusterSetLabel(clusterName, newClusterSet string) {
+	updateClusterLabel(clusterName, meshcontroller.ClusterSetLabel, newClusterSet)
 }
 
 // expectNoManifestWorks makes sure that no ManifestWorks are created, checking consistently
@@ -981,16 +1016,12 @@ func expectCacertsSecret(work *workv1.ManifestWork, expectedNamespace string) {
 	Expect(secret.Data).To(HaveKey("ca.crt"))
 }
 
-func expectControlPlaneNamespaceManifestWork(clusterName, cpNamespace string) *workv1.ManifestWork {
+func expectControlPlaneNamespaceManifestWork(clusterName, cpNamespace string) (*workv1.ManifestWork, *corev1.Namespace) {
 	work := expectManifestWork(meshcontroller.ManifestWorkNameCPNSPrefix+cpNamespace, clusterName)
-
 	Expect(work.Spec.Workload.Manifests).To(HaveLen(1))
-	ns := &corev1.Namespace{}
-	Expect(unmarshalManifest(work.Spec.Workload.Manifests[0], ns)).To(Succeed())
-	Expect(ns.Name).To(Equal(cpNamespace))
-	Expect(ns.Labels[meshcontroller.IstioNetworkLabel]).To(Equal(clusterName))
+	ns := expectNamespace(work, 0, cpNamespace)
 
-	return work
+	return work, ns
 }
 
 func expectInvalidCreateMeshFailure(name, namespace string, spec meshv1alpha1.MultiClusterMeshSpec, messageSubstring string) {
@@ -1035,10 +1066,11 @@ func unmarshalManifest(manifest workv1.Manifest, into interface{}) error {
 	return json.Unmarshal(manifest.Raw, into)
 }
 
-func expectNamespace(work *workv1.ManifestWork, index int, expectedName string) {
+func expectNamespace(work *workv1.ManifestWork, index int, expectedName string) *corev1.Namespace {
 	ns := &corev1.Namespace{}
 	Expect(unmarshalManifest(work.Spec.Workload.Manifests[index], ns)).To(Succeed())
 	Expect(ns.Name).To(Equal(expectedName))
+	return ns
 }
 
 func expectOperatorGroup(work *workv1.ManifestWork, index int, expectedName, expectedNamespace string) {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -102,6 +102,12 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 
 			It("should create ManifestWorks for each cluster", func() {
+				cpNsWork1 := expectControlPlaneNamespaceManifestWork(clusterName, "istio-system")
+				cpNsWork2 := expectControlPlaneNamespaceManifestWork(cluster2Name, "istio-system")
+
+				expectMeshOwnedLabels(cpNsWork1.Labels, meshName, testNs, clusterName)
+				expectMeshOwnedLabels(cpNsWork2.Labels, meshName, testNs, cluster2Name)
+
 				work1 := expectOperatorManifestWork(clusterName)
 				work2 := expectOperatorManifestWork(cluster2Name)
 
@@ -170,6 +176,16 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			expectSubscription(work, 2, customConfig)
 		})
 
+		It("should use custom control plane namespace when specified", func() {
+			ns := "istio-system-2"
+			util.CreateManagedCluster(ctx, k8sClient, clusterName, testClusterSet)
+			util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
+				ControlPlane: meshv1alpha1.ControlPlaneConfig{Namespace: ns},
+			})
+
+			expectControlPlaneNamespaceManifestWork(clusterName, ns)
+		})
+
 		When("referencing a non-existent ClusterSet", func() {
 			var otherClusterSet string
 
@@ -235,7 +251,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				originalVersion := work.ResourceVersion
 
 				updateMesh(meshName, testNs, func(mesh *meshv1alpha1.MultiClusterMesh) {
-					mesh.Spec.ControlPlane.Namespace = "different-ns"
+					metav1.SetMetaDataLabel(&mesh.ObjectMeta, "trigger", "reconcile")
 				})
 
 				Consistently(func() string {
@@ -412,6 +428,17 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			})
 		})
 
+		When("spec.controlPlane.namespace is changed on update", func() {
+			It("should reject the update", func() {
+				mesh := &meshv1alpha1.MultiClusterMesh{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: meshName, Namespace: testNs}, mesh)).To(Succeed())
+				mesh.Spec.ControlPlane.Namespace = "different-ns"
+				err := k8sClient.Update(ctx, mesh)
+				Expect(err).To(HaveOccurred(), "expected validation error when updating the controlPlane namespace")
+				Expect(errors.IsInvalid(err)).To(BeTrue())
+			})
+		})
+
 		DescribeTable("should reject reserved operator namespace",
 			func(ns, expectedMessage string) {
 				expectInvalidCreateMeshFailure(meshName+"-ns", testNs,
@@ -426,6 +453,22 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			Entry("kube-public", "kube-public", "kube-"),
 			Entry("default", "default", "'default'"),
 		)
+
+		It("should block mesh when control plane namespace equals operator namespace", func() {
+			conflictMesh := meshName + "-cpns"
+			util.CreateMultiClusterMesh(ctx, k8sClient, conflictMesh, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
+				ControlPlane: meshv1alpha1.ControlPlaneConfig{Namespace: "multicluster-mesh-operator"},
+			})
+			expectMeshConditionReason(conflictMesh, testNs, meshv1alpha1.ConditionReady, meshv1alpha1.ReasonNamespaceConflict)
+		})
+
+		It("should block mesh when operator namespace equals default control plane namespace", func() {
+			conflictMesh := meshName + "-opns"
+			util.CreateMultiClusterMesh(ctx, k8sClient, conflictMesh, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
+				Operator: meshv1alpha1.OperatorConfig{Namespace: "istio-system"},
+			})
+			expectMeshConditionReason(conflictMesh, testNs, meshv1alpha1.ConditionReady, meshv1alpha1.ReasonNamespaceConflict)
+		})
 
 		It("should allow two meshes with different control plane namespaces", func() {
 			util.CreateMultiClusterMesh(ctx, k8sClient, otherMesh, testNs, testClusterSet, meshv1alpha1.MultiClusterMeshSpec{
@@ -492,10 +535,15 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 			expectFinalizer(meshName, testNs)
 			expectOperatorManifestWork(clusterName)
 			expectOperatorManifestWork(cluster2)
+			expectControlPlaneNamespaceManifestWork(clusterName, "istio-system")
+			expectControlPlaneNamespaceManifestWork(cluster2, "istio-system")
 
+			cpNsMWName := meshcontroller.ManifestWorkNameCPNSPrefix + "istio-system"
 			util.DeleteResource(ctx, k8sClient, &meshv1alpha1.MultiClusterMesh{}, meshName, testNs)
 			util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, clusterName)
 			util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, cluster2)
+			util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{}, cpNsMWName, clusterName)
+			util.ExpectResourceDeleted(ctx, k8sClient, &workv1.ManifestWork{}, cpNsMWName, cluster2)
 		})
 
 		It("should work when ClusterSet doesn't exist", func() {
@@ -572,8 +620,9 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				// simulate creating the cacerts secret by cert-manager
 				util.CreateCacertsSecret(ctx, k8sClient, testNs, clusterName, meshName, testNs)
 
+				expectControlPlaneNamespaceManifestWork(clusterName, "istio-system")
 				work := expectCacertsManifestWork(clusterName)
-				expectCacertsSecret(work)
+				expectCacertsSecret(work, "istio-system")
 			})
 
 			It("should update ManifestWork when cacerts secret is updated", func() {
@@ -679,10 +728,7 @@ var _ = Describe("MultiClusterMesh Controller", func() {
 				util.CreateMultiClusterMesh(ctx, k8sClient, meshName, testNs, testClusterSet)
 				msa := expectManagedServiceAccount(testNs, meshName, clusterName)
 
-				Expect(msa.Labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
-				Expect(msa.Labels[meshcontroller.MeshNameLabel]).To(Equal(meshName))
-				Expect(msa.Labels[meshcontroller.MeshNamespaceLabel]).To(Equal(testNs))
-				Expect(msa.Labels[meshcontroller.ClusterNameLabel]).To(Equal(clusterName))
+				expectMeshOwnedLabels(msa.Labels, meshName, testNs, clusterName)
 				Expect(msa.Spec.Rotation.Validity).To(Equal(metav1.Duration{Duration: 360 * time.Hour}))
 			})
 
@@ -850,6 +896,13 @@ func updateMesh(meshName, namespace string, mutate func(*meshv1alpha1.MultiClust
 	return mesh
 }
 
+func expectMeshOwnedLabels(labels map[string]string, meshName, meshNamespace, clusterName string) {
+	Expect(labels[meshcontroller.ManagedByLabel]).To(Equal(meshcontroller.ManagedByValue))
+	Expect(labels[meshcontroller.MeshNameLabel]).To(Equal(meshName))
+	Expect(labels[meshcontroller.MeshNamespaceLabel]).To(Equal(meshNamespace))
+	Expect(labels[meshcontroller.ClusterNameLabel]).To(Equal(clusterName))
+}
+
 // expectAllManifestWorksDeleted makes sure ManifestWorks are deleted and none remain
 func expectAllManifestWorksDeleted() {
 	Eventually(func() []workv1.ManifestWork {
@@ -916,16 +969,28 @@ func expectCertificate(namespace, clusterName, meshName, issuerName, issuerKind 
 	return cert
 }
 
-func expectCacertsSecret(work *workv1.ManifestWork) {
+func expectCacertsSecret(work *workv1.ManifestWork, expectedNamespace string) {
 	Expect(work.Spec.Workload.Manifests).To(HaveLen(1))
 	secret := &corev1.Secret{}
 	Expect(unmarshalManifest(work.Spec.Workload.Manifests[0], secret)).To(Succeed())
 	Expect(secret.Name).To(Equal("cacerts"))
-	Expect(secret.Namespace).To(Equal("istio-system"))
+	Expect(secret.Namespace).To(Equal(expectedNamespace))
 	Expect(secret.Type).To(Equal(corev1.SecretTypeTLS))
 	Expect(secret.Data).To(HaveKey("tls.crt"))
 	Expect(secret.Data).To(HaveKey("tls.key"))
 	Expect(secret.Data).To(HaveKey("ca.crt"))
+}
+
+func expectControlPlaneNamespaceManifestWork(clusterName, cpNamespace string) *workv1.ManifestWork {
+	work := expectManifestWork(meshcontroller.ManifestWorkNameCPNSPrefix+cpNamespace, clusterName)
+
+	Expect(work.Spec.Workload.Manifests).To(HaveLen(1))
+	ns := &corev1.Namespace{}
+	Expect(unmarshalManifest(work.Spec.Workload.Manifests[0], ns)).To(Succeed())
+	Expect(ns.Name).To(Equal(cpNamespace))
+	Expect(ns.Labels[meshcontroller.IstioNetworkLabel]).To(Equal(clusterName))
+
+	return work
 }
 
 func expectInvalidCreateMeshFailure(name, namespace string, spec meshv1alpha1.MultiClusterMeshSpec, messageSubstring string) {


### PR DESCRIPTION
The cacerts ManifestWork targets the control plane namespace (default istio-system), which does not exist until the Istio operator creates it.
This causes the work agent to fail and enter exponential backoff.

Create the namespace via a per-cluster ManifestWork before applying operator or cacerts resources.
Make `spec.controlPlane.namespace` immutable and validate it does not collide with the operator namespace.

Closes #219