### PR TITLE
Block dependent PRs until dependencies merge

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,24 @@
+---
+name: PR Dependencies
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check:
+    name: Check Dependencies
+    if: github.repository_owner == 'stolostron'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: depends-on/depends-on-action@c7ac9a6932a7069e83aef80c202d9f60f91e43fd # v0.17.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check-unmerged-pr: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,16 @@ Contact the org [owners](https://github.com/orgs/stolostron/people?query=role%3A
 - Avoid force-pushing during review if possible. Use merge commits to resolve conflicts.
 - Use the `/hold` and `/unhold` comments to control when a PR is eligible for merge. Contributors may use `/hold` to prevent a PR from merging while additional review or discussion is in progress. This is particularly useful for complex changes that require multiple approvals. If a PR is not on hold, it becomes eligible for merge after receiving a single approving review from a maintainer.
 
+### Dependent Pull Requests
+
+If a pull request depends on another open pull request in this repository, declare the dependency in the PR description using a full PR URL:
+
+```text
+Depends-On: https://github.com/stolostron/multicluster-mesh-addon/pull/123
+```
+
+You can list multiple dependencies, one `Depends-On:` line each. The **PR Dependencies / Check Dependencies** GitHub Action fails until every listed pull request is merged, which keeps Tide from merging the dependent PR early. Use `/hold` for other reasons to block merge (WIP, discussion); dependency gating is automatic when `Depends-On:` is present.
+
 ## Developer Certificate of Origin
 
 You must sign off your commits to certify that you have the right to submit the code under the project's license. This is done using the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ Depends-On: https://github.com/stolostron/multicluster-mesh-addon/pull/123
 
 You can list multiple dependencies, one `Depends-On:` line each. The **PR Dependencies / Check Dependencies** GitHub Action fails until every listed pull request is merged, which keeps Tide from merging the dependent PR early. Use `/hold` for other reasons to block merge (WIP, discussion); dependency gating is automatic when `Depends-On:` is present.
 
+The check re-runs when the dependent PR is updated (new commits, editing description etc). It does **not** refresh automatically when a listed dependency merges. After dependencies land, re-run **PR Dependencies / Check Dependencies** on the waiting PR (or push a commit / edit the description) so the check can turn green.
+
 ## Developer Certificate of Origin
 
 You must sign off your commits to certify that you have the right to submit the code under the project's license. This is done using the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Contact the org [owners](https://github.com/orgs/stolostron/people?query=role%3A
 
 ### Dependent Pull Requests
 
-If a pull request depends on another open pull request in this repository, declare the dependency in the PR description using a full PR URL:
+If a pull request depends on another open pull request in this repository, declare the dependency in the PR description with a full PR URL (short forms like `#123` are not supported):
 
 ```text
 Depends-On: https://github.com/stolostron/multicluster-mesh-addon/pull/123
@@ -51,7 +51,7 @@ Depends-On: https://github.com/stolostron/multicluster-mesh-addon/pull/123
 
 You can list multiple dependencies, one `Depends-On:` line each. The **PR Dependencies / Check Dependencies** GitHub Action fails until every listed pull request is merged, which keeps Tide from merging the dependent PR early. Use `/hold` for other reasons to block merge (WIP, discussion); dependency gating is automatic when `Depends-On:` is present.
 
-The check re-runs when the dependent PR is updated (new commits, editing description etc). It does **not** refresh automatically when a listed dependency merges. After dependencies land, re-run **PR Dependencies / Check Dependencies** on the waiting PR (or push a commit / edit the description) so the check can turn green.
+The check does not refresh automatically when a listed dependency merges. After the parent PR lands (this repo squash-merges), merge or rebase `main` into the dependent PR. That picks up the parent's changes and re-runs the dependency check.
 
 ## Developer Certificate of Origin
 


### PR DESCRIPTION
This PR adds a GitHub Action (using similar approach as [submariner](https://github.com/submariner-io/submariner/blob/devel/.github/workflows/dependent-issues.yml))
that fails when a PR lists unmerged Depends-On targets, so Tide
won't merge it early.