### PR TITLE
Refactor e2e tests to black-box lifecycle

### DIFF
--- a/test/e2e/mesh_lifecycle_test.go
+++ b/test/e2e/mesh_lifecycle_test.go
@@ -4,6 +4,8 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
-	workv1 "open-cluster-management.io/api/work/v1"
 	msav1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -34,9 +35,22 @@ const (
 	testCatalogSource     = "operatorhubio-catalog"
 	testCatalogNamespace  = "olm"
 	testDefaultChannel    = "stable"
+
+	msaSpokeNamespace = "open-cluster-management-agent-addon"
 )
 
 var clusters = []string{"cluster1", "cluster2"}
+
+type trackedResource struct {
+	cluster string
+	c       client.Client
+	obj     client.Object
+}
+
+func (r trackedResource) Key() string {
+	kind := reflect.TypeOf(r.obj).Elem().Name()
+	return fmt.Sprintf("%s %s on %s", kind, client.ObjectKeyFromObject(r.obj), r.cluster)
+}
 
 var _ = Describe("Addon registration", func() {
 	It("should have ClusterManagementAddOn registered", func(ctx SpecContext) {
@@ -63,9 +77,15 @@ var _ = Describe("Controller health", func() {
 
 var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 	var (
-		mesh *meshv1alpha1.MultiClusterMesh
-		ns   string
+		mesh    *meshv1alpha1.MultiClusterMesh
+		ns      string
+		created = map[string]trackedResource{}
 	)
+
+	track := func(cluster string, c client.Client, obj client.Object) {
+		r := trackedResource{cluster: cluster, c: c, obj: obj.DeepCopyObject().(client.Object)}
+		created[r.Key()] = r
+	}
 
 	BeforeAll(func(ctx SpecContext) {
 		ns = util.UniqueName("test-ns")
@@ -80,9 +100,8 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	BeforeEach(func(ctx SpecContext) {
+	It("should deploy the mesh", func(ctx SpecContext) {
 		Step("Creating test mesh")
-		// Kind clusters don't have the OSSM catalog, so we override to use Sail from upstream.
 		mesh = util.CreateMultiClusterMesh(ctx, hubClient, util.UniqueName("test-mesh"), ns, "mesh-cluster-set",
 			meshv1alpha1.MultiClusterMeshSpec{
 				Operator: meshv1alpha1.OperatorConfig{
@@ -99,29 +118,7 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 		}).WithTimeout(2 * time.Minute).Should(Succeed())
 	})
 
-	AfterEach(func(ctx SpecContext) {
-		Step("Deleting test mesh %s", mesh.Name)
-		err := client.IgnoreNotFound(hubClient.Delete(ctx, mesh))
-		Expect(err).NotTo(HaveOccurred())
-
-		Step("Waiting for ManagedServiceAccounts to be cleaned up")
-		Eventually(func(g Gomega) {
-			msaList := &msav1beta1.ManagedServiceAccountList{}
-			err := hubClient.List(ctx, msaList, client.MatchingLabels{meshcontroller.ManagedByLabel: meshcontroller.ManagedByValue})
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(msaList.Items).To(BeEmpty(), "ManagedServiceAccounts still exist")
-		}).Should(Succeed())
-
-		Step("Waiting for ManifestWorks to be cleaned up")
-		Eventually(func(g Gomega) {
-			mwList := &workv1.ManifestWorkList{}
-			err := hubClient.List(ctx, mwList, client.MatchingLabels{meshcontroller.ManagedByLabel: meshcontroller.ManagedByValue})
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(mwList.Items).To(BeEmpty(), "ManifestWorks still exist")
-		}).Should(Succeed())
-	})
-
-	It("creates operator resources on spoke clusters", func(ctx SpecContext) {
+	It("should deploy operator resources to spoke clusters", func(ctx SpecContext) {
 		for cluster, spokeClient := range spokeClients {
 			Step("Verifying OperatorInstalled condition for %s", cluster)
 			cs := findClusterStatus(mesh, cluster)
@@ -130,19 +127,21 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 				"expected OperatorInstalled=True for %s", cluster)
 
 			Step("Verifying control plane namespace exists on %s", cluster)
-			ns := &corev1.Namespace{}
+			cpns := &corev1.Namespace{}
 			Eventually(func(g Gomega) {
-				g.Expect(spokeClient.Get(ctx, key.Of("istio-system"), ns)).To(Succeed())
-				g.Expect(ns.Labels[meshcontroller.IstioNetworkLabel]).To(Equal(cluster))
+				g.Expect(spokeClient.Get(ctx, key.Of("istio-system"), cpns)).To(Succeed())
+				g.Expect(cpns.Labels[meshcontroller.IstioNetworkLabel]).To(Equal(cluster))
 			}).Should(Succeed())
+			track(cluster, spokeClient, cpns)
 
 			Step("Verifying operator namespace exists on %s", cluster)
-			err := spokeClient.Get(ctx, key.Of(testOperatorNamespace), &corev1.Namespace{})
-			Expect(err).NotTo(HaveOccurred())
+			ns := &corev1.Namespace{}
+			Expect(spokeClient.Get(ctx, key.Of(testOperatorNamespace), ns)).To(Succeed())
+			track(cluster, spokeClient, ns)
 
 			Step("Verifying OperatorGroup exists on %s", cluster)
 			ogList := &operatorsv1.OperatorGroupList{}
-			err = spokeClient.List(ctx, ogList, client.InNamespace(testOperatorNamespace))
+			err := spokeClient.List(ctx, ogList, client.InNamespace(testOperatorNamespace))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ogList.Items).To(HaveLen(1))
 
@@ -152,110 +151,63 @@ var _ = Describe("MultiClusterMesh lifecycle", Ordered, func() {
 			Expect(sub.Spec.Package).To(Equal(testOperatorName))
 			Expect(sub.Spec.Channel).To(Equal(testDefaultChannel))
 			Expect(sub.Spec.CatalogSource).To(Equal(testCatalogSource))
+			Expect(sub.Spec.CatalogSourceNamespace).To(Equal(testCatalogNamespace))
 		}
 	})
 
-	It("updates spoke resources when operator config changes", func(ctx SpecContext) {
+	It("should update spoke resources when operator config changes", func(ctx SpecContext) {
 		Step("Updating mesh operator channel")
 		Expect(getMesh(ctx, mesh)).To(Succeed())
 		mesh.Spec.Operator.Channel = "candidate"
 		Expect(hubClient.Update(ctx, mesh)).To(Succeed())
 
-		Step("Verifying Subscription channel is updated on spoke clusters")
 		for cluster, spokeClient := range spokeClients {
+			Step("Verifying Subscription channel is updated on %s", cluster)
 			Eventually(func(g Gomega) {
-				g.Expect(getSubscription(ctx, spokeClient)).To(HaveField("Spec.Channel", "candidate"),
-					"expected Subscription channel on %s to be updated", cluster)
+				g.Expect(getSubscription(ctx, spokeClient)).To(HaveField("Spec.Channel", "candidate"))
 			}).Should(Succeed())
 		}
 	})
 
-	It("cleans up resources on mesh deletion", func(ctx SpecContext) {
-		Step("Deleting the mesh CR")
-		util.DeleteResource(ctx, hubClient, mesh, mesh.Name, mesh.Namespace)
-
-		Step("Verifying ManifestWorks are removed from hub")
-		for _, cluster := range clusters {
-			util.ExpectResourceDeleted(ctx, hubClient, &workv1.ManifestWork{}, meshcontroller.OperatorManifestWorkName, cluster)
-		}
-
-		Step("Verifying control plane namespaces are removed from spoke clusters")
-		for _, spokeClient := range spokeClients {
-			util.ExpectResourceDeleted(ctx, spokeClient, &corev1.Namespace{}, "istio-system", "", 2*time.Minute)
-		}
-
-		Step("Verifying Subscriptions are removed from spoke clusters")
-		for _, spokeClient := range spokeClients {
-			// Spoke-side cleanup depends on the OCM work agent processing the
-			// ManifestWork deletion and OLM processing any Subscription finalizers,
-			// which can take longer than the default timeout in CI.
-			util.ExpectResourceDeleted(ctx, spokeClient, &operatorsv1alpha1.Subscription{}, testOperatorName, testOperatorNamespace, 2*time.Minute)
-		}
-	})
-
-	It("creates ManagedServiceAccounts with token secrets for each spoke cluster", func(ctx SpecContext) {
-		for _, cluster := range clusters {
-			Step("Verifying ManagedServiceAccount and token secret for %s", cluster)
+	It("should create service accounts and token secrets for each spoke cluster", func(ctx SpecContext) {
+		for cluster, spokeClient := range spokeClients {
+			Step("Verifying service account and token secret for %s", cluster)
 			Eventually(func(g Gomega) {
 				msaList := listMeshMSAs(g, ctx, mesh, client.InNamespace(cluster))
 				g.Expect(msaList.Items).To(HaveLen(1),
 					"expected exactly one MSA for cluster %s", cluster)
 
 				msa := msaList.Items[0]
+				sa := &corev1.ServiceAccount{}
+				g.Expect(spokeClient.Get(ctx, key.Of(msa.Name, msaSpokeNamespace), sa)).To(Succeed(),
+					"ServiceAccount %s/%s should exist on spoke %s", msaSpokeNamespace, msa.Name, cluster)
+				track(cluster, spokeClient, sa)
+
 				g.Expect(msa.Status.TokenSecretRef).NotTo(BeNil(),
 					"expected MSA %s/%s to have tokenSecretRef", msa.Namespace, msa.Name)
-				g.Expect(meta.IsStatusConditionTrue(msa.Status.Conditions, msav1beta1.ConditionTypeSecretCreated)).To(BeTrue())
 
 				secret := &corev1.Secret{}
 				g.Expect(hubClient.Get(ctx, key.Of(msa.Status.TokenSecretRef.Name, cluster), secret)).To(Succeed(),
-					"token secret %s/%s should exist", cluster, msa.Status.TokenSecretRef.Name)
+					"token secret %s/%s should exist on hub", cluster, msa.Status.TokenSecretRef.Name)
+				track(cluster, hubClient, secret)
 			}).WithTimeout(2 * time.Minute).Should(Succeed())
 		}
 	})
 
-	It("cleans up ManagedServiceAccounts and token secrets on mesh deletion", func(ctx SpecContext) {
-		Step("Collecting token secret names before deletion")
-		var tokenSecretKeys []client.ObjectKey
-		msaList := listMeshMSAs(Default, ctx, mesh)
-		for _, msa := range msaList.Items {
-			if msa.Status.TokenSecretRef != nil {
-				tokenSecretKeys = append(tokenSecretKeys, client.ObjectKey{
-					Name: msa.Status.TokenSecretRef.Name, Namespace: msa.Namespace,
-				})
-			}
-		}
-
+	It("should remove spoke resources when mesh is deleted", func(ctx SpecContext) {
 		Step("Deleting the mesh CR")
 		util.DeleteResource(ctx, hubClient, mesh, mesh.Name, mesh.Namespace)
 
-		Step("Verifying ManagedServiceAccounts are removed from hub")
-		for _, cluster := range clusters {
-			Eventually(func(g Gomega) {
-				msaList := listMeshMSAs(g, ctx, mesh, client.InNamespace(cluster))
-				g.Expect(msaList.Items).To(BeEmpty(),
-					"expected MSA to be deleted in cluster %s", cluster)
-			}).Should(Succeed())
-		}
-
-		Step("Verifying token secrets are removed from hub")
-		for _, secretKey := range tokenSecretKeys {
-			util.ExpectResourceDeleted(ctx, hubClient, &corev1.Secret{}, secretKey.Name, secretKey.Namespace)
+		for label, r := range created {
+			Step("Verifying %s is removed", label)
+			util.ExpectResourceDeleted(ctx, r.c, r.obj, r.obj.GetName(), r.obj.GetNamespace(), 2*time.Minute)
 		}
 	})
-
-	// TODO: Once the controller builds Istio remote secrets from MSA token secrets,
-	// verify that for each cluster a kubeconfig-style Secret with the "istio/multiCluster"
-	// label is created on the hub. Assert the secret data contains a valid kubeconfig with
-	// the spoke API server URL and the token from the MSA token secret.
-	PIt("constructs Istio remote secrets from MSA token secrets")
-
-	// TODO: Once the controller distributes remote secrets to peer clusters,
-	// verify that for N clusters each cluster receives (N-1) remote secrets.
-	// Verify the Secret actually appears on the spoke cluster (using spokeClients).
-	// Also verify that when a cluster is removed, its remote secrets are cleaned up from
-	// all remaining peers.
-	PIt("distributes remote secrets to peer clusters")
 })
+
+func getMesh(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
+	return hubClient.Get(ctx, key.For(mesh), mesh)
+}
 
 func findClusterStatus(mesh *meshv1alpha1.MultiClusterMesh, clusterName string) *meshv1alpha1.ClusterMeshStatus {
 	for _, cs := range mesh.Status.ClusterStatus {
@@ -264,10 +216,6 @@ func findClusterStatus(mesh *meshv1alpha1.MultiClusterMesh, clusterName string) 
 		}
 	}
 	return nil
-}
-
-func getMesh(ctx context.Context, mesh *meshv1alpha1.MultiClusterMesh) error {
-	return hubClient.Get(ctx, key.For(mesh), mesh)
 }
 
 func getSubscription(ctx context.Context, spokeClient client.Client) (*operatorsv1alpha1.Subscription, error) {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	meshv1alpha1 "github.com/stolostron/multicluster-mesh-addon/pkg/apis/mesh/v1alpha1"
-	meshcontroller "github.com/stolostron/multicluster-mesh-addon/pkg/hub/mesh"
 	"github.com/stolostron/multicluster-mesh-addon/test/util"
 )
 
@@ -70,7 +69,10 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	}
 
 	Step("Checking for existing resources that can interfere with our testing")
-	checkNoExistingResources(ctx, hubClient)
+	meshList := &meshv1alpha1.MultiClusterMeshList{}
+	Expect(hubClient.List(ctx, meshList)).To(Succeed())
+	Expect(meshList.Items).To(BeEmpty(),
+		"existing MultiClusterMesh resources found; run 'make dev-clean-meshes' to clean up")
 })
 
 func env(key, def string) string {
@@ -98,18 +100,4 @@ func verifyConnection(ctx context.Context, c client.Client, name string) {
 	Expect(c.List(ctx, nsList)).To(Succeed(),
 		"failed to connect to %s cluster", name)
 	GinkgoWriter.Printf("Connected to %s cluster (%d namespaces)\n", name, len(nsList.Items))
-}
-
-func checkNoExistingResources(ctx context.Context, c client.Client) {
-	mwList := &workv1.ManifestWorkList{}
-	err := c.List(ctx, mwList, client.MatchingLabels{meshcontroller.ManagedByLabel: meshcontroller.ManagedByValue})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(mwList.Items).To(BeEmpty(),
-		"existing ManifestWorks found; run 'make dev-clean-meshes' to clean up")
-
-	msaList := &msav1beta1.ManagedServiceAccountList{}
-	err = c.List(ctx, msaList, client.MatchingLabels{meshcontroller.ManagedByLabel: meshcontroller.ManagedByValue})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(msaList.Items).To(BeEmpty(),
-		"existing ManagedServiceAccounts found; run 'make dev-clean-meshes' to clean up")
 }


### PR DESCRIPTION
The previous e2e tests asserted on hub-side implementation details (ManifestWorks, ManagedServiceAccount conditions) and created a fresh mesh per spec via BeforeEach/AfterEach.

Replace with a single lifecycle series that verifies actual spoke-side resources: operator namespace, OperatorGroup, Subscription, ServiceAccount, and token secret. Resources verified during creation are tracked and checked for removal after mesh deletion.

Align the suite preflight check with the black-box approach: verify no MultiClusterMesh CRs exist instead of checking for leftover ManifestWorks and ManagedServiceAccounts.