### PR TITLE
Clean up ManagedCluster network labels in e2e AfterAll

### DIFF
--- a/test/e2e/multi_primary_test.go
+++ b/test/e2e/multi_primary_test.go
@@ -123,12 +123,18 @@ var _ = Describe("Multi-primary data plane", Ordered, Serial, func() {
 
 		Step("Removing network labels from ManagedClusters")
 		for cluster := range spokeClients {
-			mc := &clusterv1.ManagedCluster{}
-			if err := hubClient.Get(ctx, key.Of(cluster), mc); err != nil {
-				continue
-			}
-			delete(mc.Labels, meshcontroller.IstioNetworkLabel)
-			_ = hubClient.Update(ctx, mc)
+			Eventually(func() error {
+				mc := &clusterv1.ManagedCluster{}
+				if err := hubClient.Get(ctx, key.Of(cluster), mc); err != nil {
+					if apierrors.IsNotFound(err) {
+						return nil
+					}
+					return err
+				}
+				delete(mc.Labels, meshcontroller.IstioNetworkLabel)
+				return hubClient.Update(ctx, mc)
+			}).WithTimeout(30*time.Second).WithPolling(1*time.Second).Should(Succeed(),
+				"failed to remove network label from ManagedCluster %s", cluster)
 		}
 
 		Step("Cleaning up hub resources")

--- a/test/e2e/multi_primary_test.go
+++ b/test/e2e/multi_primary_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -109,6 +110,17 @@ var _ = Describe("Multi-primary data plane", Ordered, Serial, func() {
 			spokeClient.Cleanup(ctx)
 		}
 
+		Step("Deleting test mesh %s", meshName)
+		if mesh != nil {
+			_ = client.IgnoreNotFound(hubClient.Delete(ctx, mesh))
+
+			Step("Waiting for mesh %s to be fully removed", meshName)
+			Eventually(func() bool {
+				err := hubClient.Get(ctx, key.For(mesh), mesh)
+				return apierrors.IsNotFound(err)
+			}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
+		}
+
 		Step("Removing network labels from ManagedClusters")
 		for cluster := range spokeClients {
 			mc := &clusterv1.ManagedCluster{}
@@ -117,11 +129,6 @@ var _ = Describe("Multi-primary data plane", Ordered, Serial, func() {
 			}
 			delete(mc.Labels, meshcontroller.IstioNetworkLabel)
 			_ = hubClient.Update(ctx, mc)
-		}
-
-		Step("Deleting test mesh %s", meshName)
-		if mesh != nil {
-			_ = client.IgnoreNotFound(hubClient.Delete(ctx, mesh))
 		}
 
 		Step("Cleaning up hub resources")

--- a/test/e2e/multi_primary_test.go
+++ b/test/e2e/multi_primary_test.go
@@ -109,6 +109,16 @@ var _ = Describe("Multi-primary data plane", Ordered, Serial, func() {
 			spokeClient.Cleanup(ctx)
 		}
 
+		Step("Removing network labels from ManagedClusters")
+		for cluster := range spokeClients {
+			mc := &clusterv1.ManagedCluster{}
+			if err := hubClient.Get(ctx, key.Of(cluster), mc); err != nil {
+				continue
+			}
+			delete(mc.Labels, meshcontroller.IstioNetworkLabel)
+			_ = hubClient.Update(ctx, mc)
+		}
+
 		Step("Deleting test mesh %s", meshName)
 		if mesh != nil {
 			_ = client.IgnoreNotFound(hubClient.Delete(ctx, mesh))


### PR DESCRIPTION
The multi-primary test adds topology.istio.io/network labels to ManagedClusters in BeforeAll but never removes them, causing failures when re-running against the same clusters.