### PR TITLE
Auto-detect OCP vs kind platform for e2e test config

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -73,7 +73,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	}
 
 	Step("Detecting platform (kind vs OCP)")
-	detectPlatform(ctx, spokeClients["cluster1"])
+	detectPlatform(ctx, hubClient, "cluster1")
 
 	Step("Verifying cluster connectivity")
 	verifyConnection(ctx, hubClient, "hub")
@@ -112,8 +112,8 @@ func Success(format string, args ...any) {
 	GinkgoWriter.Println("* " + fmt.Sprintf(format, args...))
 }
 
-func detectPlatform(ctx context.Context, spokeClient client.Client) {
-	cfg, err := util.DetectPlatform(ctx, spokeClient)
+func detectPlatform(ctx context.Context, hubClient client.Client, clusterName string) {
+	cfg, err := util.DetectPlatform(ctx, hubClient, clusterName)
 	Expect(err).NotTo(HaveOccurred(), "failed to detect platform")
 	GinkgoWriter.Printf("Detected platform: catalog=%s/%s, operator=%s/%s\n",
 		cfg.CatalogNamespace, cfg.CatalogSource, cfg.OperatorNamespace, cfg.OperatorName)

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -27,19 +27,16 @@ import (
 	"github.com/stolostron/multicluster-mesh-addon/test/util"
 )
 
-const (
-	testOperatorName      = "sailoperator"
-	testOperatorNamespace = "sail-operator"
-)
-
 var (
 	clusters = []string{"cluster1", "cluster2"}
 
 	hubClient    *util.E2EClient
 	spokeClients map[string]*util.E2EClient
 
-	testCatalogSource    string
-	testCatalogNamespace string
+	testOperatorName      string
+	testOperatorNamespace string
+	testCatalogSource     string
+	testCatalogNamespace  string
 )
 
 func TestE2E(t *testing.T) {
@@ -76,7 +73,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	}
 
 	Step("Detecting platform (kind vs OCP)")
-	testCatalogSource, testCatalogNamespace = detectCatalog(ctx, spokeClients["cluster1"])
+	detectPlatform(ctx, spokeClients["cluster1"])
 
 	Step("Verifying cluster connectivity")
 	verifyConnection(ctx, hubClient, "hub")
@@ -115,14 +112,21 @@ func Success(format string, args ...any) {
 	GinkgoWriter.Println("* " + fmt.Sprintf(format, args...))
 }
 
-func detectCatalog(ctx context.Context, spokeClient client.Client) (source, namespace string) {
+func detectPlatform(ctx context.Context, spokeClient client.Client) {
 	ns := &corev1.Namespace{}
 	if err := spokeClient.Get(ctx, client.ObjectKey{Name: "openshift-marketplace"}, ns); err == nil {
-		GinkgoWriter.Println("Detected OCP platform, using redhat-operators catalog")
-		return "redhat-operators", "openshift-marketplace"
+		GinkgoWriter.Println("Detected OCP platform")
+		testOperatorName = "servicemeshoperator3"
+		testOperatorNamespace = "openshift-operators"
+		testCatalogSource = "redhat-operators"
+		testCatalogNamespace = "openshift-marketplace"
+		return
 	}
-	GinkgoWriter.Println("Detected non-OCP platform, using operatorhubio-catalog")
-	return "operatorhubio-catalog", "olm"
+	GinkgoWriter.Println("Detected non-OCP platform")
+	testOperatorName = "sailoperator"
+	testOperatorNamespace = "sail-operator"
+	testCatalogSource = "operatorhubio-catalog"
+	testCatalogNamespace = "olm"
 }
 
 func verifyConnection(ctx context.Context, c client.Client, name string) {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -30,8 +30,6 @@ import (
 const (
 	testOperatorName      = "sailoperator"
 	testOperatorNamespace = "sail-operator"
-	testCatalogSource     = "operatorhubio-catalog"
-	testCatalogNamespace  = "olm"
 )
 
 var (
@@ -39,6 +37,9 @@ var (
 
 	hubClient    *util.E2EClient
 	spokeClients map[string]*util.E2EClient
+
+	testCatalogSource    string
+	testCatalogNamespace string
 )
 
 func TestE2E(t *testing.T) {
@@ -73,6 +74,9 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	} {
 		spokeClients[name] = util.NewE2EClient(clientFrom(kc), kc)
 	}
+
+	Step("Detecting platform (kind vs OCP)")
+	testCatalogSource, testCatalogNamespace = detectCatalog(ctx, spokeClients["cluster1"])
 
 	Step("Verifying cluster connectivity")
 	verifyConnection(ctx, hubClient, "hub")
@@ -109,6 +113,16 @@ func Step(format string, args ...any) {
 
 func Success(format string, args ...any) {
 	GinkgoWriter.Println("* " + fmt.Sprintf(format, args...))
+}
+
+func detectCatalog(ctx context.Context, spokeClient client.Client) (source, namespace string) {
+	ns := &corev1.Namespace{}
+	if err := spokeClient.Get(ctx, client.ObjectKey{Name: "openshift-marketplace"}, ns); err == nil {
+		GinkgoWriter.Println("Detected OCP platform, using redhat-operators catalog")
+		return "redhat-operators", "openshift-marketplace"
+	}
+	GinkgoWriter.Println("Detected non-OCP platform, using operatorhubio-catalog")
+	return "operatorhubio-catalog", "olm"
 }
 
 func verifyConnection(ctx context.Context, c client.Client, name string) {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -113,20 +113,14 @@ func Success(format string, args ...any) {
 }
 
 func detectPlatform(ctx context.Context, spokeClient client.Client) {
-	ns := &corev1.Namespace{}
-	if err := spokeClient.Get(ctx, client.ObjectKey{Name: "openshift-marketplace"}, ns); err == nil {
-		GinkgoWriter.Println("Detected OCP platform")
-		testOperatorName = "servicemeshoperator3"
-		testOperatorNamespace = "openshift-operators"
-		testCatalogSource = "redhat-operators"
-		testCatalogNamespace = "openshift-marketplace"
-		return
-	}
-	GinkgoWriter.Println("Detected non-OCP platform")
-	testOperatorName = "sailoperator"
-	testOperatorNamespace = "sail-operator"
-	testCatalogSource = "operatorhubio-catalog"
-	testCatalogNamespace = "olm"
+	cfg, err := util.DetectPlatform(ctx, spokeClient)
+	Expect(err).NotTo(HaveOccurred(), "failed to detect platform")
+	GinkgoWriter.Printf("Detected platform: catalog=%s/%s, operator=%s/%s\n",
+		cfg.CatalogNamespace, cfg.CatalogSource, cfg.OperatorNamespace, cfg.OperatorName)
+	testOperatorName = cfg.OperatorName
+	testOperatorNamespace = cfg.OperatorNamespace
+	testCatalogSource = cfg.CatalogSource
+	testCatalogNamespace = cfg.CatalogNamespace
 }
 
 func verifyConnection(ctx context.Context, c client.Client, name string) {

--- a/test/util/platform.go
+++ b/test/util/platform.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,10 +15,13 @@ type PlatformConfig struct {
 	CatalogNamespace  string
 }
 
-func DetectPlatform(ctx context.Context, c client.Reader) (PlatformConfig, error) {
-	ns := &corev1.Namespace{}
-	err := c.Get(ctx, client.ObjectKey{Name: "openshift-marketplace"}, ns)
-	if err == nil {
+func DetectPlatform(ctx context.Context, hubClient client.Reader, clusterName string) (PlatformConfig, error) {
+	cluster := &clusterv1.ManagedCluster{}
+	if err := hubClient.Get(ctx, client.ObjectKey{Name: clusterName}, cluster); err != nil {
+		return PlatformConfig{}, fmt.Errorf("failed to get ManagedCluster %s: %w", clusterName, err)
+	}
+
+	if isOpenShift(cluster) {
 		return PlatformConfig{
 			OperatorName:      "servicemeshoperator3",
 			OperatorNamespace: "sail-operator",
@@ -27,13 +29,23 @@ func DetectPlatform(ctx context.Context, c client.Reader) (PlatformConfig, error
 			CatalogNamespace:  "openshift-marketplace",
 		}, nil
 	}
-	if apierrors.IsNotFound(err) {
-		return PlatformConfig{
-			OperatorName:      "sailoperator",
-			OperatorNamespace: "sail-operator",
-			CatalogSource:     "operatorhubio-catalog",
-			CatalogNamespace:  "olm",
-		}, nil
+
+	return PlatformConfig{
+		OperatorName:      "sailoperator",
+		OperatorNamespace: "sail-operator",
+		CatalogSource:     "operatorhubio-catalog",
+		CatalogNamespace:  "olm",
+	}, nil
+}
+
+func isOpenShift(cluster *clusterv1.ManagedCluster) bool {
+	for _, claim := range cluster.Status.ClusterClaims {
+		if claim.Name == "product.open-cluster-management.io" {
+			switch claim.Value {
+			case "OpenShift", "ROSA", "ROSAHcp", "ARO", "OSD", "OpenShiftDedicated":
+				return true
+			}
+		}
 	}
-	return PlatformConfig{}, fmt.Errorf("failed to detect platform: %w", err)
+	return false
 }

--- a/test/util/platform.go
+++ b/test/util/platform.go
@@ -22,7 +22,7 @@ func DetectPlatform(ctx context.Context, c client.Reader) (PlatformConfig, error
 	if err == nil {
 		return PlatformConfig{
 			OperatorName:      "servicemeshoperator3",
-			OperatorNamespace: "openshift-operators",
+			OperatorNamespace: "sail-operator",
 			CatalogSource:     "redhat-operators",
 			CatalogNamespace:  "openshift-marketplace",
 		}, nil

--- a/test/util/platform.go
+++ b/test/util/platform.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type PlatformConfig struct {
+	OperatorName      string
+	OperatorNamespace string
+	CatalogSource     string
+	CatalogNamespace  string
+}
+
+func DetectPlatform(ctx context.Context, c client.Reader) (PlatformConfig, error) {
+	ns := &corev1.Namespace{}
+	err := c.Get(ctx, client.ObjectKey{Name: "openshift-marketplace"}, ns)
+	if err == nil {
+		return PlatformConfig{
+			OperatorName:      "servicemeshoperator3",
+			OperatorNamespace: "openshift-operators",
+			CatalogSource:     "redhat-operators",
+			CatalogNamespace:  "openshift-marketplace",
+		}, nil
+	}
+	if apierrors.IsNotFound(err) {
+		return PlatformConfig{
+			OperatorName:      "sailoperator",
+			OperatorNamespace: "sail-operator",
+			CatalogSource:     "operatorhubio-catalog",
+			CatalogNamespace:  "olm",
+		}, nil
+	}
+	return PlatformConfig{}, fmt.Errorf("failed to detect platform: %w", err)
+}


### PR DESCRIPTION
Use OCM-idiomatic product.open-cluster-management.io ClusterClaim from ManagedCluster status to detect a platform.

OpenShift: servicemeshoperator3 in sail-operator, redhat-operators catalog.
kind: sailoperator in sail-operator, operatorhubio-catalog.