### PR TITLE
Delete kind clusters sequentially as part of dev-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ dev-clean-meshes: ## Delete all mesh resources, cert-manager trust chain, and me
 
 .PHONY: dev-clean
 dev-clean: ## Destroy dev clusters and remove .kube/ folder
-	$(MAKE) --no-print-directory -j$(PARALLEL) --output-sync=line $(addprefix delete-,$(CLUSTERS))
+	$(MAKE) --no-print-directory -j1 $(addprefix delete-,$(CLUSTERS))
 	rm -rf $(DEV_KUBE_DIR)
 	$(call log,Dev environment cleaned)
 

--- a/Makefile
+++ b/Makefile
@@ -337,10 +337,10 @@ dev-clean-meshes: ## Delete all mesh resources, cert-manager trust chain, and me
 
 .PHONY: dev-clean
 dev-clean: ## Destroy dev clusters and remove .kube/ folder
-	$(MAKE) --no-print-directory -j1 $(addprefix delete-,$(CLUSTERS))
+	$(MAKE) --no-print-directory -j$(PARALLEL) --output-sync=line $(addprefix delete-,$(CLUSTERS))
 	rm -rf $(DEV_KUBE_DIR)
 	$(call log,Dev environment cleaned)
 
 .PHONY: $(addprefix delete-,$(CLUSTERS))
 $(addprefix delete-,$(CLUSTERS)): delete-%: $(KIND)
-	$(KIND) delete cluster --name $*
+	$(KIND) delete cluster --name $* --kubeconfig $(DEV_KUBE_DIR)/$*.config


### PR DESCRIPTION
kind delete cluster uses a lockfile when updating ~/.kube/config. 
If multiple clusters are deleted in parallel, they can race for the lock
and fail. Deleting clusters one at a time is fast enough, so there's little
value in parallelizing this step.